### PR TITLE
fix issue 233

### DIFF
--- a/doc/source/credits.rst
+++ b/doc/source/credits.rst
@@ -196,6 +196,10 @@ Matthew Palathingal
 * Replaced use of boost shared arrays with shared ptr in Cython.
 * Helped incorporate BiMap class into MatchEnv.
 
+Yezhi Jin
+
+* Added support for 2D arrays in the Python interface to Box functions.
+
 Source code
 -----------
 

--- a/freud/box.pyx
+++ b/freud/box.pyx
@@ -221,7 +221,7 @@ cdef class Box:
 
         Returns:
             :math:`\left(3\right)` or :math:`\left(N, 3\right)` :class:`numpy.ndarray`:
-                Vectors of real coordinates ::math:`\left(3\right)` or :math:`\left(N, 3\right)`.
+                Vectors of real coordinates: :math:`\left(3\right)` or :math:`\left(N, 3\right)`.
         """
         fs = np.asarray(fs)
         if fs.ndim > 2 or fs.shape[fs.ndim - 1] != 3:
@@ -254,7 +254,7 @@ cdef class Box:
 
         Returns:
             :math:`\left(3\right)` or :math:`\left(N, 3\right)` :class:`numpy.ndarray`:
-                Fractional coordinate vectors.
+                Fractional coordinate vectors: :math:`\left(3\right)` or :math:`\left(N, 3\right)`.
         """
         vecs = np.asarray(vecs)
         if vecs.ndim > 2 or vecs.shape[vecs.ndim - 1] != 3:

--- a/freud/box.pyx
+++ b/freud/box.pyx
@@ -221,7 +221,7 @@ cdef class Box:
         Returns:
             :math:`\left(3\right)` or :math:`\left(N, 3\right)` :class:`numpy.ndarray`:
                 Vectors of real coordinates: :math:`\left(3\right)` or :math:`\left(N, 3\right)`.
-        """
+        """  # noqa: E501
         fractions = np.asarray(fractions)
         if fractions.ndim > 2 or fractions.shape[fractions.ndim-1] != 3:
             raise ValueError(
@@ -254,7 +254,7 @@ cdef class Box:
         Returns:
             :math:`\left(3\right)` or :math:`\left(N, 3\right)` :class:`numpy.ndarray`:
                 Fractional coordinate vectors: :math:`\left(3\right)` or :math:`\left(N, 3\right)`.
-        """
+        """  # noqa: E501
         vecs = np.asarray(vecs)
         if vecs.ndim > 2 or vecs.shape[vecs.ndim-1] != 3:
             raise ValueError(
@@ -289,7 +289,7 @@ cdef class Box:
         Returns:
             :math:`\left(3\right)` or :math:`\left(N, 3\right)` :class:`numpy.ndarray`:
                 Image index vector.
-        """
+        """  # noqa: E501
         vecs = np.asarray(vecs)
         if vecs.ndim > 2 or vecs.shape[vecs.ndim-1] != 3:
             raise ValueError(

--- a/freud/box.pyx
+++ b/freud/box.pyx
@@ -211,33 +211,32 @@ cdef class Box:
     def volume(self):
         return self.thisptr.getVolume()
 
-
-    def makeCoordinates(self, fs):
+    def makeCoordinates(self, fractions):
         R"""Convert fractional coordinates into real coordinates.
 
         Args:
-            f (:math:`\left(3\right)` or :math:`\left(N, 3\right)` :class:`numpy.ndarray`):
+            fractions (:math:`\left(3\right)` or :math:`\left(N, 3\right)` :class:`numpy.ndarray`):
                 Fractional coordinates between 0 and 1 within parallelepipedal box.
 
         Returns:
             :math:`\left(3\right)` or :math:`\left(N, 3\right)` :class:`numpy.ndarray`:
                 Vectors of real coordinates: :math:`\left(3\right)` or :math:`\left(N, 3\right)`.
         """
-        fs = np.asarray(fs)
-        if fs.ndim > 2 or fs.shape[fs.ndim - 1] != 3:
+        fractions = np.asarray(fractions)
+        if fractions.ndim > 2 or fractions.shape[fractions.ndim-1] != 3:
             raise ValueError(
-                "Invalid dimensions for vecs given to box.makeCoordinates. "
+                "Invalid dimensions for fractions given to makeCoordinates. "
                 "Valid input is an array of shape (3,) or (N,3).")
 
-        fs = freud.common.convert_array(
-            fs, fs.ndim, dtype=np.float32, contiguous=True)
+        fractions = freud.common.convert_array(
+            fractions, fractions.ndim, dtype=np.float32, contiguous=True)
 
-        if fs.ndim == 1:
-            fs[:] = self._makeCoordinates(fs)
-        elif fs.ndim == 2:
-            for i, f in enumerate(fs):
-                fs[i] = self._makeCoordinates(f)
-        return fs
+        if fractions.ndim == 1:
+            fractions[:] = self._makeCoordinates(fractions)
+        elif fractions.ndim == 2:
+            for i, f in enumerate(fractions):
+                fractions[i] = self._makeCoordinates(f)
+        return fractions
 
     def _makeCoordinates(self, f):
         cdef float[::1] l_vec = f
@@ -257,9 +256,9 @@ cdef class Box:
                 Fractional coordinate vectors: :math:`\left(3\right)` or :math:`\left(N, 3\right)`.
         """
         vecs = np.asarray(vecs)
-        if vecs.ndim > 2 or vecs.shape[vecs.ndim - 1] != 3:
+        if vecs.ndim > 2 or vecs.shape[vecs.ndim-1] != 3:
             raise ValueError(
-                "Invalid dimensions for vecs given to box.makeFraction. "
+                "Invalid dimensions for vecs given to makeFraction. "
                 "Valid input is an array of shape (3,) or (N,3).")
 
         vecs = freud.common.convert_array(
@@ -294,7 +293,7 @@ cdef class Box:
         vecs = np.asarray(vecs)
         if vecs.ndim > 2 or vecs.shape[vecs.ndim-1] != 3:
             raise ValueError(
-                "Invalid dimensions for vecs given to box.getImage. "
+                "Invalid dimensions for vecs given to getImage. "
                 "Valid input is an array of shape (3,) or (N,3).")
 
         vecs = freud.common.convert_array(
@@ -348,7 +347,7 @@ cdef class Box:
         vecs = np.asarray(vecs)
         if vecs.ndim > 2 or vecs.shape[vecs.ndim-1] != 3:
             raise ValueError(
-                "Invalid dimensions for vecs given to box.wrap. "
+                "Invalid dimensions for vecs given to wrap. "
                 "Valid input is an array of shape (3,) or (N,3).")
 
         vecs = freud.common.convert_array(
@@ -391,7 +390,7 @@ cdef class Box:
 
         if vecs.ndim > 2 or vecs.shape[vecs.ndim-1] != 3:
             raise ValueError(
-                "Invalid dimensions for vecs given to box.unwrap. "
+                "Invalid dimensions for vecs given to unwrap. "
                 "Valid input is an array of shape (3,) or (N,3).")
 
         vecs = freud.common.convert_array(
@@ -528,7 +527,7 @@ cdef class Box:
 
     @classmethod
     def from_box(cls, box, dimensions=None):
-        R"""Initialize a box instance from a box-like object.
+        R"""Initialize a Box instance from a box-like object.
 
         Args:
             box:
@@ -601,7 +600,7 @@ cdef class Box:
                 if not len(box) in [2, 3, 6]:
                     raise ValueError(
                         "List-like objects must have length 2, 3, or 6 to be "
-                        "converted to a box")
+                        "converted to freud.box.Box.")
                 # Handle list-like
                 Lx = box[0]
                 Ly = box[1]
@@ -609,7 +608,7 @@ cdef class Box:
                 xy, xz, yz = box[3:6] if len(box) >= 6 else (0, 0, 0)
         except:  # noqa
             logger.debug('Supplied box cannot be converted to type '
-                         'freud.box.Box')
+                         'freud.box.Box.')
             raise
 
         # Infer dimensions if not provided.
@@ -620,7 +619,7 @@ cdef class Box:
 
     @classmethod
     def from_matrix(cls, boxMatrix, dimensions=None):
-        R"""Initialize a box instance from a box matrix.
+        R"""Initialize a Box instance from a box matrix.
 
         For more information and the source for this code,
         see: http://hoomd-blue.readthedocs.io/en/stable/box.html

--- a/tests/test_box_Box.py
+++ b/tests/test_box_Box.py
@@ -156,20 +156,39 @@ class TestBox(unittest.TestCase):
                          np.array([[25, 20, 15],
                                    [-5, 0, 0]]),
                          err_msg="ImageFail")
+        testimages = box.getImage(testpoints)
+        npt.assert_equal(testimages,
+                         np.array([[25, 20, 15],
+                                   [-5, 0, 0]]),
+                         err_msg="ImageFail")
 
     def test_coordinates(self):
         box = bx.Box(2, 2, 2)
-        f_point = np.array([0.5, 0.25, 0.75])
-        point = np.array([0, -0.5, 0.5])
+        f_point = np.array([[0.5, 0.25, 0.75],
+                            [0, 0, 0],
+                            [0.5, 0.5, 0.5]])
+        point = np.array([[0, -0.5, 0.5], [-1, -1, -1], [0, 0, 0]])
 
-        npt.assert_equal(box.makeCoordinates(f_point),
-                         point)
-        npt.assert_equal(box.makeFraction(point),
-                         f_point)
+        testcoordinates = np.array([box.makeCoordinates(f) for f in f_point])
+        npt.assert_equal(testcoordinates, point, err_msg="CoordinatesFail")
 
-        dims = np.array([2, 2, 2])
-        for i in range(10):
-            npt.assert_array_equal(box.getImage(dims*i), [i, i, i])
+        testcoordinates = box.makeCoordinates(f_point)
+
+        npt.assert_equal(testcoordinates, point, err_msg="CoordinatesFail")
+
+    def test_fraction(self):
+        box = bx.Box(2, 2, 2)
+        f_point = np.array([[0.5, 0.25, 0.75],
+                            [0, 0, 0],
+                            [0.5, 0.5, 0.5]])
+        point = np.array([[0, -0.5, 0.5], [-1, -1, -1], [0, 0, 0]])
+
+        testfraction = np.array([box.makeFraction(vec) for vec in point])
+        npt.assert_equal(testfraction, f_point, err_msg="FractionFail")
+
+        testfraction = box.makeFraction(point)
+
+        npt.assert_equal(testfraction, f_point, err_msg="FractionFail")
 
     def test_vectors(self):
         """Test getting lattice vectors"""


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Box functions (makeCoordinates, makeFraction,getImage) in freud support 2D Numpy arrays of shape (N, 3) and will return an array of the same shape.

## Description
`makeCoordinates`, `makeFraction` and `getImage` accept 2D Numpy arrays of shape `(N, 3)`.

## Motivation and Context
This change increases the efficiency by adding the functionality of supporting 2D array. Resolves #233.

## How Has This Been Tested?
I added tests for N by 3 arrays.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/glotzerlab/freud/blob/master/CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.