### PR TITLE
Update nbconvert because older versions were marked as broken.

### DIFF
--- a/doc/readthedocs-env.yml
+++ b/doc/readthedocs-env.yml
@@ -5,83 +5,70 @@ channels:
 dependencies:
   - alabaster=0.7.12=py_0
   - asn1crypto=0.24.0=py37_1003
-  - attrs=18.2.0=py_0
+  - attrs=19.1.0=py_0
   - babel=2.6.0=py_1
-  - backcall=0.1.0=py_0
   - blas=1.1=openblas
+  - bleach=3.1.0=py_0
   - bzip2=1.0.6=h14c3975_1002
   - ca-certificates=2018.11.29=ha4d7672_0
   - certifi=2018.11.29=py37_1000
-  - cffi=1.11.5=py37h9745a5d_1001
+  - cffi=1.12.2=py37h9745a5d_0
   - chardet=3.0.4=py37_1003
-  - cryptography=2.5=py37hb7f436b_0
-  - cython=0.29.4=py37hf484d3e_0
+  - cryptography=2.5=py37h9d9f1b6_1
+  - cython=0.29.6=py37hf484d3e_0
   - decorator=4.3.2=py_0
+  - defusedxml=0.5.0=py_1
   - docutils=0.14=py37_1001
   - entrypoints=0.3=py37_1000
   - gmp=6.1.2=hf484d3e_1000
   - idna=2.8=py37_1000
   - imagesize=1.1.0=py_0
-  - ipython=7.2.0=py37h24bf2e0_1000
   - ipython_genutils=0.2.0=py_1
-  - jedi=0.13.2=py37_1000
   - jinja2=2.10=py_1
-  - jsonschema=3.0.0a3=py37_1000
-  - jupyter_client=5.2.4=py_3
+  - jsonschema=3.0.1=py37_0
   - jupyter_core=4.4.0=py_0
   - libffi=3.2.1=hf484d3e_1005
   - libgcc-ng=7.3.0=hdf63c60_0
   - libgfortran-ng=7.2.0=hdf63c60_3
-  - libsodium=1.0.16=h14c3975_1001
   - libstdcxx-ng=7.3.0=hdf63c60_0
-  - markupsafe=1.1.0=py37h14c3975_1000
+  - markupsafe=1.1.1=py37h14c3975_0
   - mistune=0.8.4=py37h14c3975_1000
   - nbconvert=5.4.1=py_1
   - nbformat=4.4.0=py_1
   - nbsphinx=0.4.2=py_0
   - ncurses=6.1=hf484d3e_1002
-  - numpy=1.16.1=py37_blas_openblash1522bff_0
+  - numpy=1.16.2=py37_blas_openblash1522bff_0
   - openblas=0.3.3=h9ac9557_1001
-  - openssl=1.0.2p=h14c3975_1002
+  - openssl=1.1.1b=h14c3975_0
   - packaging=19.0=py_0
-  - pandoc=2.6=0
+  - pandoc=1.19.2=0
   - pandocfilters=1.4.2=py_1
-  - parso=0.3.3=py_0
-  - pexpect=4.6.0=py37_1000
-  - pickleshare=0.7.5=py37_1000
-  - pip=19.0.1=py37_0
-  - prompt_toolkit=2.0.8=py_0
-  - ptyprocess=0.6.0=py37_1000
+  - pip=19.0.3=py37_0
   - pycparser=2.19=py_0
   - pygments=2.3.1=py_0
   - pyopenssl=19.0.0=py37_0
   - pyparsing=2.3.1=py_0
-  - pyrsistent=0.14.9=py37h14c3975_1000
+  - pyrsistent=0.14.11=py37h14c3975_0
   - pysocks=1.6.8=py37_1002
-  - python=3.7.1=hd21baee_1000
-  - python-dateutil=2.8.0=py_0
+  - python=3.7.1=h381d211_1002
   - pytz=2018.9=py_0
-  - pyzmq=17.1.2=py37h6afc9c9_1001
   - readline=7.0=hf8c457e_1001
   - requests=2.21.0=py37_1000
-  - scipy=1.2.0=py37_blas_openblash1522bff_1201
-  - setuptools=40.7.3=py37_0
+  - scipy=1.2.1=py37_blas_openblash1522bff_0
+  - setuptools=40.8.0=py37_0
   - six=1.12.0=py37_1000
   - snowballstemmer=1.2.1=py_1
   - sphinx=1.8.4=py37_0
-  - sphinx_rtd_theme=0.4.2=py_0
+  - sphinx_rtd_theme=0.4.3=py_0
   - sphinxcontrib-websupport=1.1.0=py_1
   - sqlite=3.26.0=h67949de_1000
-  - tbb=2019.3=h6bb024c_1000
-  - tbb-devel=2019.3=h6bb024c_1000
+  - tbb=2019.4=h6bb024c_0
+  - tbb-devel=2019.4=h6bb024c_0
   - testpath=0.4.2=py37_1000
   - tk=8.6.9=h84994c4_1000
-  - tornado=5.1.1=py37h14c3975_1000
   - traitlets=4.3.2=py37_1000
   - urllib3=1.24.1=py37_1000
-  - wcwidth=0.1.7=py_1
   - webencodings=0.5.1=py_1
-  - wheel=0.32.3=py37_0
+  - wheel=0.33.1=py37_0
   - xz=5.2.4=h14c3975_1001
-  - zeromq=4.2.5=hf484d3e_1006
   - zlib=1.2.11=h14c3975_1004

--- a/doc/readthedocs-env.yml
+++ b/doc/readthedocs-env.yml
@@ -36,7 +36,7 @@ dependencies:
   - libstdcxx-ng=7.3.0=hdf63c60_0
   - markupsafe=1.1.0=py37h14c3975_1000
   - mistune=0.8.4=py37h14c3975_1000
-  - nbconvert=5.3.1=py_1
+  - nbconvert=5.4.1=py_1
   - nbformat=4.4.0=py_1
   - nbsphinx=0.4.2=py_0
   - ncurses=6.1=hf484d3e_1002


### PR DESCRIPTION
## Motivation and Context

Read the Docs builds are failing because the conda environment nbconvert is pointing to a broken version. https://anaconda.org/conda-forge/nbconvert/files

## How Has This Been Tested?

Build URL for this PR:
https://readthedocs.org/projects/freud/builds/8711800/