### PR TITLE
Issue210: Add __repr__ and __str__ methods for pretty representations of objects

### DIFF
--- a/freud/box.pyx
+++ b/freud/box.pyx
@@ -444,9 +444,9 @@ cdef class Box:
                 [0, 0, self.Lz]]
 
     def __repr__(self):
-        return ("freud.box.{cls}(Lx={Lx}, Ly={Ly}, Lz={Lz}, xy={xy}, "
-                "xz={xz}, yz={yz}, is2D={is2D})").format(
-                    cls=type(self).__name__, **self.to_dict(), is2D=self.is2D())
+        return ("freud.box.{cls}(Lx={Lx}, Ly={Ly}, Lz={Lz}, xy={xy}, \
+            xz={xz}, yz={yz}, is2D={is2D})").format(
+            cls=type(self).__name__, **self.to_dict(), is2D=self.is2D())
 
     def __str__(self):
         return repr(self)
@@ -730,7 +730,8 @@ cdef class ParticleBuffer:
         return BoxFromCPP(<freud._box.Box> self.thisptr.getBufferBox())
 
     def __repr__(self):
-        return ("freud.box.{cls}(box={box})").format(cls=type(self).__name__, box=self.buffer_box.__repr__())
+        return ("freud.box.{cls}(box={box})").format(
+            cls=type(self).__name__, box=self.buffer_box.__repr__())
 
     def __str__(self):
         return repr(self)

--- a/freud/box.pyx
+++ b/freud/box.pyx
@@ -491,9 +491,11 @@ cdef class Box:
                 [0, 0, self.Lz]]
 
     def __repr__(self):
-        return ("freud.box.{cls}(Lx={Lx}, Ly={Ly}, Lz={Lz}, xy={xy}, \
-            xz={xz}, yz={yz}, is2D={is2D})").format(
-            cls=type(self).__name__, **self.to_dict(), is2D=self.is2D())
+        return ("freud.box.{cls}(Lx={Lx}, Ly={Ly}, Lz={Lz}, " +
+                "xy={xy}, xz={xz}, yz={yz}, " +
+                "is2D={is2D})").format(cls=type(self).__name__,
+                                       **self.to_dict(),
+                                       is2D=self.is2D())
 
     def __str__(self):
         return repr(self)

--- a/freud/box.pyx
+++ b/freud/box.pyx
@@ -444,12 +444,12 @@ cdef class Box:
                 [0, 0, self.Lz]]
 
     def __repr__(self):
-        return ("{cls}(Lx={Lx}, Ly={Ly}, Lz={Lz}, xy={xy}, "
+        return ("freud.box.{cls}(Lx={Lx}, Ly={Ly}, Lz={Lz}, xy={xy}, "
                 "xz={xz}, yz={yz}, is2D={is2D})").format(
-                    cls=type(self).__name__, **self.to_dict())
+                    cls=type(self).__name__, **self.to_dict(), is2D=self.is2D())
 
     def __str__(self):
-        return __repr__(self)
+        return repr(self)
 
     def _eq(self, other):
         return self.to_dict() == other.to_dict()
@@ -728,3 +728,9 @@ cdef class ParticleBuffer:
     @property
     def buffer_box(self):
         return BoxFromCPP(<freud._box.Box> self.thisptr.getBufferBox())
+
+    def __repr__(self):
+        return ("freud.box.{cls}(box={box})").format(cls=type(self).__name__, box=self.buffer_box.__repr__())
+
+    def __str__(self):
+        return repr(self)

--- a/freud/box.pyx
+++ b/freud/box.pyx
@@ -443,10 +443,13 @@ cdef class Box:
                 [0, self.Ly, self.yz * self.Lz],
                 [0, 0, self.Lz]]
 
-    def __str__(self):
+    def __repr__(self):
         return ("{cls}(Lx={Lx}, Ly={Ly}, Lz={Lz}, xy={xy}, "
-                "xz={xz}, yz={yz}, dimensions={dimensions})").format(
+                "xz={xz}, yz={yz}, is2D={is2D})").format(
                     cls=type(self).__name__, **self.to_dict())
+
+    def __str__(self):
+        return __repr__(self)
 
     def _eq(self, other):
         return self.to_dict() == other.to_dict()

--- a/freud/cluster.pyx
+++ b/freud/cluster.pyx
@@ -163,8 +163,10 @@ cdef class Cluster:
         return cluster_keys
 
     def __repr__(self):
-        return ("freud.cluster.{cls}(box={box}, rcut={rcut})").format(
-            cls=type(self).__name__, box=self.m_box.__repr__(), rcut=self.rmax)
+        return ("freud.cluster.{cls}(box={box}, " +
+                "rcut={rcut})").format(cls=type(self).__name__,
+                                       box=self.m_box.__repr__(),
+                                       rcut=self.rmax)
 
     def __str__(self):
         return repr(self)

--- a/freud/cluster.pyx
+++ b/freud/cluster.pyx
@@ -163,7 +163,8 @@ cdef class Cluster:
         return cluster_keys
 
     def __repr__(self):
-        return ("freud.cluster.{cls}(box={box},rcut={rcut})").format(cls=type(self).__name__, box=self.m_box.__repr__(),rcut=self.rmax)
+        return ("freud.cluster.{cls}(box={box}, rcut={rcut})").format(
+            cls=type(self).__name__, box=self.m_box.__repr__(), rcut=self.rmax)
 
     def __str__(self):
         return repr(self)
@@ -300,7 +301,8 @@ cdef class ClusterProperties:
         return np.asarray(cluster_sizes, dtype=np.uint32)
 
     def __repr__(self):
-        return ("freud.cluster.{cls}(box={box})").format(cls=type(self).__name__, box=self.m_box.__repr__())
+        return ("freud.cluster.{cls}(box={box})").format(
+            cls=type(self).__name__, box=self.m_box.__repr__())
 
     def __str__(self):
         return repr(self)

--- a/freud/cluster.pyx
+++ b/freud/cluster.pyx
@@ -162,6 +162,12 @@ cdef class Cluster:
         cluster_keys = self.thisptr.getClusterKeys()
         return cluster_keys
 
+    def __repr__(self):
+        return ("freud.cluster.{cls}(box={box},rcut={rcut})").format(cls=type(self).__name__, box=self.m_box.__repr__(),rcut=self.rmax)
+
+    def __str__(self):
+        return repr(self)
+
 
 cdef class ClusterProperties:
     R"""Routines for computing properties of point clusters.
@@ -292,3 +298,9 @@ cdef class ClusterProperties:
         cdef unsigned int[::1] cluster_sizes = \
             <unsigned int[:n_clusters]> self.thisptr.getClusterSize().get()
         return np.asarray(cluster_sizes, dtype=np.uint32)
+
+    def __repr__(self):
+        return ("freud.cluster.{cls}(box={box})").format(cls=type(self).__name__, box=self.m_box.__repr__())
+
+    def __str__(self):
+        return repr(self)

--- a/freud/density.pyx
+++ b/freud/density.pyx
@@ -209,7 +209,8 @@ cdef class FloatCF:
         return np.asarray(R)
 
     def __repr__(self):
-        return ("freud.density.{cls}(rmax = {rmax},dr={dr})").format(cls=type(self).__name__,rmax=self.rmax,dr=self.dr)
+        return ("freud.density.{cls}(rmax={rmax}, dr={dr})").format(
+            cls=type(self).__name__, rmax=self.rmax, dr=self.dr)
 
     def __str__(self):
         return repr(self)
@@ -403,7 +404,8 @@ cdef class ComplexCF:
         return np.asarray(R)
 
     def __repr__(self):
-        return ("freud.density.{cls}(rmax = {rmax},dr={dr})").format(cls=type(self).__name__,rmax=self.rmax,dr=self.dr)
+        return ("freud.density.{cls}(rmax={rmax}, dr={dr})").format(
+            cls=type(self).__name__, rmax=self.rmax, dr=self.dr)
 
     def __str__(self):
         return repr(self)
@@ -463,11 +465,11 @@ cdef class GaussianDensity:
         if len(args) == 3:
             self.thisptr = new freud._density.GaussianDensity(
                 args[0], args[1], args[2])
-            self.arglist = [args[0],args[1],args[2]]
+            self.arglist = [args[0], args[1], args[2]]
         elif len(args) == 5:
             self.thisptr = new freud._density.GaussianDensity(
                 args[0], args[1], args[2], args[3], args[4])
-            self.arglist = [args[0],args[1],args[2],args[3],args[4]]
+            self.arglist = [args[0], args[1], args[2], args[3], args[4]]
         else:
             raise TypeError('GaussianDensity takes exactly 3 or 5 arguments')
 
@@ -516,12 +518,17 @@ cdef class GaussianDensity:
 
     def __repr__(self):
         if len(self.arglist) == 3:
-            return ("freud.density.{cls}({width},{r_cut},{sigma})".format(cls=type(self).__name__,
-            width=self.arglist[0],r_cut=self.arglist[1],sigma=self.arglist[2]))
+            return ("freud.density.{cls}({width}, {r_cut}, {sigma})".format(
+                cls=type(self).__name__,
+                width=self.arglist[0],
+                r_cut=self.arglist[1],
+                sigma=self.arglist[2]))
         elif len(self.arglist) == 5:
-            return ("freud.density.{cls}({width_x},{width_y},{width_z},{r_cut},{sigma})".format(
-            cls=type(self).__name__, width_x=self.arglist[0],width_y=self.arglist[1],width_z=self.arglist[2],
-            r_cut=self.arglist[3],sigma=self.arglist[4]))
+            return ("freud.density.{cls}({width_x}, {width_y}, {width_z}, \
+                {r_cut},{sigma})".format(
+                cls=type(self).__name__, width_x=self.arglist[0],
+                width_y=self.arglist[1], width_z=self.arglist[2],
+                r_cut=self.arglist[3], sigma=self.arglist[4]))
         else:
             raise TypeError('GaussianDensity takes exactly 3 or 5 arguments')
 
@@ -663,7 +670,10 @@ cdef class LocalDensity:
         return np.asarray(num_neighbors)
 
     def __repr__(self):
-        return ("freud.density.{cls}(r_cut={r_cut},volume={volume},diameter={diameter})").format(cls=type(self).__name__,r_cut=self.r_cut,volume=self.volume,diameter=self.diameter)
+        return ("freud.density.{cls}(r_cut={r_cut}, volume={volume}, \
+            diameter={diameter})").format(
+            cls=type(self).__name__, r_cut=self.r_cut,
+            volume=self.volume, diameter=self.diameter)
 
     def __str__(self):
         return repr(self)
@@ -826,7 +836,9 @@ cdef class RDF:
         return np.asarray(n_r)
 
     def __repr__(self):
-        return ("freud.density.{cls}(rmax={rmax},dr={dr},rmin={rmin})").format(cls=type(self).__name__,rmax=self.rmax,dr=self.dr,rmin=self.rmin)
+        return ("freud.density.{cls}(rmax={rmax}, dr={dr}, rmin={rmin})").
+        format(cls=type(self).__name__, rmax=self.rmax,
+               dr=self.dr, rmin=self.rmin)
 
     def __str__(self):
         return repr(self)

--- a/freud/density.pyx
+++ b/freud/density.pyx
@@ -518,17 +518,19 @@ cdef class GaussianDensity:
 
     def __repr__(self):
         if len(self.arglist) == 3:
-            return ("freud.density.{cls}({width}, {r_cut}, {sigma})".format(
-                cls=type(self).__name__,
-                width=self.arglist[0],
-                r_cut=self.arglist[1],
-                sigma=self.arglist[2]))
+            return ("freud.density.{cls}({width}, " +
+                    "{r_cut}, {sigma})").format(cls=type(self).__name__,
+                                                width=self.arglist[0],
+                                                r_cut=self.arglist[1],
+                                                sigma=self.arglist[2])
         elif len(self.arglist) == 5:
-            return ("freud.density.{cls}({width_x}, {width_y}, {width_z}, \
-                {r_cut},{sigma})".format(
-                cls=type(self).__name__, width_x=self.arglist[0],
-                width_y=self.arglist[1], width_z=self.arglist[2],
-                r_cut=self.arglist[3], sigma=self.arglist[4]))
+            return ("freud.density.{cls}({width_x}, {width_y}, {width_z}, " +
+                    "{r_cut}, {sigma})").format(cls=type(self).__name__,
+                                                width_x=self.arglist[0],
+                                                width_y=self.arglist[1],
+                                                width_z=self.arglist[2],
+                                                r_cut=self.arglist[3],
+                                                sigma=self.arglist[4])
         else:
             raise TypeError('GaussianDensity takes exactly 3 or 5 arguments')
 
@@ -670,10 +672,11 @@ cdef class LocalDensity:
         return np.asarray(num_neighbors)
 
     def __repr__(self):
-        return ("freud.density.{cls}(r_cut={r_cut}, volume={volume}, \
-            diameter={diameter})").format(
-            cls=type(self).__name__, r_cut=self.r_cut,
-            volume=self.volume, diameter=self.diameter)
+        return ("freud.density.{cls}(r_cut={r_cut}, volume={volume}, " +
+                "diameter={diameter})").format(cls=type(self).__name__,
+                                               r_cut=self.r_cut,
+                                               volume=self.volume,
+                                               diameter=self.diameter)
 
     def __str__(self):
         return repr(self)
@@ -836,9 +839,11 @@ cdef class RDF:
         return np.asarray(n_r)
 
     def __repr__(self):
-        return ("freud.density.{cls}(rmax={rmax}, dr={dr}, rmin={rmin})").
-        format(cls=type(self).__name__, rmax=self.rmax,
-               dr=self.dr, rmin=self.rmin)
+        return ("freud.density.{cls}(rmax={rmax}, dr={dr}, " +
+                "rmin={rmin})").format(cls=type(self).__name__,
+                                       rmax=self.rmax,
+                                       dr=self.dr,
+                                       rmin=self.rmin)
 
     def __str__(self):
         return repr(self)

--- a/freud/density.pyx
+++ b/freud/density.pyx
@@ -72,12 +72,14 @@ cdef class FloatCF:
     """
     cdef freud._density.CorrelationFunction[double] * thisptr
     cdef rmax
+    cdef dr
 
     def __cinit__(self, float rmax, float dr):
         if dr <= 0.0:
             raise ValueError("dr must be > 0")
         self.thisptr = new freud._density.CorrelationFunction[double](rmax, dr)
         self.rmax = rmax
+        self.dr = dr
 
     def __dealloc__(self):
         del self.thisptr
@@ -206,6 +208,12 @@ cdef class FloatCF:
             <float[:n_bins]> self.thisptr.getR().get()
         return np.asarray(R)
 
+    def __repr__(self):
+        return ("freud.density.{cls}(rmax = {rmax},dr={dr})").format(cls=type(self).__name__,rmax=self.rmax,dr=self.dr)
+
+    def __str__(self):
+        return repr(self)
+
 
 cdef class ComplexCF:
     R"""Computes the complex pairwise correlation function.
@@ -256,6 +264,7 @@ cdef class ComplexCF:
     """
     cdef freud._density.CorrelationFunction[np.complex128_t] * thisptr
     cdef rmax
+    cdef dr
 
     def __cinit__(self, float rmax, float dr):
         if dr <= 0.0:
@@ -263,6 +272,7 @@ cdef class ComplexCF:
         self.thisptr = new freud._density.CorrelationFunction[np.complex128_t](
             rmax, dr)
         self.rmax = rmax
+        self.dr = dr
 
     def __dealloc__(self):
         del self.thisptr
@@ -392,6 +402,12 @@ cdef class ComplexCF:
             <float[:n_bins]> self.thisptr.getR().get()
         return np.asarray(R)
 
+    def __repr__(self):
+        return ("freud.density.{cls}(rmax = {rmax},dr={dr})").format(cls=type(self).__name__,rmax=self.rmax,dr=self.dr)
+
+    def __str__(self):
+        return repr(self)
+
 
 cdef class GaussianDensity:
     R"""Computes the density of a system on a grid.
@@ -441,14 +457,17 @@ cdef class GaussianDensity:
             The centers of each bin.
     """  # noqa: E501
     cdef freud._density.GaussianDensity * thisptr
+    cdef arglist
 
     def __cinit__(self, *args):
         if len(args) == 3:
             self.thisptr = new freud._density.GaussianDensity(
                 args[0], args[1], args[2])
+            self.arglist = [args[0],args[1],args[2]]
         elif len(args) == 5:
             self.thisptr = new freud._density.GaussianDensity(
                 args[0], args[1], args[2], args[3], args[4])
+            self.arglist = [args[0],args[1],args[2],args[3],args[4]]
         else:
             raise TypeError('GaussianDensity takes exactly 3 or 5 arguments')
 
@@ -494,6 +513,13 @@ cdef class GaussianDensity:
         else:
             array_shape = (width_z, width_y, width_x)
         return np.reshape(np.asarray(density), array_shape)
+
+    def __repr__(self):
+        if len(self.arglist) == 3:
+            return ("freud.density.{cls}(width={width},rcut={rcut},dr={dr})").format(cls=type(self).__name__, width=self.width,rcut=self.rcut,dr=self.dr)
+
+    def __str__(self):
+        return repr(self)
 
 
 cdef class LocalDensity:

--- a/freud/environment.pxd
+++ b/freud/environment.pxd
@@ -12,11 +12,16 @@ cdef class BondOrder:
     cdef freud._environment.BondOrder * thisptr
     cdef num_neigh
     cdef rmax
+    cdef k
+    cdef n_bins_t
+    cdef n_bins_p
 
 cdef class LocalDescriptors:
     cdef freud._environment.LocalDescriptors * thisptr
     cdef num_neigh
     cdef rmax
+    cdef lmax
+    cdef negative_m
 
 cdef class MatchEnv:
     cdef freud._environment.MatchEnv * thisptr

--- a/freud/environment.pyx
+++ b/freud/environment.pyx
@@ -128,6 +128,9 @@ cdef class BondOrder:
             rmax, k, n, n_bins_t, n_bins_p)
         self.rmax = rmax
         self.num_neigh = n
+        self.k = k
+        self.n_bins_t = n_bins_t
+        self.n_bins_p = n_bins_p
 
     def __dealloc__(self):
         del self.thisptr
@@ -305,6 +308,13 @@ cdef class BondOrder:
     def n_bins_phi(self):
         return self.thisptr.getNBinsPhi()
 
+    def __repr__(self):
+        return ("freud.environment.{cls}(rmax={rmax},k={k},num_neigh={num_neigh},n_bins_t={n_bins_t},n_bins_p={n_bins_p})".format(
+        cls=type(self).__name__,rmax=self.rmax,k=self.k,num_neigh=self.num_neigh,n_bins_t=self.n_bins_t,n_bins_p=self.n_bins_p))
+
+    def __str__(self):
+        return repr(self)
+
 
 cdef class LocalDescriptors:
     R"""Compute a set of descriptors (a numerical "fingerprint") of a particle's
@@ -359,6 +369,8 @@ cdef class LocalDescriptors:
             num_neighbors, lmax, rmax, negative_m)
         self.num_neigh = num_neighbors
         self.rmax = rmax
+        self.lmax = lmax
+        self.negative_m = negative_m
 
     def __dealloc__(self):
         del self.thisptr
@@ -524,6 +536,13 @@ cdef class LocalDescriptors:
     @property
     def l_max(self):
         return self.thisptr.getLMax()
+
+    def __repr__(self):
+        return ("freud.environment.{cls}(num_neigh={num_neigh},lmax={lmax},rmax={rmax},negative_m={negative_m})".format(
+        cls=type(self).__name__,num_neigh=self.num_neigh,lmax=self.lmax,rmax=self.rmax,negative_m=self.negative_m))
+
+    def __str__(self):
+        return repr(self)
 
 
 cdef class MatchEnv:
@@ -894,6 +913,13 @@ cdef class MatchEnv:
     def num_clusters(self):
         return self.thisptr.getNumClusters()
 
+    def __repr__(self):
+        return "freud.environment.{cls}(box={box},rmax={rmax},k={k})".format(cls=type(self).__name__,box=self.m_box.__repr__(),rmax=self.rmax,k=self.num_neigh)
+
+    def __str__(self):
+        return repr(self)
+
+
 
 cdef class AngularSeparation:
     R"""Calculates the minimum angles of separation between particles and
@@ -1104,6 +1130,12 @@ cdef class AngularSeparation:
     def n_global(self):
         return self.thisptr.getNglobal()
 
+    def __repr__(self):
+        return "freud.environment.{cls}(rmax={rmax},n={n})".format(cls=type(self).__name__,rmax=self.rmax,n=self.num_neigh)
+
+    def __str__(self):
+        return repr(self)
+
 
 cdef class LocalBondProjection:
     R"""Calculates the maximal projection of nearest neighbor bonds for each
@@ -1279,3 +1311,9 @@ cdef class LocalBondProjection:
     @property
     def box(self):
         return freud.box.BoxFromCPP(<freud._box.Box> self.thisptr.getBox())
+
+    def __repr__(self):
+        return "freud.environment.{cls}(rmax={rmax},num_neigh={num_neigh})".format(cls=type(self).__name__,rmax=self.rmax,num_neigh=self.num_neigh)
+
+    def __str__(self):
+        return repr(self)

--- a/freud/environment.pyx
+++ b/freud/environment.pyx
@@ -309,11 +309,14 @@ cdef class BondOrder:
         return self.thisptr.getNBinsPhi()
 
     def __repr__(self):
-        return ("freud.environment.{cls}(rmax={rmax}, k={k}, num_neigh= \
-            {num_neigh},n_bins_t={n_bins_t},n_bins_p={n_bins_p})".format(
-                cls=type(self).__name__, rmax=self.rmax,
-                k=self.k, num_neigh=self.num_neigh, n_bins_t=self.n_bins_t,
-                n_bins_p=self.n_bins_p))
+        return ("freud.environment.{cls}(rmax={rmax}, k={k}, " +
+                "num_neigh={num_neigh}, n_bins_t={n_bins_t}, " +
+                "n_bins_p={n_bins_p})".format(cls=type(self).__name__,
+                                              rmax=self.rmax,
+                                              k=self.k,
+                                              num_neigh=self.num_neigh,
+                                              n_bins_t=self.n_bins_t,
+                                              n_bins_p=self.n_bins_p))
 
     def __str__(self):
         return repr(self)
@@ -541,10 +544,13 @@ cdef class LocalDescriptors:
         return self.thisptr.getLMax()
 
     def __repr__(self):
-        return ("freud.environment.{cls}(num_neigh={num_neigh}, \
-            lmax={lmax}, rmax={rmax}, negative_m={negative_m})".format(
-            cls=type(self).__name__, num_neigh=self.num_neigh, lmax=self.lmax,
-            rmax=self.rmax, negative_m=self.negative_m))
+        return ("freud.environment.{cls}(num_neigh={num_neigh}, " +
+                "lmax={lmax}, rmax={rmax}, " +
+                "negative_m={negative_m})".format(cls=type(self).__name__,
+                                                  num_neigh=self.num_neigh,
+                                                  lmax=self.lmax,
+                                                  rmax=self.rmax,
+                                                  negative_m=self.negative_m))
 
     def __str__(self):
         return repr(self)
@@ -1318,9 +1324,10 @@ cdef class LocalBondProjection:
         return freud.box.BoxFromCPP(<freud._box.Box> self.thisptr.getBox())
 
     def __repr__(self):
-        return "freud.environment.{cls}(rmax={rmax}, num_neigh={num_neigh})".
-        format(cls=type(self).__name__, rmax=self.rmax,
-               num_neigh=self.num_neigh)
+        return ("freud.environment.{cls}(rmax={rmax}, " +
+                "num_neigh={num_neigh})").format(cls=type(self).__name__,
+                                                 rmax=self.rmax,
+                                                 num_neigh=self.num_neigh)
 
     def __str__(self):
         return repr(self)

--- a/freud/environment.pyx
+++ b/freud/environment.pyx
@@ -309,8 +309,11 @@ cdef class BondOrder:
         return self.thisptr.getNBinsPhi()
 
     def __repr__(self):
-        return ("freud.environment.{cls}(rmax={rmax},k={k},num_neigh={num_neigh},n_bins_t={n_bins_t},n_bins_p={n_bins_p})".format(
-        cls=type(self).__name__,rmax=self.rmax,k=self.k,num_neigh=self.num_neigh,n_bins_t=self.n_bins_t,n_bins_p=self.n_bins_p))
+        return ("freud.environment.{cls}(rmax={rmax}, k={k}, num_neigh= \
+            {num_neigh},n_bins_t={n_bins_t},n_bins_p={n_bins_p})".format(
+                cls=type(self).__name__, rmax=self.rmax,
+                k=self.k, num_neigh=self.num_neigh, n_bins_t=self.n_bins_t,
+                n_bins_p=self.n_bins_p))
 
     def __str__(self):
         return repr(self)
@@ -538,8 +541,10 @@ cdef class LocalDescriptors:
         return self.thisptr.getLMax()
 
     def __repr__(self):
-        return ("freud.environment.{cls}(num_neigh={num_neigh},lmax={lmax},rmax={rmax},negative_m={negative_m})".format(
-        cls=type(self).__name__,num_neigh=self.num_neigh,lmax=self.lmax,rmax=self.rmax,negative_m=self.negative_m))
+        return ("freud.environment.{cls}(num_neigh={num_neigh}, \
+            lmax={lmax}, rmax={rmax}, negative_m={negative_m})".format(
+            cls=type(self).__name__, num_neigh=self.num_neigh, lmax=self.lmax,
+            rmax=self.rmax, negative_m=self.negative_m))
 
     def __str__(self):
         return repr(self)
@@ -914,12 +919,12 @@ cdef class MatchEnv:
         return self.thisptr.getNumClusters()
 
     def __repr__(self):
-        return "freud.environment.{cls}(box={box},rmax={rmax},k={k})".format(cls=type(self).__name__,box=self.m_box.__repr__(),rmax=self.rmax,k=self.num_neigh)
+        return "freud.environment.{cls}(box={box}, rmax={rmax}, k={k})".format(
+            cls=type(self).__name__, box=self.m_box.__repr__(),
+            rmax=self.rmax, k=self.num_neigh)
 
     def __str__(self):
         return repr(self)
-
-
 
 cdef class AngularSeparation:
     R"""Calculates the minimum angles of separation between particles and
@@ -1131,11 +1136,11 @@ cdef class AngularSeparation:
         return self.thisptr.getNglobal()
 
     def __repr__(self):
-        return "freud.environment.{cls}(rmax={rmax},n={n})".format(cls=type(self).__name__,rmax=self.rmax,n=self.num_neigh)
+        return "freud.environment.{cls}(rmax={rmax}, n={n})".format(
+            cls=type(self).__name__, rmax=self.rmax, n=self.num_neigh)
 
     def __str__(self):
         return repr(self)
-
 
 cdef class LocalBondProjection:
     R"""Calculates the maximal projection of nearest neighbor bonds for each
@@ -1313,7 +1318,9 @@ cdef class LocalBondProjection:
         return freud.box.BoxFromCPP(<freud._box.Box> self.thisptr.getBox())
 
     def __repr__(self):
-        return "freud.environment.{cls}(rmax={rmax},num_neigh={num_neigh})".format(cls=type(self).__name__,rmax=self.rmax,num_neigh=self.num_neigh)
+        return "freud.environment.{cls}(rmax={rmax}, num_neigh={num_neigh})".
+        format(cls=type(self).__name__, rmax=self.rmax,
+               num_neigh=self.num_neigh)
 
     def __str__(self):
         return repr(self)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add __repr__ and __str__ methods to box module, cluster module, density module and environment module.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The objects created by freud lack "pretty representations". Adding __repr__ and __str__ methods can help users quickly debug code in the terminal or in a Jupyter notebook.
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Create an object of each class, and call repr and str on each object to check the output.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/glotzerlab/freud/blob/master/CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
