### PR TITLE
Use NumPy arrays for more return types in Box.

### DIFF
--- a/freud/box.pyx
+++ b/freud/box.pyx
@@ -298,13 +298,12 @@ cdef class Box:
 
         vecs = freud.common.convert_array(
             vecs, vecs.ndim, dtype=np.float32, contiguous=True)
-        images = np.empty_like(vecs, dtype=int)
 
         if vecs.ndim == 1:
-            images[:] = self._getImage(vecs)
+            images = np.asarray(self._getImage(vecs), dtype=int)
         elif vecs.ndim == 2:
-            for i, vec in enumerate(vecs):
-                images[i] = self._getImage(vec)
+            images = np.asarray([self.getImage(vec) for vec in vecs],
+                                dtype=int)
         return images
 
     def _getImage(self, vec):

--- a/freud/box.pyx
+++ b/freud/box.pyx
@@ -72,7 +72,7 @@ cdef class Box:
             The xz tilt factor.
         yz (float):
             The yz tilt factor.
-        L (tuple, settable):
+        L (:math:`\left(3\right)` :class:`numpy.ndarray`, settable):
             The box lengths along x, y, and z.
         Lx (float, settable):
             The x-dimension length.
@@ -80,13 +80,13 @@ cdef class Box:
             The y-dimension length.
         Lz (float, settable):
             The z-dimension length.
-        Linv (tuple):
+        Linv (:math:`\left(3\right)` :class:`numpy.ndarray`):
             The inverse box lengths.
         volume (float):
             The box volume (area in 2D).
         dimensions (int, settable):
             The number of dimensions (2 or 3).
-        periodic (list, settable):
+        periodic (:math:`\left(3\right)` :class:`numpy.ndarray`, settable):
             Whether or not the box is periodic.
         periodic_x (bool, settable):
             Whether or not the box is periodic in x.
@@ -131,7 +131,7 @@ cdef class Box:
     @property
     def L(self):
         cdef vec3[float] result = self.thisptr.getL()
-        return (result.x, result.y, result.z)
+        return np.asarray([result.x, result.y, result.z])
 
     @L.setter
     def L(self, value):
@@ -205,7 +205,7 @@ cdef class Box:
     @property
     def Linv(self):
         cdef vec3[float] result = self.thisptr.getLinv()
-        return (result.x, result.y, result.z)
+        return np.asarray([result.x, result.y, result.z])
 
     @property
     def volume(self):
@@ -298,13 +298,14 @@ cdef class Box:
 
         vecs = freud.common.convert_array(
             vecs, vecs.ndim, dtype=np.float32, contiguous=True)
+        images = np.empty_like(vecs, dtype=int)
 
         if vecs.ndim == 1:
-            vecs[:] = self._getImage(vecs)
+            images[:] = self._getImage(vecs)
         elif vecs.ndim == 2:
             for i, vec in enumerate(vecs):
-                vecs[i] = self._getImage(vec)
-        return vecs
+                images[i] = self._getImage(vec)
+        return images
 
     def _getImage(self, vec):
         cdef const float[::1] l_vec = vec
@@ -320,12 +321,13 @@ cdef class Box:
                 Index (:math:`0 \leq i < d`) of the lattice vector, where :math:`d` is the box dimension (2 or 3).
 
         Returns:
-            list[float, float, float]: Lattice vector with index :math:`i`.
+            :math:`\left(3\right)` :class:`numpy.ndarray`:
+                Lattice vector with index :math:`i`.
         """  # noqa: E501
         cdef vec3[float] result = self.thisptr.getLatticeVector(i)
         if self.thisptr.is2D():
             result.z = 0.0
-        return [result.x, result.y, result.z]
+        return np.asarray([result.x, result.y, result.z])
 
     def wrap(self, vecs):
         R"""Wrap a given array of vectors from real space into the box, using
@@ -419,7 +421,7 @@ cdef class Box:
     @property
     def periodic(self):
         periodic = self.thisptr.getPeriodic()
-        return [periodic.x, periodic.y, periodic.z]
+        return np.asarray([periodic.x, periodic.y, periodic.z])
 
     @periodic.setter
     def periodic(self, periodic):
@@ -484,11 +486,11 @@ cdef class Box:
         R"""Returns the box matrix (3x3).
 
         Returns:
-            list of lists, shape 3x3: box matrix
+            :math:`\left(3, 3\right)` :class:`numpy.ndarray`: Box matrix
         """
-        return [[self.Lx, self.xy * self.Ly, self.xz * self.Lz],
-                [0, self.Ly, self.yz * self.Lz],
-                [0, 0, self.Lz]]
+        return np.asarray([[self.Lx, self.xy * self.Ly, self.xz * self.Lz],
+                           [0, self.Ly, self.yz * self.Lz],
+                           [0, 0, self.Lz]])
 
     def __repr__(self):
         return ("freud.box.{cls}(Lx={Lx}, Ly={Ly}, Lz={Lz}, " +

--- a/tests/test_box_Box.py
+++ b/tests/test_box_Box.py
@@ -208,22 +208,23 @@ class TestBox(unittest.TestCase):
 
     def test_periodic(self):
         box = freud.box.Box(1, 2, 3, 0, 0, 0)
-        falses = [False, False, False]
-        trues = [True, True, True]
-        npt.assert_equal(box.periodic, trues)
+        npt.assert_array_equal(box.periodic, True)
         self.assertTrue(box.periodic_x)
         self.assertTrue(box.periodic_y)
         self.assertTrue(box.periodic_z)
 
-        box.periodic = falses
-        npt.assert_equal(box.periodic, falses)
+        # Test setting all flags together
+        box.periodic = False
+        npt.assert_array_equal(box.periodic, False)
         self.assertFalse(box.periodic_x)
         self.assertFalse(box.periodic_y)
         self.assertFalse(box.periodic_z)
 
-        box.periodic = trues
-        npt.assert_equal(box.periodic, trues)
+        # Test setting flags as a list
+        box.periodic = [True, True, True]
+        npt.assert_array_equal(box.periodic, True)
 
+        # Test setting each flag separately
         box.periodic_x = False
         box.periodic_y = False
         box.periodic_z = False
@@ -232,7 +233,7 @@ class TestBox(unittest.TestCase):
         self.assertEqual(box.periodic_z, False)
 
         box.periodic = True
-        npt.assert_equal(box.periodic, trues)
+        npt.assert_array_equal(box.periodic, True)
 
     def test_equal(self):
         box = freud.box.Box(2, 2, 2, 1, 0.5, 0.1)

--- a/tests/test_box_Box.py
+++ b/tests/test_box_Box.py
@@ -193,7 +193,7 @@ class TestBox(unittest.TestCase):
         b_list = [1, 2, 3, 0.1, 0.2, 0.3]
         Lx, Ly, Lz, xy, xz, yz = b_list
         box = freud.box.Box.from_box(b_list)
-        self.assertEqual(
+        npt.assert_allclose(
             box.getLatticeVector(0),
             [Lx, 0, 0]
         )
@@ -208,21 +208,21 @@ class TestBox(unittest.TestCase):
 
     def test_periodic(self):
         box = freud.box.Box(1, 2, 3, 0, 0, 0)
-        false = [False, False, False]
-        true = [True, True, True]
-        self.assertEqual(box.periodic, true)
+        falses = [False, False, False]
+        trues = [True, True, True]
+        npt.assert_equal(box.periodic, trues)
         self.assertTrue(box.periodic_x)
         self.assertTrue(box.periodic_y)
         self.assertTrue(box.periodic_z)
 
-        box.periodic = false
-        self.assertEqual(box.periodic, false)
+        box.periodic = falses
+        npt.assert_equal(box.periodic, falses)
         self.assertFalse(box.periodic_x)
         self.assertFalse(box.periodic_y)
         self.assertFalse(box.periodic_z)
 
-        box.periodic = true
-        self.assertEqual(box.periodic, true)
+        box.periodic = trues
+        npt.assert_equal(box.periodic, trues)
 
         box.periodic_x = False
         box.periodic_y = False
@@ -232,7 +232,7 @@ class TestBox(unittest.TestCase):
         self.assertEqual(box.periodic_z, False)
 
         box.periodic = True
-        self.assertEqual(box.periodic, true)
+        npt.assert_equal(box.periodic, trues)
 
     def test_equal(self):
         box = freud.box.Box(2, 2, 2, 1, 0.5, 0.1)


### PR DESCRIPTION
## Motivation and Context
This PR resolves #280 and related places where return types are not NumPy arrays.

## How Has This Been Tested?
Tests were updated to support NumPy arrays.

## Types of changes
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/glotzerlab/freud/blob/master/CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have updated the [Changelog](https://github.com/glotzerlab/freud/blob/master/ChangeLog.md).
