### PR TITLE
Empty particle buffers should have zero length.

### DIFF
--- a/freud/box.pyx
+++ b/freud/box.pyx
@@ -705,7 +705,7 @@ cdef class ParticleBuffer:
         cdef unsigned int buffer_size = \
             dereference(self.thisptr.getBufferParticles().get()).size()
         if not buffer_size:
-            return np.array([[]], dtype=np.float32)
+            return np.empty(shape=(0, 0), dtype=np.float32)
         cdef float[:, ::1] buffer_particles = \
             <float[:buffer_size, :3]> (<float*> dereference(
                 self.thisptr.getBufferParticles().get()).data())

--- a/freud/box.pyx
+++ b/freud/box.pyx
@@ -661,13 +661,13 @@ cdef class ParticleBuffer:
         box (:py:class:`freud.box.Box`): Simulation box.
 
     Attributes:
-        buffer_particles (:class:`numpy.ndarray`):
-            The buffer particles.
-        buffer_ids (:class:`numpy.ndarray`):
-            The buffer ids.
+        buffer_particles (:math:`\left(N_{buffer}, 3\right)` :class:`numpy.ndarray`):
+            The buffer particle positions.
+        buffer_ids (:math:`\left(N_{buffer}\right)` :class:`numpy.ndarray`):
+            The buffer particle ids.
         buffer_box (:class:`freud.box.Box`):
             The buffer box, expanded to hold the replicated particles.
-    """
+    """ # noqa: E501
 
     def __cinit__(self, box):
         cdef Box b = freud.common.convert_box(box)

--- a/freud/box.pyx
+++ b/freud/box.pyx
@@ -667,7 +667,7 @@ cdef class ParticleBuffer:
             The buffer particle ids.
         buffer_box (:class:`freud.box.Box`):
             The buffer box, expanded to hold the replicated particles.
-    """ # noqa: E501
+    """  # noqa: E501
 
     def __cinit__(self, box):
         cdef Box b = freud.common.convert_box(box)

--- a/freud/box.pyx
+++ b/freud/box.pyx
@@ -705,7 +705,7 @@ cdef class ParticleBuffer:
         cdef unsigned int buffer_size = \
             dereference(self.thisptr.getBufferParticles().get()).size()
         if not buffer_size:
-            return np.empty(shape=(0, 0), dtype=np.float32)
+            return np.empty(shape=(0, 3), dtype=np.float32)
         cdef float[:, ::1] buffer_particles = \
             <float[:buffer_size, :3]> (<float*> dereference(
                 self.thisptr.getBufferParticles().get()).data())

--- a/tests/test_box_ParticleBuffer.py
+++ b/tests/test_box_ParticleBuffer.py
@@ -19,10 +19,20 @@ class TestParticleBuffer(unittest.TestCase):
         # Add a z-component of 0
         positions = np.insert(positions, 2, 0, axis=1).astype(np.float32)
 
+        # Compute with zero buffer distance
+        pbuff.compute(positions, buffer=0, images=False)
+        self.assertEqual(len(pbuff.buffer_particles), 0)
+        npt.assert_array_equal(pbuff.buffer_box.L, np.asarray(fbox.L))
+
         # Compute with buffer distances
         pbuff.compute(positions, buffer=0.5*L, images=False)
         self.assertEqual(len(pbuff.buffer_particles), 3 * N)
         npt.assert_array_equal(pbuff.buffer_box.L, 2 * np.asarray(fbox.L))
+
+        # Compute with zero images
+        pbuff.compute(positions, buffer=0, images=True)
+        self.assertEqual(len(pbuff.buffer_particles), 0)
+        npt.assert_array_equal(pbuff.buffer_box.L, np.asarray(fbox.L))
 
         # Compute with images
         pbuff.compute(positions, buffer=1, images=True)
@@ -40,10 +50,20 @@ class TestParticleBuffer(unittest.TestCase):
         # Generate random points in the box
         positions = np.random.uniform(-L/2, L/2, size=(N, 3))
 
+        # Compute with zero buffer distance
+        pbuff.compute(positions, buffer=0, images=False)
+        self.assertEqual(len(pbuff.buffer_particles), 0)
+        npt.assert_array_equal(pbuff.buffer_box.L, np.asarray(fbox.L))
+
         # Compute with buffer distances
         pbuff.compute(positions, buffer=0.5*L, images=False)
         self.assertEqual(len(pbuff.buffer_particles), 7 * N)
         npt.assert_array_equal(pbuff.buffer_box.L, 2 * np.asarray(fbox.L))
+
+        # Compute with zero images
+        pbuff.compute(positions, buffer=0, images=True)
+        self.assertEqual(len(pbuff.buffer_particles), 0)
+        npt.assert_array_equal(pbuff.buffer_box.L, np.asarray(fbox.L))
 
         # Compute with images
         pbuff.compute(positions, buffer=1, images=True)
@@ -63,6 +83,11 @@ class TestParticleBuffer(unittest.TestCase):
         # Convert fractional coordinates to real coordinates
         positions = np.asarray(list(map(fbox.makeCoordinates, positions)))
         positions = fbox.wrap(positions)
+
+        # Compute with zero images
+        pbuff.compute(positions, buffer=0, images=True)
+        self.assertEqual(len(pbuff.buffer_particles), 0)
+        npt.assert_array_equal(pbuff.buffer_box.L, np.asarray(fbox.L))
 
         # Compute with images
         pbuff.compute(positions, buffer=2, images=True)


### PR DESCRIPTION
## Description
I changed the shape of an empty particle buffer from `(1, 0)` to `(0, 3)` so it has zero length (otherwise it suggests that it contains one particle) and a shape that can be concatenated with a real set of positions of shape `(N, 3)`.

## How Has This Been Tested?
I added tests to ensure this behavior when using zero buffer distance or zero images.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the [**CONTRIBUTING**](https://github.com/glotzerlab/freud/blob/master/CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
