### PR TITLE
Remove saru from Nematic OP.

### DIFF
--- a/cpp/order/NematicOrderParameter.h
+++ b/cpp/order/NematicOrderParameter.h
@@ -11,7 +11,6 @@
 #include "Box.h"
 #include "VectorMath.h"
 #include "TensorMath.h"
-#include "saruprng.h"
 #include "NearestNeighbors.h"
 #include "Index1D.h"
 


### PR DESCRIPTION
The saru random number generator is not used by NematicOrderParameter (it is a vestige from CubaticOrderParameter). This PR removes the unused header.