### PR TITLE
Fix type of y_max argument in PMFTXY2D.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 * New neighbor querying API to enable reuse of query data structures.
 * Exposed AABB tree to user.
 
+### Fixed
+* Corrected type of `y_max` argument to PMFTXY2D from int to float.
+
 ## v1.0.0 - 2019-02-08
 
 ### Added

--- a/freud/_pmft.pxd
+++ b/freud/_pmft.pxd
@@ -60,7 +60,7 @@ cdef extern from "PMFTXYT.h" namespace "freud::pmft":
 
 cdef extern from "PMFTXY2D.h" namespace "freud::pmft":
     cdef cppclass PMFTXY2D(PMFT):
-        PMFTXY2D(float, unsigned int, unsigned int, unsigned int) except +
+        PMFTXY2D(float, float, unsigned int, unsigned int) except +
 
         void accumulate(freud._box.Box &,
                         const freud._locality.NeighborList*,

--- a/tests/test_pmft.py
+++ b/tests/test_pmft.py
@@ -160,7 +160,8 @@ class TestPMFTXYT(unittest.TestCase):
         nbinsY = 30
         nbinsT = 40
         myPMFT = freud.pmft.PMFTXYT(maxX, maxY, nbinsX, nbinsY, nbinsT)
-        npt.assert_equal(myPMFT.r_cut, np.linalg.norm([maxX, maxY]), atol=1e-6)
+        npt.assert_allclose(myPMFT.r_cut,
+                            np.linalg.norm([maxX, maxY]), atol=1e-6)
 
     def test_bins(self):
         maxX = 3.6
@@ -287,7 +288,8 @@ class TestPMFTXY2D(unittest.TestCase):
         nbinsX = 100
         nbinsY = 110
         myPMFT = freud.pmft.PMFTXY2D(maxX, maxY, nbinsX, nbinsY)
-        npt.assert_equal(myPMFT.r_cut, np.linalg.norm([maxX, maxY]), atol=1e-6)
+        npt.assert_allclose(myPMFT.r_cut,
+                            np.linalg.norm([maxX, maxY]), atol=1e-6)
 
     def test_bins(self):
         maxX = 3.6

--- a/tests/test_pmft.py
+++ b/tests/test_pmft.py
@@ -139,8 +139,8 @@ class TestPMFTXYT(unittest.TestCase):
         points = np.array([[-1.0, 0.0, 0.0], [1.0, 0.0, 0.0]],
                           dtype=np.float32)
         angles = np.array([0.0, 0.0], dtype=np.float32)
-        maxX = 3.0
-        maxY = 4.0
+        maxX = 3.6
+        maxY = 4.2
         nbinsX = 20
         nbinsY = 30
         nbinsT = 40
@@ -154,17 +154,17 @@ class TestPMFTXYT(unittest.TestCase):
             myPMFT.accumulate(box, points, angles, points, angles)
 
     def test_r_cut(self):
-        maxX = 3.0
-        maxY = 4.0
+        maxX = 3.6
+        maxY = 4.2
         nbinsX = 20
         nbinsY = 30
         nbinsT = 40
         myPMFT = freud.pmft.PMFTXYT(maxX, maxY, nbinsX, nbinsY, nbinsT)
-        npt.assert_equal(myPMFT.r_cut, 5.0)
+        npt.assert_equal(myPMFT.r_cut, np.linalg.norm([maxX, maxY]), atol=1e-6)
 
     def test_bins(self):
-        maxX = 3.0
-        maxY = 4.0
+        maxX = 3.6
+        maxY = 4.2
         nbinsX = 20
         nbinsY = 30
         nbinsT = 40
@@ -215,8 +215,8 @@ class TestPMFTXYT(unittest.TestCase):
         points = np.array([[-1.0, 0.0, 0.0], [1.0, 0.1, 0.0]],
                           dtype=np.float32)
         angles = np.array([0.0, np.pi/2], dtype=np.float32)
-        maxX = 3.0
-        maxY = 4.0
+        maxX = 3.6
+        maxY = 4.2
         nbinsX = 20
         nbinsY = 30
         nbinsT = 40
@@ -268,8 +268,8 @@ class TestPMFTXY2D(unittest.TestCase):
         points = np.array([[-1.0, 0.0, 0.0], [1.0, 0.0, 0.0]],
                           dtype=np.float32)
         angles = np.array([0.0, 0.0], dtype=np.float32)
-        maxX = 3.0
-        maxY = 4.0
+        maxX = 3.6
+        maxY = 4.2
         nbinsX = 100
         nbinsY = 110
         myPMFT = freud.pmft.PMFTXY2D(maxX, maxY, nbinsX, nbinsY)
@@ -282,16 +282,16 @@ class TestPMFTXY2D(unittest.TestCase):
             myPMFT.accumulate(box, points, angles, points, angles)
 
     def test_r_cut(self):
-        maxX = 3.0
-        maxY = 4.0
+        maxX = 3.6
+        maxY = 4.2
         nbinsX = 100
         nbinsY = 110
         myPMFT = freud.pmft.PMFTXY2D(maxX, maxY, nbinsX, nbinsY)
-        npt.assert_equal(myPMFT.r_cut, 5.0)
+        npt.assert_equal(myPMFT.r_cut, np.linalg.norm([maxX, maxY]), atol=1e-6)
 
     def test_bins(self):
-        maxX = 3.0
-        maxY = 4.0
+        maxX = 3.6
+        maxY = 4.2
         nbinsX = 20
         nbinsY = 30
         dx = (2.0 * maxX / float(nbinsX))
@@ -332,8 +332,8 @@ class TestPMFTXY2D(unittest.TestCase):
         points = np.array([[-1.0, 0.0, 0.0], [1.0, 0.0, 0.0]],
                           dtype=np.float32)
         angles = np.array([0.0, 0.0], dtype=np.float32)
-        maxX = 3.0
-        maxY = 4.0
+        maxX = 3.6
+        maxY = 4.2
         nbinsX = 100
         nbinsY = 110
         dx = (2.0 * maxX / float(nbinsX))


### PR DESCRIPTION
## Description
@jamesaan found a bug in PMFTXY2D where the `y_max` argument was being converted from a floating-point number to an integer. This PR fixes it.

## How Has This Been Tested?
A test was edited to demonstrate the failing behavior (by using non-integral values).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/glotzerlab/freud/blob/master/CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the [Changelog](https://github.com/glotzerlab/freud/blob/master/ChangeLog.md).