### PR TITLE
LinkCell computes cell neighbors on need basis

### DIFF
--- a/cpp/locality/LinkCell.cc
+++ b/cpp/locality/LinkCell.cc
@@ -83,7 +83,6 @@ void LinkCell::updateInternal(const box::Box& box, float cell_width)
                 throw runtime_error("At least one cell must be present.");
                 }
             m_celldim = celldim;
-            // computeCellNeighbors();
             }
         m_cell_width = cell_width;
         }
@@ -273,9 +272,9 @@ const std::vector<unsigned int>& LinkCell::computeCellNeighbors(unsigned int cur
     {
     std::vector<unsigned int> neighbor_cells;
     vec3<unsigned int> l_idx = m_cell_index(cur_cell);
-    unsigned int i = l_idx.x;
-    unsigned int j = l_idx.y;
-    unsigned int k = l_idx.z;
+    int i = (int) l_idx.x;
+    int j = (int) l_idx.y;
+    int k = (int) l_idx.z;
 
     // loop over the neighbor cells
     int starti, startj, startk;

--- a/cpp/locality/LinkCell.cc
+++ b/cpp/locality/LinkCell.cc
@@ -272,61 +272,61 @@ const std::vector<unsigned int>& LinkCell::computeCellNeighbors(unsigned int cur
     {
     std::vector<unsigned int> neighbor_cells;
     vec3<unsigned int> l_idx = m_cell_index(cur_cell);
-    int i = (int) l_idx.x;
-    int j = (int) l_idx.y;
-    int k = (int) l_idx.z;
+    const int i = (int) l_idx.x;
+    const int j = (int) l_idx.y;
+    const int k = (int) l_idx.z;
 
     // loop over the neighbor cells
     int starti, startj, startk;
     int endi, endj, endk;
     if (m_celldim.x < 3)
         {
-        starti = (int)i;
+        starti = i;
         }
     else
         {
-        starti = (int)i - 1;
+        starti = i - 1;
         }
     if (m_celldim.y < 3)
         {
-        startj = (int)j;
+        startj = j;
         }
     else
         {
-        startj = (int)j - 1;
+        startj = j - 1;
         }
     if (m_celldim.z < 3)
         {
-        startk = (int)k;
+        startk = k;
         }
     else
         {
-        startk = (int)k - 1;
+        startk = k - 1;
         }
 
     if (m_celldim.x < 2)
         {
-        endi = (int)i;
+        endi = i;
         }
     else
         {
-        endi = (int)i + 1;
+        endi = i + 1;
         }
     if (m_celldim.y < 2)
         {
-        endj = (int)j;
+        endj = j;
         }
     else
         {
-        endj = (int)j + 1;
+        endj = j + 1;
         }
     if (m_celldim.z < 2)
         {
-        endk = (int)k;
+        endk = k;
         }
     else
         {
-        endk = (int)k + 1;
+        endk = k + 1;
         }
     if (m_box.is2D())
         startk = endk = k;

--- a/cpp/locality/LinkCell.cc
+++ b/cpp/locality/LinkCell.cc
@@ -83,7 +83,7 @@ void LinkCell::updateInternal(const box::Box& box, float cell_width)
                 throw runtime_error("At least one cell must be present.");
                 }
             m_celldim = celldim;
-            computeCellNeighbors();
+            // computeCellNeighbors();
             }
         m_cell_width = cell_width;
         }
@@ -269,93 +269,180 @@ void LinkCell::compute(const box::Box& box,
         });
     }
 
-void LinkCell::computeCellNeighbors()
+// void LinkCell::computeCellNeighbors()
+//     {
+//     // clear the list
+//     m_cell_neighbors.clear();
+//     m_cell_neighbors.resize(getNumCells());
+
+//     // for each cell
+//     for (unsigned int k = 0; k < m_cell_index.getD(); k++)
+//         for (unsigned int j = 0; j < m_cell_index.getH(); j++)
+//             for (unsigned int i = 0; i < m_cell_index.getW(); i++)
+//                 {
+//                 // clear the list
+//                 unsigned int cur_cell = m_cell_index(i,j,k);
+//                 m_cell_neighbors[cur_cell].clear();
+
+//                 // loop over the neighbor cells
+//                 int starti, startj, startk;
+//                 int endi, endj, endk;
+//                 if (m_celldim.x < 3)
+//                     {
+//                     starti = (int)i;
+//                     }
+//                 else
+//                     {
+//                     starti = (int)i - 1;
+//                     }
+//                 if (m_celldim.y < 3)
+//                     {
+//                     startj = (int)j;
+//                     }
+//                 else
+//                     {
+//                     startj = (int)j - 1;
+//                     }
+//                 if (m_celldim.z < 3)
+//                     {
+//                     startk = (int)k;
+//                     }
+//                 else
+//                     {
+//                     startk = (int)k - 1;
+//                     }
+
+//                 if (m_celldim.x < 2)
+//                     {
+//                     endi = (int)i;
+//                     }
+//                 else
+//                     {
+//                     endi = (int)i + 1;
+//                     }
+//                 if (m_celldim.y < 2)
+//                     {
+//                     endj = (int)j;
+//                     }
+//                 else
+//                     {
+//                     endj = (int)j + 1;
+//                     }
+//                 if (m_celldim.z < 2)
+//                     {
+//                     endk = (int)k;
+//                     }
+//                 else
+//                     {
+//                     endk = (int)k + 1;
+//                     }
+//                 if (m_box.is2D())
+//                     startk = endk = k;
+
+//                 for (int neighk = startk; neighk <= endk; neighk++)
+//                     for (int neighj = startj; neighj <= endj; neighj++)
+//                         for (int neighi = starti; neighi <= endi; neighi++)
+//                             {
+//                             // wrap back into the box
+//                             int wrapi = (m_cell_index.getW()+neighi) % m_cell_index.getW();
+//                             int wrapj = (m_cell_index.getH()+neighj) % m_cell_index.getH();
+//                             int wrapk = (m_cell_index.getD()+neighk) % m_cell_index.getD();
+
+//                             unsigned int neigh_cell = m_cell_index(wrapi, wrapj, wrapk);
+//                             // add to the list
+//                             m_cell_neighbors[cur_cell].push_back(neigh_cell);
+//                             }
+
+//                 // sort the list
+//                 sort(m_cell_neighbors[cur_cell].begin(), m_cell_neighbors[cur_cell].end());
+//                 }
+//     }
+
+
+void LinkCell::computeCellNeighbors(unsigned int cur_cell)
     {
-    // clear the list
-    m_cell_neighbors.clear();
-    m_cell_neighbors.resize(getNumCells());
+    std::vector<unsigned int> neighbor_cells;
+    vec3<unsigned int> l_idx = m_cell_index(cur_cell);
+    unsigned int i = l_idx.x;
+    unsigned int j = l_idx.y;
+    unsigned int k = l_idx.z;
 
-    // for each cell
-    for (unsigned int k = 0; k < m_cell_index.getD(); k++)
-        for (unsigned int j = 0; j < m_cell_index.getH(); j++)
-            for (unsigned int i = 0; i < m_cell_index.getW(); i++)
+    // loop over the neighbor cells
+    int starti, startj, startk;
+    int endi, endj, endk;
+    if (m_celldim.x < 3)
+        {
+        starti = (int)i;
+        }
+    else
+        {
+        starti = (int)i - 1;
+        }
+    if (m_celldim.y < 3)
+        {
+        startj = (int)j;
+        }
+    else
+        {
+        startj = (int)j - 1;
+        }
+    if (m_celldim.z < 3)
+        {
+        startk = (int)k;
+        }
+    else
+        {
+        startk = (int)k - 1;
+        }
+
+    if (m_celldim.x < 2)
+        {
+        endi = (int)i;
+        }
+    else
+        {
+        endi = (int)i + 1;
+        }
+    if (m_celldim.y < 2)
+        {
+        endj = (int)j;
+        }
+    else
+        {
+        endj = (int)j + 1;
+        }
+    if (m_celldim.z < 2)
+        {
+        endk = (int)k;
+        }
+    else
+        {
+        endk = (int)k + 1;
+        }
+    if (m_box.is2D())
+        startk = endk = k;
+
+    for (int neighk = startk; neighk <= endk; neighk++)
+        for (int neighj = startj; neighj <= endj; neighj++)
+            for (int neighi = starti; neighi <= endi; neighi++)
                 {
-                // clear the list
-                unsigned int cur_cell = m_cell_index(i,j,k);
-                m_cell_neighbors[cur_cell].clear();
+                // wrap back into the box
+                int wrapi = (m_cell_index.getW()+neighi) % m_cell_index.getW();
+                int wrapj = (m_cell_index.getH()+neighj) % m_cell_index.getH();
+                int wrapk = (m_cell_index.getD()+neighk) % m_cell_index.getD();
 
-                // loop over the neighbor cells
-                int starti, startj, startk;
-                int endi, endj, endk;
-                if (m_celldim.x < 3)
-                    {
-                    starti = (int)i;
-                    }
-                else
-                    {
-                    starti = (int)i - 1;
-                    }
-                if (m_celldim.y < 3)
-                    {
-                    startj = (int)j;
-                    }
-                else
-                    {
-                    startj = (int)j - 1;
-                    }
-                if (m_celldim.z < 3)
-                    {
-                    startk = (int)k;
-                    }
-                else
-                    {
-                    startk = (int)k - 1;
-                    }
-
-                if (m_celldim.x < 2)
-                    {
-                    endi = (int)i;
-                    }
-                else
-                    {
-                    endi = (int)i + 1;
-                    }
-                if (m_celldim.y < 2)
-                    {
-                    endj = (int)j;
-                    }
-                else
-                    {
-                    endj = (int)j + 1;
-                    }
-                if (m_celldim.z < 2)
-                    {
-                    endk = (int)k;
-                    }
-                else
-                    {
-                    endk = (int)k + 1;
-                    }
-                if (m_box.is2D())
-                    startk = endk = k;
-
-                for (int neighk = startk; neighk <= endk; neighk++)
-                    for (int neighj = startj; neighj <= endj; neighj++)
-                        for (int neighi = starti; neighi <= endi; neighi++)
-                            {
-                            // wrap back into the box
-                            int wrapi = (m_cell_index.getW()+neighi) % m_cell_index.getW();
-                            int wrapj = (m_cell_index.getH()+neighj) % m_cell_index.getH();
-                            int wrapk = (m_cell_index.getD()+neighk) % m_cell_index.getD();
-
-                            unsigned int neigh_cell = m_cell_index(wrapi, wrapj, wrapk);
-                            // add to the list
-                            m_cell_neighbors[cur_cell].push_back(neigh_cell);
-                            }
-
-                // sort the list
-                sort(m_cell_neighbors[cur_cell].begin(), m_cell_neighbors[cur_cell].end());
+                unsigned int neigh_cell = m_cell_index(wrapi, wrapj, wrapk);
+                // add to the list
+                neighbor_cells.push_back(neigh_cell);
                 }
+
+    // sort the list
+    sort(neighbor_cells.begin(), neighbor_cells.end());
+    // }
+    CellNeighbors::accessor a;
+    m_cell_neighbors.insert(a, cur_cell);
+    a->second = neighbor_cells;
+    return;
     }
 
 //! Given a set of points, find the k elements of this data structure

--- a/cpp/locality/LinkCell.cc
+++ b/cpp/locality/LinkCell.cc
@@ -269,97 +269,7 @@ void LinkCell::compute(const box::Box& box,
         });
     }
 
-// void LinkCell::computeCellNeighbors()
-//     {
-//     // clear the list
-//     m_cell_neighbors.clear();
-//     m_cell_neighbors.resize(getNumCells());
-
-//     // for each cell
-//     for (unsigned int k = 0; k < m_cell_index.getD(); k++)
-//         for (unsigned int j = 0; j < m_cell_index.getH(); j++)
-//             for (unsigned int i = 0; i < m_cell_index.getW(); i++)
-//                 {
-//                 // clear the list
-//                 unsigned int cur_cell = m_cell_index(i,j,k);
-//                 m_cell_neighbors[cur_cell].clear();
-
-//                 // loop over the neighbor cells
-//                 int starti, startj, startk;
-//                 int endi, endj, endk;
-//                 if (m_celldim.x < 3)
-//                     {
-//                     starti = (int)i;
-//                     }
-//                 else
-//                     {
-//                     starti = (int)i - 1;
-//                     }
-//                 if (m_celldim.y < 3)
-//                     {
-//                     startj = (int)j;
-//                     }
-//                 else
-//                     {
-//                     startj = (int)j - 1;
-//                     }
-//                 if (m_celldim.z < 3)
-//                     {
-//                     startk = (int)k;
-//                     }
-//                 else
-//                     {
-//                     startk = (int)k - 1;
-//                     }
-
-//                 if (m_celldim.x < 2)
-//                     {
-//                     endi = (int)i;
-//                     }
-//                 else
-//                     {
-//                     endi = (int)i + 1;
-//                     }
-//                 if (m_celldim.y < 2)
-//                     {
-//                     endj = (int)j;
-//                     }
-//                 else
-//                     {
-//                     endj = (int)j + 1;
-//                     }
-//                 if (m_celldim.z < 2)
-//                     {
-//                     endk = (int)k;
-//                     }
-//                 else
-//                     {
-//                     endk = (int)k + 1;
-//                     }
-//                 if (m_box.is2D())
-//                     startk = endk = k;
-
-//                 for (int neighk = startk; neighk <= endk; neighk++)
-//                     for (int neighj = startj; neighj <= endj; neighj++)
-//                         for (int neighi = starti; neighi <= endi; neighi++)
-//                             {
-//                             // wrap back into the box
-//                             int wrapi = (m_cell_index.getW()+neighi) % m_cell_index.getW();
-//                             int wrapj = (m_cell_index.getH()+neighj) % m_cell_index.getH();
-//                             int wrapk = (m_cell_index.getD()+neighk) % m_cell_index.getD();
-
-//                             unsigned int neigh_cell = m_cell_index(wrapi, wrapj, wrapk);
-//                             // add to the list
-//                             m_cell_neighbors[cur_cell].push_back(neigh_cell);
-//                             }
-
-//                 // sort the list
-//                 sort(m_cell_neighbors[cur_cell].begin(), m_cell_neighbors[cur_cell].end());
-//                 }
-//     }
-
-
-void LinkCell::computeCellNeighbors(unsigned int cur_cell)
+const std::vector<unsigned int>& LinkCell::computeCellNeighbors(unsigned int cur_cell)
     {
     std::vector<unsigned int> neighbor_cells;
     vec3<unsigned int> l_idx = m_cell_index(cur_cell);
@@ -438,11 +348,12 @@ void LinkCell::computeCellNeighbors(unsigned int cur_cell)
 
     // sort the list
     sort(neighbor_cells.begin(), neighbor_cells.end());
-    // }
+
+    // add the vector of neighbor cells to the hash table
     CellNeighbors::accessor a;
     m_cell_neighbors.insert(a, cur_cell);
     a->second = neighbor_cells;
-    return;
+    return a->second;
     }
 
 //! Given a set of points, find the k elements of this data structure

--- a/cpp/locality/LinkCell.h
+++ b/cpp/locality/LinkCell.h
@@ -426,6 +426,9 @@ class LinkCell : public NeighborQuery
         //! Get a list of neighbors to a cell
         const std::vector<unsigned int>& getCellNeighbors(unsigned int cell)
             {
+                // check if the list of neighbors has been already computed
+                // return the list if it has
+                // otherwise, compute it and return
                 CellNeighbors::const_accessor a;
                 if(m_cell_neighbors.find(a, cell)) 
                     {
@@ -433,9 +436,10 @@ class LinkCell : public NeighborQuery
                     }
                 else 
                     {
-                        computeCellNeighbors(cell);
-                        m_cell_neighbors.find(a, cell);
-                        return a->second;
+                        // computeCellNeighbors(cell);
+                        // m_cell_neighbors.find(a, cell);
+                        // return a->second;
+                        return computeCellNeighbors(cell);
                     }
             }
 
@@ -468,8 +472,7 @@ class LinkCell : public NeighborQuery
         void updateInternal(const box::Box& box, float cell_width);
 
         //! Helper function to compute cell neighbors
-        // void computeCellNeighbors();
-        void computeCellNeighbors(unsigned int cell);
+        const std::vector<unsigned int>& computeCellNeighbors(unsigned int cell);
 
         box::Box m_box;                //!< Simulation box where the particles belong
         Index3D m_cell_index;          //!< Indexer to compute cell indices

--- a/cpp/locality/LinkCell.h
+++ b/cpp/locality/LinkCell.h
@@ -430,15 +430,12 @@ class LinkCell : public NeighborQuery
                 // return the list if it has
                 // otherwise, compute it and return
                 CellNeighbors::const_accessor a;
-                if(m_cell_neighbors.find(a, cell)) 
+                if(m_cell_neighbors.find(a, cell))
                     {
                         return a->second;
                     }
-                else 
+                else
                     {
-                        // computeCellNeighbors(cell);
-                        // m_cell_neighbors.find(a, cell);
-                        // return a->second;
                         return computeCellNeighbors(cell);
                     }
             }
@@ -482,9 +479,8 @@ class LinkCell : public NeighborQuery
         vec3<unsigned int> m_celldim;  //!< Cell dimensions
 
         std::shared_ptr<unsigned int> m_cell_list;                 //!< The cell list last computed
-        // std::vector< std::vector<unsigned int> > m_cell_neighbors; //!< List of cell neighbors to each cell
         typedef tbb::concurrent_hash_map<unsigned int, std::vector<unsigned int> >  CellNeighbors;
-        CellNeighbors m_cell_neighbors;
+        CellNeighbors m_cell_neighbors;                            //!< Hash map of cell neighbors for each cell
         NeighborList m_neighbor_list;                              //!< Stored neighbor list
     };
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
LinkCell used to compute cell neighbors for all cells, which was an overhead for sparse inputs, since there are some cells that never get used, if the cell does not contain any particle.
For example, suppose we generate random points within `-L/2` and `L/2`. 
If we use box size of `L` for `LinkCell.compute` method, the old implementation and the new implementation run essentially at same speed, if the particles are densely distributed.
However, if we increase the box size, for example `3*L`, the particles within the box are concentrated in the center, and there are no particles in the boundary.
The old implementation still computes cell neighbors on those outer cells that do not ever get used, and gives us essentially `L/rcut`^3 complexity, which can be observed from explosion in the runtime.
The new implementation does not compute cell neighbors on those outer cells, and thus it runs at essentially same speed as the box of size `L` case. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
It passed the tests on circle.ci, and the runtime behavior has been measured.

## Screenshots (if appropriate):
![comparison_rcut_dev0 5](https://user-images.githubusercontent.com/15791520/58190002-95607080-7c89-11e9-9fa9-f32914e1c564.png)
The new implementation.
![comparison_rcut_stable0 5](https://user-images.githubusercontent.com/15791520/58190025-a27d5f80-7c89-11e9-878a-8f9cdd4620ba.png)
The stable implementation.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature (non-breaking change which adds or improves functionality)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the [**CONTRIBUTING**](https://github.com/glotzerlab/freud/blob/master/CONTRIBUTING.md) document.
- [x] All new and existing tests passed.
- [ ] I have updated the [Changelog](https://github.com/glotzerlab/freud/blob/master/ChangeLog.md).
