### PR TITLE
Apply clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,27 @@
+﻿---
+BasedOnStyle: WebKit
+AlignAfterOpenBracket: Align
+AlignTrailingComments: 'true'
+AllowShortFunctionsOnASingleLine: Empty
+AllowShortIfStatementsOnASingleLine: 'false'
+AllowShortLoopsOnASingleLine: 'false'
+BreakBeforeBraces: Attach
+BreakConstructorInitializers: BeforeColon
+ColumnLimit: '110'
+CompactNamespaces: 'true'
+Cpp11BracedListStyle: 'true'
+FixNamespaceComments: 'true'
+IndentWidth: '4'
+Language: Cpp
+NamespaceIndentation: None
+PointerAlignment: Left
+SortIncludes: 'true'
+SpaceAfterCStyleCast: 'true'
+SpaceAfterTemplateKeyword: 'false'
+SpaceBeforeParens: ControlStatements
+SpacesInAngles: 'false'
+Standard: Cpp11
+TabWidth: '4'
+UseTab: Never
+
+...


### PR DESCRIPTION
## Description
This PR sets a clang-format standard for the C++ code in freud.

## Motivation and Context
Our C++ codebase is sometimes hard to read and inconsistently styled. This PR will create a uniform standard for C++ code going forward.

This style could be applied gradually as we work on individual modules or all-at-once (ideally after merging spatial data and before the hackathon, TBD on both).

This website is very helpful for visualizing the output of clang-format: https://zed0.co.uk/clang-format-configurator/