### PR TITLE
Throw runtime_error in generic query to halt control flow and remove compile warning.

### DIFF
--- a/cpp/locality/AABBQuery.h
+++ b/cpp/locality/AABBQuery.h
@@ -65,7 +65,7 @@ class AABBQuery : public NeighborQuery
                 }
             else
                 {
-                assert("Invalid query mode provided to generic query function.");
+                throw std::runtime_error("Invalid query mode provided to generic query function.");
                 }
             }
 

--- a/cpp/locality/NeighborQuery.h
+++ b/cpp/locality/NeighborQuery.h
@@ -129,7 +129,7 @@ class NeighborQuery
                 }
             else
                 {
-                std::runtime_error("Invalid query mode provided to generic query function.");
+                throw std::runtime_error("Invalid query mode provided to generic query function.");
                 }
             }
 


### PR DESCRIPTION
See title.