### PR TITLE
Build PyPI wheels with older NumPy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,8 +31,15 @@ references:
       command: |
         cd ~/ci/freud
         git clone ${CIRCLE_REPOSITORY_URL} .
-        git fetch --force origin "refs/tags/${CIRCLE_TAG}"
-        git checkout -q "$CIRCLE_TAG"
+        if [ -n "$CIRCLE_TAG" ]
+        then
+          git reset --hard "$CIRCLE_SHA1"
+          git checkout -q "$CIRCLE_TAG"
+        elif [ -n "$CIRCLE_BRANCH" ]
+        then
+          git reset --hard "$CIRCLE_SHA1"
+          git checkout -q -B "$CIRCLE_BRANCH"
+        fi
 
   get_requirements: &get_requirements
     run:
@@ -122,9 +129,23 @@ references:
 
             # Build wheels
             for PYBIN in /opt/python/*/bin; do
-                echo "Building for `${PYBIN}/python --version`"
-                "${PYBIN}/pip" install -r ~/ci/freud/requirements.txt --progress-bar=off
-                "${PYBIN}/pip" wheel ~/ci/freud/ -w ~/wheelhouse/ --no-deps
+              # Split the echo command and the version since python2
+              # --version doesn't return the value, just prints it.
+              echo "Building for "
+              ${PYBIN}/python --version
+
+              "${PYBIN}/python" -m pip install cython --no-deps --ignore-installed -q --progress-bar=off
+              rm -rf numpy-1.10.0rc2
+              curl -sSLO https://github.com/numpy/numpy/archive/v1.10.0rc2.tar.gz
+              tar -xzf v1.10.0rc2.tar.gz
+              cd numpy-1.10.0rc2
+              rm -f numpy/random/mtrand/mtrand.c
+              rm -f PKG-INFO
+              "${PYBIN}/python" -m pip install . --no-deps --ignore-installed -v --progress-bar=off -q
+
+              "${PYBIN}/pip" install -r ~/ci/freud/requirements.txt --progress-bar=off
+              "${PYBIN}/pip" wheel ~/ci/freud/ -w ~/wheelhouse/ --no-deps --no-build-isolation --no-use-pep517
+              break
             done
 
             # Update RPath for wheels
@@ -134,7 +155,7 @@ references:
 
             # Install from and test all wheels
             for PYBIN in /opt/python/*/bin/; do
-                "${PYBIN}/pip" install freud_analysis --no-index -f ~/ci/freud/wheelhouse
+                "${PYBIN}/python" -m pip install freud_analysis --no-deps --no-index -f ~/ci/freud/wheelhouse
                 cd ~/ci/freud/tests
                 "${PYBIN}/python" -m unittest discover . -v
             done

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -145,7 +145,6 @@ references:
 
               "${PYBIN}/pip" install -r ~/ci/freud/requirements.txt --progress-bar=off
               "${PYBIN}/pip" wheel ~/ci/freud/ -w ~/wheelhouse/ --no-deps --no-build-isolation --no-use-pep517
-              break
             done
 
             # Update RPath for wheels
@@ -201,9 +200,19 @@ references:
                 echo "Building for Python ${VERSION}"
                 pyenv install ${VERSION}
                 pyenv global ${VERSION}
+
+                pip install cython --no-deps --ignore-installed -q --progress-bar=off
+                rm -rf numpy-1.10.0rc2
+                curl -sSLO https://github.com/numpy/numpy/archive/v1.10.0rc2.tar.gz
+                tar -xzf v1.10.0rc2.tar.gz
+                cd numpy-1.10.0rc2
+                rm -f numpy/random/mtrand/mtrand.c
+                rm -f PKG-INFO
+                "${PYBIN}/python" -m pip install . --no-deps --ignore-installed -v --progress-bar=off -q
+
                 pip install -r ~/ci/freud/requirements.txt
                 pip install wheel delocate
-                pip wheel ~/ci/freud/ -w ~/wheelhouse/ --no-deps
+                pip wheel ~/ci/freud/ -w ~/wheelhouse/ --no-deps --no-build-isolation --no-use-pep517
             done
 
             # Update RPath for wheels
@@ -214,7 +223,7 @@ references:
             # Install from and test all wheels
             for VERSION in ${PY_VERSIONS[@]}; do
                 pyenv global ${VERSION}
-                pip install freud_analysis --no-index -f ~/ci/freud/wheelhouse
+                pip install freud_analysis --no-deps --no-index -f ~/ci/freud/wheelhouse
                 cd ~/ci/freud/tests
                 python -m unittest discover . -v
             done

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -135,10 +135,10 @@ references:
               ${PYBIN}/python --version
 
               "${PYBIN}/python" -m pip install cython --no-deps --ignore-installed -q --progress-bar=off
-              rm -rf numpy-1.10.0rc2
-              curl -sSLO https://github.com/numpy/numpy/archive/v1.10.0rc2.tar.gz
-              tar -xzf v1.10.0rc2.tar.gz
-              cd numpy-1.10.0rc2
+              rm -rf numpy-1.10.4
+              curl -sSLO https://github.com/numpy/numpy/archive/v1.10.4.tar.gz
+              tar -xzf v1.10.4.tar.gz
+              cd numpy-1.10.4
               rm -f numpy/random/mtrand/mtrand.c
               rm -f PKG-INFO
               "${PYBIN}/python" -m pip install . --no-deps --ignore-installed -v --progress-bar=off -q
@@ -202,10 +202,10 @@ references:
                 pyenv global ${VERSION}
 
                 pip install cython --no-deps --ignore-installed -q --progress-bar=off
-                rm -rf numpy-1.10.0rc2
-                curl -sSLO https://github.com/numpy/numpy/archive/v1.10.0rc2.tar.gz
-                tar -xzf v1.10.0rc2.tar.gz
-                cd numpy-1.10.0rc2
+                rm -rf numpy-1.10.4
+                curl -sSLO https://github.com/numpy/numpy/archive/v1.10.4.tar.gz
+                tar -xzf v1.10.4.tar.gz
+                cd numpy-1.10.4
                 rm -f numpy/random/mtrand/mtrand.c
                 rm -f PKG-INFO
                 "${PYBIN}/python" -m pip install . --no-deps --ignore-installed -v --progress-bar=off -q

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -29,3 +29,4 @@
 - [ ] I have read the [**CONTRIBUTING**](https://github.com/glotzerlab/freud/blob/master/CONTRIBUTING.md) document.
 - [ ] I have added tests to cover my changes.
 - [ ] All new and existing tests passed.
+- [ ] I have updated the [Changelog](https://github.com/glotzerlab/freud/blob/master/ChangeLog.md).


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Changes the deployment script to use the oldest version of NumPy supported by freud (1.10).

## Motivation and Context
Currently `pip install` from PyPI tries to use wheels, and when it finds appropriate wheels for a given Python version it installs them even if those wheels don't work for the existing NumPy versions due to ABI incompatibilities. This change builds the PyPI wheels with the oldest possible version of NumPy so that users can use PyPI wheels no matter which NumPy version they have installed beforehand.

## How Has This Been Tested?
I downloaded the relevant Docker images and ran these manually to ensure that the build succeeded and tests passed. However, I have not tried actually uploading to PyPI and then installing from there. I also have not tested the OS X wheel building process because we have no way to do that locally; we'll have to wait until this is merged and made live to deal with that problem I think.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds or improves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/glotzerlab/freud/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
