### PR TITLE
Refactored convert array

### DIFF
--- a/freud/box.pyx
+++ b/freud/box.pyx
@@ -228,8 +228,7 @@ cdef class Box:
                 "Invalid dimensions for fractions given to makeCoordinates. "
                 "Valid input is an array of shape (3,) or (N,3).")
 
-        fractions = freud.common.convert_array(
-            fractions, fractions.ndim, dtype=np.float32, contiguous=True)
+        fractions = freud.common.convert_array(fractions, fractions.ndim)
 
         if fractions.ndim == 1:
             fractions[:] = self._makeCoordinates(fractions)
@@ -261,8 +260,7 @@ cdef class Box:
                 "Invalid dimensions for vecs given to makeFraction. "
                 "Valid input is an array of shape (3,) or (N,3).")
 
-        vecs = freud.common.convert_array(
-            vecs, vecs.ndim, dtype=np.float32, contiguous=True)
+        vecs = freud.common.convert_array(vecs, vecs.ndim)
 
         if vecs.ndim == 1:
             vecs[:] = self._makeFraction(vecs)
@@ -296,8 +294,7 @@ cdef class Box:
                 "Invalid dimensions for vecs given to getImage. "
                 "Valid input is an array of shape (3,) or (N,3).")
 
-        vecs = freud.common.convert_array(
-            vecs, vecs.ndim, dtype=np.float32, contiguous=True)
+        vecs = freud.common.convert_array(vecs, vecs.ndim)
 
         if vecs.ndim == 1:
             vecs[:] = self._getImage(vecs)
@@ -350,8 +347,7 @@ cdef class Box:
                 "Invalid dimensions for vecs given to wrap. "
                 "Valid input is an array of shape (3,) or (N,3).")
 
-        vecs = freud.common.convert_array(
-            vecs, vecs.ndim, dtype=np.float32, contiguous=True)
+        vecs = freud.common.convert_array(vecs, vecs.ndim)
 
         if vecs.ndim == 1:
             # only one vector to wrap
@@ -393,10 +389,8 @@ cdef class Box:
                 "Invalid dimensions for vecs given to unwrap. "
                 "Valid input is an array of shape (3,) or (N,3).")
 
-        vecs = freud.common.convert_array(
-            vecs, vecs.ndim, dtype=np.float32, contiguous=True)
-        imgs = freud.common.convert_array(
-            imgs, vecs.ndim, dtype=np.int32, contiguous=True)
+        vecs = freud.common.convert_array(vecs, vecs.ndim)
+        imgs = freud.common.convert_array(imgs, vecs.ndim, dtype=np.int32)
 
         if vecs.ndim == 1:
             # only one vector to unwrap
@@ -740,8 +734,7 @@ cdef class ParticleBuffer:
                 each side, meaning that one image doubles the box side lengths,
                 two images triples the box side lengths, and so on.
         """
-        points = freud.common.convert_array(
-            points, 2, dtype=np.float32, contiguous=True, array_name='points')
+        points = freud.common.convert_array(points, 2, array_name='points')
 
         if points.shape[1] != 3:
             raise RuntimeError(

--- a/freud/box.pyx
+++ b/freud/box.pyx
@@ -228,7 +228,7 @@ cdef class Box:
                 "Invalid dimensions for fractions given to makeCoordinates. "
                 "Valid input is an array of shape (3,) or (N,3).")
 
-        fractions = freud.common.convert_array(fractions, fractions.ndim)
+        fractions = freud.common.convert_array(fractions)
 
         if fractions.ndim == 1:
             fractions[:] = self._makeCoordinates(fractions)
@@ -260,7 +260,7 @@ cdef class Box:
                 "Invalid dimensions for vecs given to makeFraction. "
                 "Valid input is an array of shape (3,) or (N,3).")
 
-        vecs = freud.common.convert_array(vecs, vecs.ndim)
+        vecs = freud.common.convert_array(vecs)
 
         if vecs.ndim == 1:
             vecs[:] = self._makeFraction(vecs)
@@ -294,7 +294,7 @@ cdef class Box:
                 "Invalid dimensions for vecs given to getImage. "
                 "Valid input is an array of shape (3,) or (N,3).")
 
-        vecs = freud.common.convert_array(vecs, vecs.ndim)
+        vecs = freud.common.convert_array(vecs)
 
         if vecs.ndim == 1:
             vecs[:] = self._getImage(vecs)
@@ -347,7 +347,7 @@ cdef class Box:
                 "Invalid dimensions for vecs given to wrap. "
                 "Valid input is an array of shape (3,) or (N,3).")
 
-        vecs = freud.common.convert_array(vecs, vecs.ndim)
+        vecs = freud.common.convert_array(vecs)
 
         if vecs.ndim == 1:
             # only one vector to wrap
@@ -389,7 +389,7 @@ cdef class Box:
                 "Invalid dimensions for vecs given to unwrap. "
                 "Valid input is an array of shape (3,) or (N,3).")
 
-        vecs = freud.common.convert_array(vecs, vecs.ndim)
+        vecs = freud.common.convert_array(vecs)
         imgs = freud.common.convert_array(imgs, vecs.ndim, dtype=np.int32)
 
         if vecs.ndim == 1:

--- a/freud/box.pyx
+++ b/freud/box.pyx
@@ -734,7 +734,7 @@ cdef class ParticleBuffer:
                 each side, meaning that one image doubles the box side lengths,
                 two images triples the box side lengths, and so on.
         """
-        points = freud.common.convert_array(points, 2, array_name='points')
+        points = freud.common.convert_array(points, 2)
 
         if points.shape[1] != 3:
             raise RuntimeError(

--- a/freud/cluster.pyx
+++ b/freud/cluster.pyx
@@ -98,8 +98,7 @@ cdef class Cluster:
             box (:class:`freud.box.Box`, optional):
                 Simulation box (Default value = None).
         """
-        points = freud.common.convert_array(
-            points, 2, dtype=np.float32)
+        points = freud.common.convert_array(points, 2)
         if points.shape[1] != 3:
             raise RuntimeError(
                 'Need a list of 3D points for computeClusters()')
@@ -132,8 +131,7 @@ cdef class Cluster:
             keys((:math:`N_{particles}`) :class:`numpy.ndarray`):
                 Membership keys, one for each particle.
         """
-        keys = freud.common.convert_array(
-            keys, 1, dtype=np.uint32)
+        keys = freud.common.convert_array(keys, 1, dtype=np.uint32)
         if keys.shape[0] != self.num_particles:
             raise RuntimeError(
                 'keys must be a 1D array of length num_particles')
@@ -247,7 +245,7 @@ cdef class ClusterProperties:
         else:
             b = freud.common.convert_box(box)
 
-        points = freud.common.convert_array(points, 2, dtype=np.float32)
+        points = freud.common.convert_array(points, 2)
         if points.shape[1] != 3:
             raise RuntimeError(
                 'Need a list of 3D points for computeClusterProperties()')

--- a/freud/cluster.pyx
+++ b/freud/cluster.pyx
@@ -99,7 +99,7 @@ cdef class Cluster:
                 Simulation box (Default value = None).
         """
         points = freud.common.convert_array(
-            points, 2, dtype=np.float32, contiguous=True)
+            points, 2, dtype=np.float32)
         if points.shape[1] != 3:
             raise RuntimeError(
                 'Need a list of 3D points for computeClusters()')
@@ -133,7 +133,7 @@ cdef class Cluster:
                 Membership keys, one for each particle.
         """
         keys = freud.common.convert_array(
-            keys, 1, dtype=np.uint32, contiguous=True)
+            keys, 1, dtype=np.uint32)
         if keys.shape[0] != self.num_particles:
             raise RuntimeError(
                 'keys must be a 1D array of length num_particles')
@@ -247,13 +247,12 @@ cdef class ClusterProperties:
         else:
             b = freud.common.convert_box(box)
 
-        points = freud.common.convert_array(
-            points, 2, dtype=np.float32, contiguous=True)
+        points = freud.common.convert_array(points, 2, dtype=np.float32)
         if points.shape[1] != 3:
             raise RuntimeError(
                 'Need a list of 3D points for computeClusterProperties()')
         cluster_idx = freud.common.convert_array(
-            cluster_idx, 1, dtype=np.uint32, contiguous=True)
+            cluster_idx, 1, dtype=np.uint32)
         if cluster_idx.shape[0] != points.shape[0]:
             raise RuntimeError(
                 ('cluster_idx must be a 1D array of matching length/number'

--- a/freud/common.py
+++ b/freud/common.py
@@ -10,7 +10,7 @@ import freud.box
 logger = logging.getLogger(__name__)
 
 
-def convert_array(array, dimensions, dtype=None,
+def convert_array(array, dimensions, dtype=np.float32,
                   contiguous=True, array_name=None):
     """Function which takes a given array, checks the dimensions,
     and converts to a supplied dtype and/or makes the array

--- a/freud/common.py
+++ b/freud/common.py
@@ -11,7 +11,7 @@ logger = logging.getLogger(__name__)
 
 
 def convert_array(array, dimensions, dtype=np.float32,
-                  contiguous=True, array_name=None):
+                  contiguous=True):
     """Function which takes a given array, checks the dimensions,
     and converts to a supplied dtype and/or makes the array
     contiguous as required by the user.
@@ -23,12 +23,10 @@ def convert_array(array, dimensions, dtype=np.float32,
         dimensions (int): Expected dimensions of the array.
         dtype: code:`dtype` to convert the array to if :code:`array.dtype`
             is different. If `None`, :code:`dtype` will not be changed.
-            (Default value = None).
+            (Default value = `numpy.float32`).
         contiguous (bool): Whether to cast the array to a contiguous (Default
             value = True).
         array. Default behavior casts to a contiguous array.
-        array_name (str): Name of the array, used for errors (Default value =
-            None).
 
     Returns:
         py:class:`numpy.ndarray`: Array.
@@ -37,7 +35,7 @@ def convert_array(array, dimensions, dtype=np.float32,
 
     if array.ndim != dimensions:
         raise TypeError("{}.ndim = {}; expected ndim = {}".format(
-            array_name or "array", array.ndim, dimensions))
+            "array", array.ndim, dimensions))
     return np.require(
         array, dtype=dtype, requirements=['C'] if contiguous else None)
 

--- a/freud/common.py
+++ b/freud/common.py
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 def convert_array(array, dimensions=None, dtype=np.float32):
     """Function which takes a given array, checks the dimensions,
     and converts to a supplied dtype and/or makes the array
-    contiguous as required by the user.
+    contiguous.
 
     .. moduleauthor:: Eric Harper <harperic@umich.edu>
 
@@ -22,12 +22,11 @@ def convert_array(array, dimensions=None, dtype=np.float32):
         dimensions (int): Expected dimensions of the array. If 'None',
             no dimensionality check will be done (Default value = 'None').
         dtype: code:`dtype` to convert the array to if :code:`array.dtype`
-            is different. If `None`, :code:`dtype` will not be changed.
+            is different. If `None`, :code:`dtype` will not be changed
             (Default value = `numpy.float32`).
-        array. Default behavior casts to a contiguous array.
 
     Returns:
-        py:class:`numpy.ndarray`: Array.
+        :class:`numpy.ndarray`: Array.
     """
     array = np.asarray(array)
 

--- a/freud/common.py
+++ b/freud/common.py
@@ -19,7 +19,8 @@ def convert_array(array, dimensions=None, dtype=np.float32):
 
     Args:
         array (:class:`numpy.ndarray`): Array to check and convert.
-        dimensions (int): Expected dimensions of the array.
+        dimensions (int): Expected dimensions of the array. If 'None',
+            no dimensionality check will be done (Default value = 'None').
         dtype: code:`dtype` to convert the array to if :code:`array.dtype`
             is different. If `None`, :code:`dtype` will not be changed.
             (Default value = `numpy.float32`).

--- a/freud/common.py
+++ b/freud/common.py
@@ -10,8 +10,7 @@ import freud.box
 logger = logging.getLogger(__name__)
 
 
-def convert_array(array, dimensions, dtype=np.float32,
-                  contiguous=True):
+def convert_array(array, dimensions=None, dtype=np.float32):
     """Function which takes a given array, checks the dimensions,
     and converts to a supplied dtype and/or makes the array
     contiguous as required by the user.
@@ -24,8 +23,6 @@ def convert_array(array, dimensions, dtype=np.float32,
         dtype: code:`dtype` to convert the array to if :code:`array.dtype`
             is different. If `None`, :code:`dtype` will not be changed.
             (Default value = `numpy.float32`).
-        contiguous (bool): Whether to cast the array to a contiguous (Default
-            value = True).
         array. Default behavior casts to a contiguous array.
 
     Returns:
@@ -33,11 +30,10 @@ def convert_array(array, dimensions, dtype=np.float32,
     """
     array = np.asarray(array)
 
-    if array.ndim != dimensions:
-        raise TypeError("{}.ndim = {}; expected ndim = {}".format(
-            "array", array.ndim, dimensions))
-    return np.require(
-        array, dtype=dtype, requirements=['C'] if contiguous else None)
+    if dimensions is not None and array.ndim != dimensions:
+        raise TypeError("array.ndim = {}; expected ndim = {}".format(
+            array.ndim, dimensions))
+    return np.require(array, dtype=dtype, requirements=['C'])
 
 
 def convert_box(box):

--- a/freud/density.pyx
+++ b/freud/density.pyx
@@ -111,15 +111,11 @@ cdef class FloatCF:
             points = ref_points
         if values is None:
             values = ref_values
-        ref_points = freud.common.convert_array(
-            ref_points, 2, dtype=np.float32, contiguous=True,
-            array_name="ref_points")
-        points = freud.common.convert_array(
-            points, 2, dtype=np.float32, contiguous=True, array_name="points")
+        ref_points = freud.common.convert_array(ref_points, 2)
+        points = freud.common.convert_array(points, 2)
         ref_values = freud.common.convert_array(
-            ref_values, 1, dtype=np.float64, contiguous=True)
-        values = freud.common.convert_array(
-            values, 1, dtype=np.float64, contiguous=True)
+            ref_values, 1, dtype=np.float64)
+        values = freud.common.convert_array(values, 1, dtype=np.float64)
         if ref_points.shape[1] != 3 or points.shape[1] != 3:
             raise ValueError("The 2nd dimension must have 3 values: x, y, z")
         cdef const float[:, ::1] l_ref_points = ref_points
@@ -305,15 +301,11 @@ cdef class ComplexCF:
             points = ref_points
         if values is None:
             values = ref_values
-        ref_points = freud.common.convert_array(
-            ref_points, 2, dtype=np.float32, contiguous=True,
-            array_name="ref_points")
-        points = freud.common.convert_array(
-            points, 2, dtype=np.float32, contiguous=True, array_name="points")
+        ref_points = freud.common.convert_array(ref_points, 2)
+        points = freud.common.convert_array(points, 2)
         ref_values = freud.common.convert_array(
-            ref_values, 1, dtype=np.complex128, contiguous=True)
-        values = freud.common.convert_array(
-            values, 1, dtype=np.complex128, contiguous=True)
+            ref_values, 1, dtype=np.complex128)
+        values = freud.common.convert_array(values, 1, dtype=np.complex128)
         if ref_points.shape[1] != 3 or points.shape[1] != 3:
             raise ValueError("The 2nd dimension must have 3 values: x, y, z")
         cdef const float[:, ::1] l_ref_points = ref_points
@@ -488,8 +480,7 @@ cdef class GaussianDensity:
                 Points to calculate the local density.
         """
         cdef freud.box.Box b = freud.common.convert_box(box)
-        points = freud.common.convert_array(
-            points, 2, dtype=np.float32, contiguous=True, array_name="points")
+        points = freud.common.convert_array(points, 2)
         if points.shape[1] != 3:
             raise ValueError("The 2nd dimension must have 3 values: x, y, z")
         cdef const float[:, ::1] l_points = points
@@ -629,11 +620,8 @@ cdef class LocalDensity:
         cdef freud.box.Box b = freud.common.convert_box(box)
         if points is None:
             points = ref_points
-        ref_points = freud.common.convert_array(
-            ref_points, 2, dtype=np.float32, contiguous=True,
-            array_name="ref_points")
-        points = freud.common.convert_array(
-            points, 2, dtype=np.float32, contiguous=True, array_name="points")
+        ref_points = freud.common.convert_array(ref_points, 2)
+        points = freud.common.convert_array(points, 2)
         if ref_points.shape[1] != 3 or points.shape[1] != 3:
             raise ValueError("The 2nd dimension must have 3 values: x, y, z")
         cdef const float[:, ::1] l_ref_points = ref_points
@@ -769,11 +757,8 @@ cdef class RDF:
         cdef freud.box.Box b = freud.common.convert_box(box)
         if points is None:
             points = ref_points
-        ref_points = freud.common.convert_array(
-            ref_points, 2, dtype=np.float32, contiguous=True,
-            array_name="ref_points")
-        points = freud.common.convert_array(
-            points, 2, dtype=np.float32, contiguous=True, array_name="points")
+        ref_points = freud.common.convert_array(ref_points, 2)
+        points = freud.common.convert_array(points, 2)
         if ref_points.shape[1] != 3 or points.shape[1] != 3:
             raise ValueError("The 2nd dimension must have 3 values: x, y, z")
         cdef const float[:, ::1] l_ref_points = ref_points

--- a/freud/environment.pyx
+++ b/freud/environment.pyx
@@ -174,26 +174,19 @@ cdef class BondOrder:
         if orientations is None:
             orientations = ref_orientations
 
-        ref_points = freud.common.convert_array(
-            ref_points, 2, dtype=np.float32, contiguous=True,
-            array_name="ref_points")
+        ref_points = freud.common.convert_array(ref_points, 2)
         if ref_points.shape[1] != 3:
             raise TypeError('ref_points should be an Nx3 array')
 
-        points = freud.common.convert_array(
-            points, 2, dtype=np.float32, contiguous=True, array_name="points")
+        points = freud.common.convert_array(points, 2)
         if points.shape[1] != 3:
             raise TypeError('points should be an Nx3 array')
 
-        ref_orientations = freud.common.convert_array(
-            ref_orientations, 2, dtype=np.float32, contiguous=True,
-            array_name="ref_orientations")
+        ref_orientations = freud.common.convert_array(ref_orientations, 2)
         if ref_orientations.shape[1] != 4:
             raise TypeError('ref_orientations should be an Nx4 array')
 
-        orientations = freud.common.convert_array(
-            orientations, 2, dtype=np.float32, contiguous=True,
-            array_name="orientations")
+        orientations = freud.common.convert_array(orientations, 2)
         if orientations.shape[1] != 4:
             raise TypeError('orientations should be an Nx4 array')
 
@@ -408,17 +401,14 @@ cdef class LocalDescriptors:
         """  # noqa: E501
         cdef freud.box.Box b = freud.common.convert_box(box)
 
-        points_ref = freud.common.convert_array(
-            points_ref, 2, dtype=np.float32, contiguous=True,
-            array_name="points_ref")
+        points_ref = freud.common.convert_array(points_ref, 2)
         if points_ref.shape[1] != 3:
             raise TypeError('points_ref should be an Nx3 array')
 
         if points is None:
             points = points_ref
 
-        points = freud.common.convert_array(
-            points, 2, dtype=np.float32, contiguous=True, array_name="points")
+        points = freud.common.convert_array(points, 2)
         if points.shape[1] != 3:
             raise TypeError('points should be an Nx3 array')
 
@@ -469,17 +459,14 @@ cdef class LocalDescriptors:
             raise RuntimeError(
                 'Unknown LocalDescriptors orientation mode: {}'.format(mode))
 
-        points_ref = freud.common.convert_array(
-            points_ref, 2, dtype=np.float32, contiguous=True,
-            array_name="points_ref")
+        points_ref = freud.common.convert_array(points_ref, 2)
         if points_ref.shape[1] != 3:
             raise TypeError('points_ref should be an Nx3 array')
 
         if points is None:
             points = points_ref
 
-        points = freud.common.convert_array(
-            points, 2, dtype=np.float32, contiguous=True, array_name="points")
+        points = freud.common.convert_array(points, 2)
         if points.shape[1] != 3:
             raise TypeError('points should be an Nx3 array')
 
@@ -492,9 +479,7 @@ cdef class LocalDescriptors:
                     ('Orientations must be given to orient LocalDescriptors '
                         'with particles\' orientations'))
 
-            orientations = freud.common.convert_array(
-                orientations, 2, dtype=np.float32, contiguous=True,
-                array_name="orientations")
+            orientations = freud.common.convert_array(orientations, 2)
             if orientations.shape[1] != 4:
                 raise TypeError('orientations should be an Nx4 array')
 
@@ -651,9 +636,7 @@ cdef class MatchEnv:
                 NeighborList to use to find neighbors of every particle, to
                 compare environments (Default value = :code:`None`).
         """
-        points = freud.common.convert_array(
-            points, 2, dtype=np.float32, contiguous=True,
-            array_name="points")
+        points = freud.common.convert_array(points, 2)
         if points.shape[1] != 3:
             raise TypeError('points should be an Nx3 array')
 
@@ -708,15 +691,11 @@ cdef class MatchEnv:
                 NeighborList to use to find bonds (Default value =
                 :code:`None`).
         """
-        points = freud.common.convert_array(
-            points, 2, dtype=np.float32, contiguous=True,
-            array_name="points")
+        points = freud.common.convert_array(points, 2)
         if points.shape[1] != 3:
             raise TypeError('points should be an Nx3 array')
 
-        refPoints = freud.common.convert_array(
-            refPoints, 2, dtype=np.float32, contiguous=True,
-            array_name="refPoints")
+        refPoints = freud.common.convert_array(refPoints, 2)
         if refPoints.shape[1] != 3:
             raise TypeError('refPoints should be an Nx3 array')
 
@@ -759,15 +738,11 @@ cdef class MatchEnv:
                 Vector of minimal RMSD values, one value per particle.
 
         """
-        points = freud.common.convert_array(
-            points, 2, dtype=np.float32, contiguous=True,
-            array_name="points")
+        points = freud.common.convert_array(points, 2)
         if points.shape[1] != 3:
             raise TypeError('points should be an Nx3 array')
 
-        refPoints = freud.common.convert_array(
-            refPoints, 2, dtype=np.float32, contiguous=True,
-            array_name="refPoints")
+        refPoints = freud.common.convert_array(refPoints, 2)
         if refPoints.shape[1] != 3:
             raise TypeError('refPoints should be an Nx3 array')
 
@@ -814,15 +789,11 @@ cdef class MatchEnv:
                 correspond to each other. Empty if they do not correspond to
                 each other.
         """  # noqa: E501
-        refPoints1 = freud.common.convert_array(
-            refPoints1, 2, dtype=np.float32, contiguous=True,
-            array_name="refPoints1")
+        refPoints1 = freud.common.convert_array(refPoints1, 2)
         if refPoints1.shape[1] != 3:
             raise TypeError('refPoints1 should be an Nx3 array')
 
-        refPoints2 = freud.common.convert_array(
-            refPoints2, 2, dtype=np.float32, contiguous=True,
-            array_name="refPoints2")
+        refPoints2 = freud.common.convert_array(refPoints2, 2)
         if refPoints2.shape[1] != 3:
             raise TypeError('refPoints2 should be an Nx3 array')
 
@@ -864,15 +835,11 @@ cdef class MatchEnv:
                 set of refPoints2, and the mapping between the vectors of
                 refPoints1 and refPoints2 that somewhat minimizes the RMSD.
         """  # noqa: E501
-        refPoints1 = freud.common.convert_array(
-            refPoints1, 2, dtype=np.float32, contiguous=True,
-            array_name="refPoints1")
+        refPoints1 = freud.common.convert_array(refPoints1, 2)
         if refPoints1.shape[1] != 3:
             raise TypeError('refPoints1 should be an Nx3 array')
 
-        refPoints2 = freud.common.convert_array(
-            refPoints2, 2, dtype=np.float32, contiguous=True,
-            array_name="refPoints2")
+        refPoints2 = freud.common.convert_array(refPoints2, 2)
         if refPoints2.shape[1] != 3:
             raise TypeError('refPoints2 should be an Nx3 array')
 
@@ -1028,31 +995,23 @@ cdef class AngularSeparation:
                 :code:`None`).
         """  # noqa: E501
         cdef freud.box.Box b = freud.common.convert_box(box)
-        ref_points = freud.common.convert_array(
-            ref_points, 2, dtype=np.float32, contiguous=True,
-            array_name="ref_points")
+        ref_points = freud.common.convert_array(ref_points, 2)
         if ref_points.shape[1] != 3:
             raise TypeError('ref_points should be an Nx3 array')
 
-        points = freud.common.convert_array(
-            points, 2, dtype=np.float32, contiguous=True, array_name="points")
+        points = freud.common.convert_array(points, 2)
         if points.shape[1] != 3:
             raise TypeError('points should be an Nx3 array')
 
-        ref_ors = freud.common.convert_array(
-            ref_ors, 2, dtype=np.float32, contiguous=True,
-            array_name="ref_ors")
+        ref_ors = freud.common.convert_array(ref_ors, 2)
         if ref_ors.shape[1] != 4:
             raise TypeError('ref_ors should be an Nx4 array')
 
-        ors = freud.common.convert_array(
-            ors, 2, dtype=np.float32, contiguous=True, array_name="ors")
+        ors = freud.common.convert_array(ors, 2)
         if ors.shape[1] != 4:
             raise TypeError('ors should be an Nx4 array')
 
-        equiv_quats = freud.common.convert_array(
-            equiv_quats, 2, dtype=np.float32, contiguous=True,
-            array_name="equiv_quats")
+        equiv_quats = freud.common.convert_array(equiv_quats, 2)
         if equiv_quats.shape[1] != 4:
             raise TypeError('equiv_quats should be an N_equiv x 4 array')
 
@@ -1095,21 +1054,15 @@ cdef class AngularSeparation:
                 Important: :code:`equiv_quats` must include both :math:`q` and
                 :math:`-q`, for all included quaternions.
         """
-        global_ors = freud.common.convert_array(
-            global_ors, 2, dtype=np.float32, contiguous=True,
-            array_name="global_ors")
+        global_ors = freud.common.convert_array(global_ors, 2)
         if global_ors.shape[1] != 4:
             raise TypeError('global_ors should be an Nx4 array')
 
-        ors = freud.common.convert_array(
-            ors, 2, dtype=np.float32, contiguous=True,
-            array_name="ors")
+        ors = freud.common.convert_array(ors, 2)
         if ors.shape[1] != 4:
             raise TypeError('ors should be an Nx4 array')
 
-        equiv_quats = freud.common.convert_array(
-            equiv_quats, 2, dtype=np.float32, contiguous=True,
-            array_name="equiv_quats")
+        equiv_quats = freud.common.convert_array(equiv_quats, 2)
         if equiv_quats.shape[1] != 4:
             raise TypeError('equiv_quats should be an N_equiv x 4 array')
 
@@ -1251,35 +1204,25 @@ cdef class LocalBondProjection:
                 :code:`None`).
         """  # noqa: E501
         cdef freud.box.Box b = freud.common.convert_box(box)
-        ref_points = freud.common.convert_array(
-            ref_points, 2, dtype=np.float32, contiguous=True,
-            array_name="ref_points")
+        ref_points = freud.common.convert_array(ref_points, 2)
         if ref_points.shape[1] != 3:
             raise TypeError('ref_points should be an Nx3 array')
 
-        ref_ors = freud.common.convert_array(
-            ref_ors, 2, dtype=np.float32, contiguous=True,
-            array_name="ref_ors")
+        ref_ors = freud.common.convert_array(ref_ors, 2)
         if ref_ors.shape[1] != 4:
             raise TypeError('ref_ors should be an Nx4 array')
 
         if points is None:
             points = ref_points
-        points = freud.common.convert_array(
-            points, 2, dtype=np.float32, contiguous=True,
-            array_name="points")
+        points = freud.common.convert_array(points, 2)
         if points.shape[1] != 3:
             raise TypeError('points should be an Nx3 array')
 
-        equiv_quats = freud.common.convert_array(
-            equiv_quats, 2, dtype=np.float32, contiguous=True,
-            array_name="equiv_quats")
+        equiv_quats = freud.common.convert_array(equiv_quats, 2)
         if equiv_quats.shape[1] != 4:
             raise TypeError('equiv_quats should be an N_equiv x 4 array')
 
-        proj_vecs = freud.common.convert_array(
-            proj_vecs, 2, dtype=np.float32, contiguous=True,
-            array_name="proj_vecs")
+        proj_vecs = freud.common.convert_array(proj_vecs, 2)
         if proj_vecs.shape[1] != 3:
             raise TypeError('proj_vecs should be an Nx3 array')
 

--- a/freud/interface.pyx
+++ b/freud/interface.pyx
@@ -64,11 +64,8 @@ cdef class InterfaceMeasure:
                 Neighborlist to use to find bonds (Default value = None).
         """
         b = freud.common.convert_box(box)
-        ref_points = freud.common.convert_array(
-            ref_points, 2, dtype=np.float32, contiguous=True,
-            array_name="ref_points")
-        points = freud.common.convert_array(
-            points, 2, dtype=np.float32, contiguous=True, array_name="points")
+        ref_points = freud.common.convert_array(ref_points, 2)
+        points = freud.common.convert_array(points, 2)
         if ref_points.shape[1] != 3 or points.shape[1] != 3:
             raise RuntimeError('Need to provide array with x, y, z positions')
 

--- a/freud/locality.pyx
+++ b/freud/locality.pyx
@@ -284,9 +284,7 @@ cdef class NeighborQuery:
         # This function is temporarily included for testing and may be
         # removed in future releases.
         # Can't use this function with old-style NeighborQuery objects
-        points = freud.common.convert_array(
-            np.atleast_2d(points), 2, dtype=np.float32, contiguous=True,
-            array_name="points")
+        points = freud.common.convert_array(np.atleast_2d(points), 2)
 
         cdef shared_ptr[freud._locality.NeighborQueryIterator] iterator
         cdef const float[:, ::1] l_points = points
@@ -335,9 +333,7 @@ cdef class NeighborQuery:
             raise RuntimeError("You cannot use the query method unless this "
                                "object was originally constructed with "
                                "reference points")
-        points = freud.common.convert_array(
-            np.atleast_2d(points), 2, dtype=np.float32, contiguous=True,
-            array_name="points")
+        points = freud.common.convert_array(np.atleast_2d(points), 2)
         if points.shape[1] != 3:
             raise TypeError('points should be an Nx3 array')
 
@@ -367,9 +363,7 @@ cdef class NeighborQuery:
             raise RuntimeError("You cannot use the query method unless this "
                                "object was originally constructed with "
                                "reference points")
-        points = freud.common.convert_array(
-            np.atleast_2d(points), 2, dtype=np.float32, contiguous=True,
-            array_name="points")
+        points = freud.common.convert_array(np.atleast_2d(points), 2)
         if points.shape[1] != 3:
             raise TypeError('points should be an Nx3 array')
 
@@ -465,12 +459,8 @@ cdef class NeighborList:
                 Array of per-bond weights (if :code:`None` is given, use a
                 value of 1 for each weight) (Default value = :code:`None`).
         """
-        index_i = freud.common.convert_array(index_i, dimensions=1,
-                                             dtype=np.uint64, contiguous=True,
-                                             array_name='index_i')
-        index_j = freud.common.convert_array(index_j, dimensions=1,
-                                             dtype=np.uint64, contiguous=True,
-                                             array_name='index_j')
+        index_i = freud.common.convert_array(index_i, 1, dtype=np.uint64)
+        index_j = freud.common.convert_array(index_j, 1, dtype=np.uint64)
 
         if index_i.shape != index_j.shape:
             raise TypeError('index_i and index_j should be the same size')
@@ -478,9 +468,7 @@ cdef class NeighborList:
         if weights is None:
             weights = np.ones(index_i.shape, dtype=np.float32)
         else:
-            weights = freud.common.convert_array(
-                weights, dimensions=1, dtype=np.float32, contiguous=True,
-                array_name='weights')
+            weights = freud.common.convert_array(weights, 1)
 
         if weights.shape != index_i.shape:
             raise TypeError('weights and index_i should be the same size')
@@ -693,14 +681,11 @@ cdef class NeighborList:
                 (Default value = 0).
         """
         cdef freud.box.Box b = freud.common.convert_box(box)
-        ref_points = freud.common.convert_array(
-            ref_points, 2, dtype=np.float32, contiguous=True,
-            array_name="ref_points")
+        ref_points = freud.common.convert_array(ref_points, 2)
         if ref_points.shape[1] != 3:
             raise TypeError('ref_points should be an Nx3 array')
 
-        points = freud.common.convert_array(
-            points, 2, dtype=np.float32, contiguous=True, array_name="points")
+        points = freud.common.convert_array(points, 2)
         if points.shape[1] != 3:
             raise TypeError('points should be an Nx3 array')
 
@@ -827,9 +812,7 @@ cdef class AABBQuery(NeighborQuery):
             # Assume valid set of arguments is passed
             self.queryable = True
             self._box = freud.common.convert_box(box)
-            self.points = freud.common.convert_array(
-                points, 2, dtype=np.float32, contiguous=True,
-                array_name="points").copy()
+            self.points = freud.common.convert_array(points, 2).copy()
             l_points = self.points
             self.thisptr = self.nqptr = new freud._locality.AABBQuery(
                 dereference(self._box.thisptr),
@@ -844,9 +827,7 @@ cdef class AABBQuery(NeighborQuery):
         # This function is temporarily included for testing and WILL be
         # removed in future releases.
         # Can't use this function with old-style NeighborQuery objects
-        points = freud.common.convert_array(
-            np.atleast_2d(points), 2, dtype=np.float32, contiguous=True,
-            array_name="points")
+        points = freud.common.convert_array(np.atleast_2d(points), 2)
 
         cdef shared_ptr[freud._locality.NeighborQueryIterator] iterator
         cdef const float[:, ::1] l_points = points
@@ -891,9 +872,7 @@ cdef class AABBQuery(NeighborQuery):
             :class:`~.NeighborQueryResult`: Results object containing the
             output of this query.
         """
-        points = freud.common.convert_array(
-            np.atleast_2d(points), 2, dtype=np.float32, contiguous=True,
-            array_name="points")
+        points = freud.common.convert_array(np.atleast_2d(points), 2)
         if points.shape[1] != 3:
             raise TypeError('points should be an Nx3 array')
 
@@ -1007,9 +986,7 @@ cdef class LinkCell(NeighborQuery):
         if points is not None:
             # The new API
             self.queryable = True
-            self.points = freud.common.convert_array(
-                points, 2, dtype=np.float32, contiguous=True,
-                array_name="points").copy()
+            self.points = freud.common.convert_array(points, 2).copy()
             l_points = self.points
             self.thisptr = self.nqptr = new freud._locality.LinkCell(
                 dereference(self._box.thisptr), float(cell_width),
@@ -1043,8 +1020,7 @@ cdef class LinkCell(NeighborQuery):
         Returns:
             unsigned int: Cell index.
         """
-        point = freud.common.convert_array(
-            point, 1, dtype=np.float32, contiguous=True, array_name="point")
+        point = freud.common.convert_array(point, 1)
 
         cdef const float[::1] cPoint = point
 
@@ -1112,17 +1088,14 @@ cdef class LinkCell(NeighborQuery):
             points is ref_points or points is None) \
             if exclude_ii is None else exclude_ii
 
-        ref_points = freud.common.convert_array(
-            ref_points, 2, dtype=np.float32, contiguous=True,
-            array_name="ref_points")
+        ref_points = freud.common.convert_array(ref_points, 2)
         if ref_points.shape[1] != 3:
             raise TypeError('ref_points should be an Nx3 array')
 
         if points is None:
             points = ref_points
 
-        points = freud.common.convert_array(
-            points, 2, dtype=np.float32, contiguous=True, array_name="points")
+        points = freud.common.convert_array(points, 2)
         if points.shape[1] != 3:
             raise TypeError('points should be an Nx3 array')
 
@@ -1363,17 +1336,14 @@ cdef class NearestNeighbors:
             points is ref_points or points is None) \
             if exclude_ii is None else exclude_ii
 
-        ref_points = freud.common.convert_array(
-            ref_points, 2, dtype=np.float32, contiguous=True,
-            array_name="ref_points")
+        ref_points = freud.common.convert_array(ref_points, 2)
         if ref_points.shape[1] != 3:
             raise TypeError('ref_points should be an Nx3 array')
 
         if points is None:
             points = ref_points
 
-        points = freud.common.convert_array(
-            points, 2, dtype=np.float32, contiguous=True, array_name="points")
+        points = freud.common.convert_array(points, 2)
         if points.shape[1] != 3:
             raise TypeError('points should be an Nx3 array')
 

--- a/freud/msd.pyx
+++ b/freud/msd.pyx
@@ -150,7 +150,7 @@ cdef class MSD:
             )
 
         if images is not None:
-            images = freud.common.convert_array(images, 3)
+            images = freud.common.convert_array(images, 3, dtype=np.int32)
             if images.shape[2] != 3:
                 raise TypeError(
                     'images should be a 3-dimensional array of shape'

--- a/freud/msd.pyx
+++ b/freud/msd.pyx
@@ -142,9 +142,7 @@ cdef class MSD:
                 positions are assumed to be unwrapped already.
         """  # noqa: E501
 
-        positions = freud.common.convert_array(
-            positions, 3, dtype=np.float32, contiguous=True,
-            array_name="positions")
+        positions = freud.common.convert_array(positions, 3)
         if positions.shape[2] != 3:
             raise TypeError(
                 'positions should be a 3-dimensional array of shape'
@@ -152,9 +150,7 @@ cdef class MSD:
             )
 
         if images is not None:
-            images = freud.common.convert_array(
-                images, 3, dtype=np.float32, contiguous=True,
-                array_name="images")
+            images = freud.common.convert_array(images, 3)
             if images.shape[2] != 3:
                 raise TypeError(
                     'images should be a 3-dimensional array of shape'

--- a/freud/order.pyx
+++ b/freud/order.pyx
@@ -242,8 +242,7 @@ cdef class NematicOrderParameter:
             orientations (:math:`\left(N_{particles}, 4 \right)` :class:`numpy.ndarray`):
                 Orientations to calculate the order parameter.
         """  # noqa: E501
-        orientations = freud.common.convert_array(
-            orientations, 2)
+        orientations = freud.common.convert_array(orientations, 2)
         if orientations.shape[1] != 4:
             raise TypeError('orientations should be an Nx4 array')
 
@@ -1552,8 +1551,7 @@ cdef class RotationalAutocorrelation:
             ors ((:math:`N_{orientations}`, 4) :class:`numpy.ndarray`):
                 Orientations for the frame of interest.
         """
-        ref_ors = freud.common.convert_array(
-            ref_ors, 2)
+        ref_ors = freud.common.convert_array(ref_ors, 2)
         if ref_ors.shape[1] != 4:
             raise TypeError('ref_ors should be an Nx4 array')
 

--- a/freud/order.pyx
+++ b/freud/order.pyx
@@ -117,9 +117,7 @@ cdef class CubaticOrderParameter:
             orientations ((:math:`N_{particles}`, 4) :class:`numpy.ndarray`):
                 Orientations as angles to use in computation.
         """
-        orientations = freud.common.convert_array(
-            orientations, 2, dtype=np.float32, contiguous=True,
-            array_name="orientations")
+        orientations = freud.common.convert_array(orientations, 2)
         if orientations.shape[1] != 4:
             raise TypeError('orientations should be an Nx4 array')
 
@@ -235,8 +233,7 @@ cdef class NematicOrderParameter:
 
         cdef vec3[float] l_u = vec3[float](u[0], u[1], u[2])
         self.thisptr = new freud._order.NematicOrderParameter(l_u)
-        self.u = freud.common.convert_array(
-            u, 1, dtype=np.float32, contiguous=True, array_name="u")
+        self.u = freud.common.convert_array(u, 1)
 
     def compute(self, orientations):
         R"""Calculates the per-particle and global order parameter.
@@ -246,8 +243,7 @@ cdef class NematicOrderParameter:
                 Orientations to calculate the order parameter.
         """  # noqa: E501
         orientations = freud.common.convert_array(
-            orientations, 2, dtype=np.float32, contiguous=True,
-            array_name="orientations")
+            orientations, 2)
         if orientations.shape[1] != 4:
             raise TypeError('orientations should be an Nx4 array')
 
@@ -354,8 +350,7 @@ cdef class HexOrderParameter:
                 Neighborlist to use to find bonds.
         """
         cdef freud.box.Box b = freud.common.convert_box(box)
-        points = freud.common.convert_array(
-            points, 2, dtype=np.float32, contiguous=True, array_name="points")
+        points = freud.common.convert_array(points, 2)
         if points.shape[1] != 3:
             raise TypeError('points should be an Nx3 array')
 
@@ -448,8 +443,7 @@ cdef class TransOrderParameter:
                 Neighborlist to use to find bonds.
         """
         cdef freud.box.Box b = freud.common.convert_box(box)
-        points = freud.common.convert_array(
-            points, 2, dtype=np.float32, contiguous=True, array_name="points")
+        points = freud.common.convert_array(points, 2)
         if points.shape[1] != 3:
             raise TypeError('points should be an Nx3 array')
 
@@ -644,8 +638,7 @@ cdef class LocalQl:
             nlist (:class:`freud.locality.NeighborList`, optional):
                 Neighborlist to use to find bonds (Default value = None).
         """
-        points = freud.common.convert_array(
-            points, 2, dtype=np.float32, contiguous=True, array_name="points")
+        points = freud.common.convert_array(points, 2)
         if points.shape[1] != 3:
             raise TypeError('points should be an Nx3 array')
 
@@ -669,8 +662,7 @@ cdef class LocalQl:
             nlist (:class:`freud.locality.NeighborList`, optional):
                 Neighborlist to use to find bonds (Default value = None).
         """
-        points = freud.common.convert_array(
-            points, 2, dtype=np.float32, contiguous=True, array_name="points")
+        points = freud.common.convert_array(points, 2)
         if points.shape[1] != 3:
             raise TypeError('points should be an Nx3 array')
 
@@ -697,8 +689,7 @@ cdef class LocalQl:
             nlist (:class:`freud.locality.NeighborList`, optional):
                 Neighborlist to use to find bonds (Default value = None).
         """
-        points = freud.common.convert_array(
-            points, 2, dtype=np.float32, contiguous=True, array_name="points")
+        points = freud.common.convert_array(points, 2)
         if points.shape[1] != 3:
             raise TypeError('points should be an Nx3 array')
 
@@ -725,8 +716,7 @@ cdef class LocalQl:
             nlist (:class:`freud.locality.NeighborList`, optional):
                 Neighborlist to use to find bonds (Default value = None).
         """
-        points = freud.common.convert_array(
-            points, 2, dtype=np.float32, contiguous=True, array_name="points")
+        points = freud.common.convert_array(points, 2)
         if points.shape[1] != 3:
             raise TypeError('points should be an Nx3 array')
 
@@ -1243,8 +1233,7 @@ cdef class SolLiq:
             nlist (:class:`freud.locality.NeighborList`, optional):
                 Neighborlist to use to find bonds (Default value = None).
         """
-        points = freud.common.convert_array(
-            points, 2, dtype=np.float32, contiguous=True, array_name="points")
+        points = freud.common.convert_array(points, 2)
         if points.shape[1] != 3:
             raise TypeError('points should be an Nx3 array')
 
@@ -1272,8 +1261,7 @@ cdef class SolLiq:
             nlist (:class:`freud.locality.NeighborList`, optional):
                 Neighborlist to use to find bonds (Default value = None).
         """
-        points = freud.common.convert_array(
-            points, 2, dtype=np.float32, contiguous=True, array_name="points")
+        points = freud.common.convert_array(points, 2)
         if points.shape[1] != 3:
             raise TypeError('points should be an Nx3 array')
 
@@ -1298,8 +1286,7 @@ cdef class SolLiq:
             nlist (:class:`freud.locality.NeighborList`, optional):
                 Neighborlist to use to find bonds (Default value = None).
         """
-        points = freud.common.convert_array(
-            points, 2, dtype=np.float32, contiguous=True, array_name="points")
+        points = freud.common.convert_array(points, 2)
         if points.shape[1] != 3:
             raise TypeError('points should be an Nx3 array')
 
@@ -1566,13 +1553,11 @@ cdef class RotationalAutocorrelation:
                 Orientations for the frame of interest.
         """
         ref_ors = freud.common.convert_array(
-            ref_ors, 2, dtype=np.float32, contiguous=True,
-            array_name="ref_ors")
+            ref_ors, 2)
         if ref_ors.shape[1] != 4:
             raise TypeError('ref_ors should be an Nx4 array')
 
-        ors = freud.common.convert_array(
-            ors, 2, dtype=np.float32, contiguous=True, array_name="ors")
+        ors = freud.common.convert_array(ors, 2)
         if ors.shape[1] != 4:
             raise TypeError('ors should be an Nx4 array')
 

--- a/freud/pmft.pyx
+++ b/freud/pmft.pyx
@@ -935,8 +935,7 @@ cdef class PMFTXYZ(_PMFT):
         else:
             if face_orientations.ndim < 2 or face_orientations.ndim > 3:
                 raise ValueError("points must be a 2 or 3 dimensional array")
-            face_orientations = freud.common.convert_array(
-                face_orientations, face_orientations.ndim)
+            face_orientations = freud.common.convert_array(face_orientations)
             if face_orientations.ndim == 2:
                 if face_orientations.shape[1] != 4:
                     raise ValueError(

--- a/freud/pmft.pyx
+++ b/freud/pmft.pyx
@@ -192,24 +192,18 @@ cdef class PMFTR12(_PMFT):
         if orientations is None:
             orientations = ref_orientations
 
-        ref_points = freud.common.convert_array(
-            ref_points, 2, dtype=np.float32, contiguous=True,
-            array_name="ref_points")
+        ref_points = freud.common.convert_array(ref_points, 2)
         if ref_points.shape[1] != 3:
             raise TypeError('ref_points should be an Nx3 array')
 
         ref_orientations = freud.common.convert_array(
-            ref_orientations.squeeze(), 1, dtype=np.float32, contiguous=True,
-            array_name="ref_orientations")
+            ref_orientations.squeeze(), 1)
 
-        points = freud.common.convert_array(
-            points, 2, dtype=np.float32, contiguous=True, array_name="points")
+        points = freud.common.convert_array(points, 2)
         if points.shape[1] != 3:
             raise TypeError('points should be an Nx3 array')
 
-        orientations = freud.common.convert_array(
-            orientations.squeeze(), 1, dtype=np.float32, contiguous=True,
-            array_name="orientations")
+        orientations = freud.common.convert_array(orientations.squeeze(), 1)
 
         defaulted_nlist = freud.locality.make_default_nlist(
             b, ref_points, points, self.rmax, nlist, None)
@@ -443,24 +437,18 @@ cdef class PMFTXYT(_PMFT):
         if orientations is None:
             orientations = ref_orientations
 
-        ref_points = freud.common.convert_array(
-            ref_points, 2, dtype=np.float32, contiguous=True,
-            array_name="ref_points")
+        ref_points = freud.common.convert_array(ref_points, 2)
         if ref_points.shape[1] != 3:
             raise TypeError('ref_points should be an Nx3 array')
 
         ref_orientations = freud.common.convert_array(
-            ref_orientations.squeeze(), 1, dtype=np.float32, contiguous=True,
-            array_name="ref_orientations")
+            ref_orientations.squeeze(), 1)
 
-        points = freud.common.convert_array(
-            points, 2, dtype=np.float32, contiguous=True, array_name="points")
+        points = freud.common.convert_array(points, 2)
         if points.shape[1] != 3:
             raise TypeError('points should be an Nx3 array')
 
-        orientations = freud.common.convert_array(
-            orientations.squeeze(), 1, dtype=np.float32, contiguous=True,
-            array_name="orientations")
+        orientations = freud.common.convert_array(orientations.squeeze(), 1)
 
         defaulted_nlist = freud.locality.make_default_nlist(
             b, ref_points, points, self.rmax, nlist, None)
@@ -678,24 +666,19 @@ cdef class PMFTXY2D(_PMFT):
         if orientations is None:
             orientations = ref_orientations
 
-        ref_points = freud.common.convert_array(
-            ref_points, 2, dtype=np.float32, contiguous=True,
-            array_name="ref_points")
+        ref_points = freud.common.convert_array(ref_points, 2)
         if ref_points.shape[1] != 3:
             raise TypeError('ref_points should be an Nx3 array')
 
         ref_orientations = freud.common.convert_array(
-            ref_orientations.squeeze(), 1, dtype=np.float32, contiguous=True,
-            array_name="ref_orientations")
+            ref_orientations.squeeze(), 1)
 
-        points = freud.common.convert_array(
-            points, 2, dtype=np.float32, contiguous=True, array_name="points")
+        points = freud.common.convert_array(points, 2)
         if points.shape[1] != 3:
             raise TypeError('points should be an Nx3 array')
 
         orientations = freud.common.convert_array(
-            orientations.squeeze(), 1, dtype=np.float32, contiguous=True,
-            array_name="orientations")
+            orientations.squeeze(), 1)
 
         defaulted_nlist = freud.locality.make_default_nlist(
             b, ref_points, points, self.rmax, nlist, None)
@@ -924,28 +907,21 @@ cdef class PMFTXYZ(_PMFT):
         if orientations is None:
             orientations = ref_orientations
 
-        ref_points = freud.common.convert_array(
-            ref_points, 2, dtype=np.float32, contiguous=True,
-            array_name="ref_points")
+        ref_points = freud.common.convert_array(ref_points, 2)
         if ref_points.shape[1] != 3:
             raise TypeError('ref_points should be an Nx3 array')
 
-        ref_orientations = freud.common.convert_array(
-            ref_orientations, 2, dtype=np.float32, contiguous=True,
-            array_name="ref_orientations")
+        ref_orientations = freud.common.convert_array(ref_orientations, 2)
         if ref_orientations.shape[1] != 4:
             raise ValueError(
                 "The 2nd dimension must have 4 values: w, x, y, z")
 
-        points = freud.common.convert_array(
-            points, 2, dtype=np.float32, contiguous=True, array_name="points")
+        points = freud.common.convert_array(points, 2)
         if points.shape[1] != 3:
             raise TypeError('points should be an Nx3 array')
         points = points - self.shiftvec.reshape(1, 3)
 
-        orientations = freud.common.convert_array(
-            orientations, 2, dtype=np.float32, contiguous=True,
-            array_name="orientations")
+        orientations = freud.common.convert_array(orientations, 2)
         if orientations.shape[1] != 4:
             raise ValueError(
                 "The 2nd dimension must have 4 values: w, x, y, z")
@@ -960,11 +936,7 @@ cdef class PMFTXYZ(_PMFT):
             if face_orientations.ndim < 2 or face_orientations.ndim > 3:
                 raise ValueError("points must be a 2 or 3 dimensional array")
             face_orientations = freud.common.convert_array(
-                face_orientations, face_orientations.ndim,
-                dtype=np.float32, contiguous=True,
-                array_name=("face_orientations must be a {} "
-                            "dimensional array").format(
-                                face_orientations.ndim))
+                face_orientations, face_orientations.ndim)
             if face_orientations.ndim == 2:
                 if face_orientations.shape[1] != 4:
                     raise ValueError(

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -22,12 +22,10 @@ class TestCommon(unittest.TestCase):
         npt.assert_equal(y.flags.contiguous, False)
         z = common.convert_array(y, 2)
         npt.assert_equal(z.flags.contiguous, True)
-        # test the dim_message
-        try:
-            z = common.convert_array(
-                y, 1, dtype=np.float32)
-        except TypeError:
-            npt.assert_equal(True, True)
+
+        # test dimension checking
+        with self.assertRaises(TypeError):
+            z = common.convert_array(y, 1, dtype=np.float32)
 
         # test for non-default dtype
         z = common.convert_array(y, dtype=np.float64)
@@ -39,7 +37,7 @@ class TestCommon(unittest.TestCase):
         z = common.convert_array(y, 2)
         npt.assert_equal(z, zl)
 
-        # test for dimensions defualt argument
+        # test for dimensions default argument
         zd = common.convert_array(y)
         z = common.convert_array(y, 2)
         npt.assert_equal(z, zd)

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -25,10 +25,24 @@ class TestCommon(unittest.TestCase):
         # test the dim_message
         try:
             z = common.convert_array(
-                y, 1, dtype=np.float32,
-                dim_message="ref_points must be a 2 dimensional array")
+                y, 1, dtype=np.float32)
         except TypeError:
             npt.assert_equal(True, True)
+
+        # test for non-default dtype
+        z = common.convert_array(y, dtype=np.float64)
+        npt.assert_equal(z.dtype, np.float64)
+
+        # test for list of list input
+        yl = [list(r) for r in y]
+        zl = common.convert_array(yl, 2)
+        z = common.convert_array(y, 2)
+        npt.assert_equal(z, zl)
+
+        # test for dimensions defualt argument
+        zd = common.convert_array(y)
+        z = common.convert_array(y, 2)
+        npt.assert_equal(z, zd)
 
     def test_convert_matrix_box(self):
         matrix_box = np.array([[1, 2, 3],

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -20,12 +20,12 @@ class TestCommon(unittest.TestCase):
         npt.assert_equal(z.dtype, np.float32)
         # now make contiguous
         npt.assert_equal(y.flags.contiguous, False)
-        z = common.convert_array(y, 2, contiguous=True)
+        z = common.convert_array(y, 2)
         npt.assert_equal(z.flags.contiguous, True)
         # test the dim_message
         try:
             z = common.convert_array(
-                y, 1, dtype=np.float32, contiguous=True,
+                y, 1, dtype=np.float32,
                 dim_message="ref_points must be a 2 dimensional array")
         except TypeError:
             npt.assert_equal(True, True)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Made the default `dtype` of `freud.common.convert_array` to be `numpy.float32` and removed the parameter `array_name`. 
Relevant changes were made in other modules that use the `freud.common.convert_array` method.
Also, removed the parameter `contiguous=True` since it is always true.
Added default argument for `dimensions` to be `None`.
If `dimensions=None`, no dimensionality check is done. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The code looks shorter and simpler.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Passed all the current tests.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature (non-breaking change which adds or improves functionality)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/glotzerlab/freud/blob/master/CONTRIBUTING.md) document.
- [x] All new and existing tests passed.
- [ ] I have updated the [Changelog](https://github.com/glotzerlab/freud/blob/master/ChangeLog.md).
