### PR TITLE
Fix/pypi deployment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -192,6 +192,7 @@ references:
 
             # Install from and test all wheels
             for VERSION in ${PY_VERSIONS[@]}; do
+                pyenv global ${VERSION}
                 pip install freud_analysis --no-index -f ~/ci/freud/wheelhouse
                 cd ~/ci/freud/tests
                 python -m unittest discover . -v

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,6 +24,17 @@ references:
   load_code: &load_code
     checkout
 
+  load_code_centos: &load_code_centos
+    # For use with old OS that doesn't support clone over ssh
+    run:
+      name: Checkout repository without ssh
+      command: |
+        cd ~/ci/freud
+        git clone ${CIRCLE_REPOSITORY_URL} .
+        export CIRCLE_TAG=v1.0.0  # Hard code for testing
+        git fetch --force origin "refs/tags/${CIRCLE_TAG}"
+        git checkout -q "$CIRCLE_TAG"
+
   get_requirements: &get_requirements
     run:
       name: Install dependencies
@@ -90,7 +101,7 @@ references:
           name: Install software
           working_directory: /root/code
           command: yum install -y openssh-clients
-      - *load_code
+      - *load_code_centos
       - run:
           name: Update freud submodules
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,6 @@ references:
       command: |
         cd ~/ci/freud
         git clone ${CIRCLE_REPOSITORY_URL} .
-        export CIRCLE_TAG=v1.0.0  # Hard code for testing
         git fetch --force origin "refs/tags/${CIRCLE_TAG}"
         git checkout -q "$CIRCLE_TAG"
 


### PR DESCRIPTION
This fixes some of the PyPI deployment issues we experienced with 1.0. The Linux issue is fixed by manually checking out the code instead of using CircleCI's checkout script, which forces cloning over ssh on this VM that's too old to handle it. The Mac deployment had a bug that was causing it to just retest the same Python version's installation of freud multiple times, which I've fixed, but the underlying cause of the deployment failure is still present. The problem there appears to be in the most recent release of SciPy. I've opened issue scipy/scipy#9858, we can see if they're able to solve that problem.