### PR TITLE
Update jupyter_client build.

### DIFF
--- a/doc/readthedocs-env.yml
+++ b/doc/readthedocs-env.yml
@@ -27,7 +27,7 @@ dependencies:
   - jedi=0.13.2=py37_1000
   - jinja2=2.10=py_1
   - jsonschema=3.0.0a3=py37_1000
-  - jupyter_client=5.2.4=py_1
+  - jupyter_client=5.2.4=py_3
   - jupyter_core=4.4.0=py_0
   - libffi=3.2.1=hf484d3e_1005
   - libgcc-ng=7.3.0=hdf63c60_0


### PR DESCRIPTION
## Motivation and Context
Read the Docs builds are failing because the conda environment `jupyter_client` is pointing to a broken version. https://anaconda.org/conda-forge/jupyter_client/files

## How Has This Been Tested?
Error message ([RTD](https://readthedocs.org/projects/freud/builds/8706477/)):
```
Solving environment: ...working... failed

ResolvePackageNotFound: 
  - jupyter_client==5.2.4=py_1
```

Tested build URL for this PR:
https://readthedocs.org/projects/freud/builds/8706486/

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)