### PR TITLE
Skip slow tests

### DIFF
--- a/tests/test_density_ComplexCF.py
+++ b/tests/test_density_ComplexCF.py
@@ -96,7 +96,7 @@ class TestOCF(unittest.TestCase):
 
 
 class TestSummation(unittest.TestCase):
-    @unittest.skipIf('CI' in os.environ, 'Skipping test on CI')
+    @unittest.skip('Skipping slow summation test.')
     def test_summation(self):
         # Causes the correlation function to add lots of small numbers together
         # This leads to vastly different results with different numbers of

--- a/tests/test_density_LocalDensity.py
+++ b/tests/test_density_LocalDensity.py
@@ -18,7 +18,7 @@ class TestLD(unittest.TestCase):
                             dtype=np.float32) * 10 - 5
         self.ld = density.LocalDensity(3, 1, 1)
 
-    @unittest.skipIf('CI' in os.environ, 'Skipping test on CI')
+    @unittest.skip('Skipping slow LocalDensity test.')
     def test_compute_api(self):
         # test 2 args, no keyword
         self.ld.compute(self.box, self.pos)
@@ -40,7 +40,7 @@ class TestLD(unittest.TestCase):
         npt.assert_array_less(
             np.fabs(self.ld.num_neighbors - 1130.973355292), 200)
 
-    @unittest.skipIf('CI' in os.environ, 'Skipping test on CI')
+    @unittest.skip('Skipping slow LocalDensity test.')
     def test_refpoints(self):
         """Test that LocalDensity can compute a correct density at each point
         using the reference points as the data points."""


### PR DESCRIPTION
## Description
We have had some difficulty with freud's slowest tests crashing user systems. Instead of skipping on CI, we should skip these always.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds or improves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the [**CONTRIBUTING**](https://github.com/glotzerlab/freud/blob/master/CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.