### PR TITLE
Fix/remove extra cpp includes

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,6 +2,14 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## next
+
+### Changed
+* Removed extra C++ includes to speed up builds.
+
+### Removed
+* Removed outdated `computeNList` function from `LocalDescriptors`.
+
 ## v1.1.0 - 2019-05-23
 
 ### Added
@@ -13,7 +21,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 * ParticleBuffer supports different buffer sizes in x, y, z.
 * Box makeCoordinates, makeFraction, getImage now support 2D arrays with multiple points.
 
-### Changes
+### Changed
 * Use constant memoryviews to prevent errors with read-only inputs.
 * LocalQl is now parallelized with TBB.
 * Optimized performance of RotationalAutocorrelation.

--- a/cpp/box/Box.cc
+++ b/cpp/box/Box.cc
@@ -4,7 +4,6 @@
 #include <iostream>
 
 #include "Box.h"
-#include "Index1D.h"
 
 using namespace std;
 

--- a/cpp/box/ParticleBuffer.h
+++ b/cpp/box/ParticleBuffer.h
@@ -9,7 +9,6 @@
 
 #include "Box.h"
 #include "VectorMath.h"
-#include "Index1D.h"
 
 /*! \file ParticleBuffer.h
     \brief Replicates particles across periodic boundaries.

--- a/cpp/cluster/Cluster.h
+++ b/cpp/cluster/Cluster.h
@@ -10,8 +10,8 @@
 #include <vector>
 
 #include "Box.h"
+#include "NeighborList.h"
 #include "VectorMath.h"
-#include "LinkCell.h"
 
 /*! \file Cluster.h
     \brief Routines for clustering points.

--- a/cpp/density/CorrelationFunction.h
+++ b/cpp/density/CorrelationFunction.h
@@ -8,8 +8,8 @@
 #include <tbb/tbb.h>
 
 #include "Box.h"
+#include "NeighborList.h"
 #include "VectorMath.h"
-#include "LinkCell.h"
 
 /*! \file CorrelationFunction.h
     \brief Generic pairwise correlation functions.

--- a/cpp/density/GaussianDensity.h
+++ b/cpp/density/GaussianDensity.h
@@ -8,8 +8,8 @@
 #include <tbb/tbb.h>
 
 #include "Box.h"
-#include "VectorMath.h"
 #include "Index1D.h"
+#include "VectorMath.h"
 
 /*! \file GaussianDensity.h
     \brief Routines for computing Gaussian smeared densities from points.

--- a/cpp/density/LocalDensity.h
+++ b/cpp/density/LocalDensity.h
@@ -9,8 +9,8 @@
 #include <tbb/tbb.h>
 
 #include "Box.h"
-#include "VectorMath.h"
 #include "NeighborList.h"
+#include "VectorMath.h"
 
 /*! \file LocalDensity.h
     \brief Routines for computing local density around a point.

--- a/cpp/density/RDF.h
+++ b/cpp/density/RDF.h
@@ -9,9 +9,8 @@
 #include <tbb/tbb.h>
 
 #include "Box.h"
-#include "VectorMath.h"
 #include "NeighborList.h"
-#include "Index1D.h"
+#include "VectorMath.h"
 
 /*! \file RDF.h
     \brief Routines for computing radial density functions.

--- a/cpp/environment/AngularSeparation.h
+++ b/cpp/environment/AngularSeparation.h
@@ -9,10 +9,8 @@
 #include <ostream>
 #include <tbb/tbb.h>
 
-#include "Box.h"
 #include "VectorMath.h"
-#include "NearestNeighbors.h"
-#include "Index1D.h"
+#include "NeighborList.h"
 
 /*! \file AngularSeparation.h
     \brief Compute the angular separation for each particle.

--- a/cpp/environment/BondOrder.cc
+++ b/cpp/environment/BondOrder.cc
@@ -8,6 +8,7 @@
 #endif
 
 #include "BondOrder.h"
+#include "Index1D.h"
 
 using namespace std;
 using namespace tbb;

--- a/cpp/environment/BondOrder.h
+++ b/cpp/environment/BondOrder.h
@@ -9,9 +9,8 @@
 #include <tbb/tbb.h>
 
 #include "Box.h"
+#include "NeighborList.h"
 #include "VectorMath.h"
-#include "NearestNeighbors.h"
-#include "Index1D.h"
 
 /*! \file BondOrder.h
     \brief Compute the bond order diagram for the system of particles.

--- a/cpp/environment/LocalBondProjection.h
+++ b/cpp/environment/LocalBondProjection.h
@@ -10,9 +10,8 @@
 #include <tbb/tbb.h>
 
 #include "Box.h"
+#include "NeighborList.h"
 #include "VectorMath.h"
-#include "NearestNeighbors.h"
-#include "Index1D.h"
 
 /*! \file LocalBondProjection.h
     \brief Compute the projection of nearest neighbor bonds for each particle onto some

--- a/cpp/environment/LocalDescriptors.cc
+++ b/cpp/environment/LocalDescriptors.cc
@@ -21,17 +21,9 @@ using hoomd::matrix::diagonalize;
 
 namespace freud { namespace environment {
 
-LocalDescriptors::LocalDescriptors(
-        unsigned int neighmax, unsigned int lmax, float rmax, bool negative_m):
-    m_neighmax(neighmax), m_lmax(lmax),
-    m_negative_m(negative_m), m_nn(rmax, neighmax), m_Nref(0), m_nSphs(0)
+LocalDescriptors::LocalDescriptors(unsigned int lmax, bool negative_m):
+    m_lmax(lmax), m_negative_m(negative_m), m_Nref(0), m_nSphs(0)
     {
-    }
-
-
-void LocalDescriptors::computeNList(const box::Box& box, const vec3<float> *r_ref, unsigned int Nref, const vec3<float> *r, unsigned int Np)
-    {
-    m_nn.compute(box, r_ref, Nref, r, Np);
     }
 
 void LocalDescriptors::compute(const box::Box& box, const freud::locality::NeighborList *nlist,
@@ -41,15 +33,6 @@ void LocalDescriptors::compute(const box::Box& box, const freud::locality::Neigh
                                const quat<float> *q_ref,
                                LocalDescriptorOrientation orientation)
     {
-    // legacy API, use internal NearestNeighbors if nlist is a null pointer
-    if(!nlist)
-        {
-        if(m_nn.getNref() != Nref || m_nn.getNp() != Np)
-            throw runtime_error("Must call computeNList() before compute");
-
-        nlist = m_nn.getNeighborList();
-        }
-
     nlist->validate(Nref, Np);
     const size_t *neighbor_list(nlist->getNeighbors());
 

--- a/cpp/environment/LocalDescriptors.h
+++ b/cpp/environment/LocalDescriptors.h
@@ -7,11 +7,9 @@
 #include <memory>
 
 #include "Box.h"
+#include "NeighborList.h"
 #include "VectorMath.h"
-#include "NearestNeighbors.h"
 #include "fsph/src/spherical_harmonics.hpp"
-
-#include "tbb/atomic.h"
 
 /*! \file LocalDescriptors.h
   \brief Computes local descriptors.
@@ -32,18 +30,9 @@ class LocalDescriptors
 public:
     //! Constructor
     //!
-    //! \param neighmax Maximum number of neighbors to compute descriptors for
     //! \param lmax Maximum spherical harmonic l to consider
-    //! \param rmax Initial guess of the maximum radius to look for n_neigh neighbors
     //! \param negative_m whether to calculate Ylm for negative m
-    LocalDescriptors(unsigned int neighmax,
-                     unsigned int lmax, float rmax, bool negative_m);
-
-    //! Get the maximum number of neighbors
-    unsigned int getNeighmax() const
-        {
-        return m_neighmax;
-        }
+    LocalDescriptors(unsigned int lmax, bool negative_m);
 
     //! Get the last number of spherical harmonics computed
     unsigned int getNSphs() const
@@ -62,10 +51,6 @@ public:
         {
         return m_Nref;
         }
-
-    //! Compute the nearest neighbors for each particle
-    void computeNList(const box::Box& box, const vec3<float> *r_ref,
-                      unsigned int Nref, const vec3<float> *r, unsigned int Np);
 
     //! Compute the local neighborhood descriptors given some
     //! positions and the number of particles
@@ -90,10 +75,8 @@ public:
         }
 
 private:
-    unsigned int m_neighmax;          //!< Maximum number of neighbors to calculate
     unsigned int m_lmax;              //!< Maximum spherical harmonic l to calculate
     bool m_negative_m;                //!< true if we should compute Ylm for negative m
-    locality::NearestNeighbors m_nn;  //!< NearestNeighbors to find neighbors with
     unsigned int m_Nref;              //!< Last number of points computed
     unsigned int m_nSphs;             //!< Last number of bond spherical harmonics computed
 

--- a/cpp/environment/MatchEnv.h
+++ b/cpp/environment/MatchEnv.h
@@ -14,9 +14,8 @@
 #include <vector>
 
 #include "Box.h"
+#include "NeighborList.h"
 #include "VectorMath.h"
-#include "Cluster.h"
-#include "NearestNeighbors.h"
 #include "BiMap.h"
 #include "brute_force.h"
 

--- a/cpp/locality/AABB.h
+++ b/cpp/locality/AABB.h
@@ -4,9 +4,9 @@
 #ifndef AABB_H
 #define AABB_H
 
-#include "HOOMDMath.h"
-#include "VectorMath.h"
 #include <algorithm>
+
+#include "VectorMath.h"
 
 /*! \file AABB.h
     \brief Basic AABB routines

--- a/cpp/locality/AABBQuery.cc
+++ b/cpp/locality/AABBQuery.cc
@@ -2,10 +2,10 @@
 // This file is from the freud project, released under the BSD 3-Clause License.
 
 #include <algorithm>
+#include <limits>
 #include <stdexcept>
 #include <tbb/tbb.h>
 #include <tuple>
-#include <limits>
 
 #include "AABBQuery.h"
 

--- a/cpp/locality/AABBQuery.h
+++ b/cpp/locality/AABBQuery.h
@@ -4,15 +4,13 @@
 #ifndef AABBQUERY_H
 #define AABBQUERY_H
 
-#include <vector>
-#include <memory>
 #include <map>
+#include <memory>
+#include <vector>
 
-#include "NeighborQuery.h"
-#include "Box.h"
-#include "NeighborList.h"
-#include "Index1D.h"
 #include "AABBTree.h"
+#include "Box.h"
+#include "NeighborQuery.h"
 
 /*! \file AABBQuery.h
     \brief Build an AABB tree from points and query it for neighbors.

--- a/cpp/locality/AABBTree.h
+++ b/cpp/locality/AABBTree.h
@@ -4,13 +4,12 @@
 #ifndef AABB_TREE_H
 #define AABB_TREE_H
 
-#include "HOOMDMath.h"
-#include "VectorMath.h"
 #include <cstring>
-#include <vector>
 #include <stack>
+#include <vector>
 
 #include "AABB.h"
+#include "VectorMath.h"
 
 /*! \file AABBTree.h
     \brief AABBTree build and query methods

--- a/cpp/locality/AABBTree.h
+++ b/cpp/locality/AABBTree.h
@@ -4,6 +4,7 @@
 #ifndef AABB_TREE_H
 #define AABB_TREE_H
 
+#include <cassert>
 #include <cstring>
 #include <stack>
 #include <vector>

--- a/cpp/locality/LinkCell.cc
+++ b/cpp/locality/LinkCell.cc
@@ -1,12 +1,12 @@
 // Copyright (c) 2010-2019 The Regents of the University of Michigan
 // This file is from the freud project, released under the BSD 3-Clause License.
 
-#include <iostream>
 #include <algorithm>
+#include <cmath>
+#include <iostream>
 #include <stdexcept>
 #include <tbb/tbb.h>
 #include <tuple>
-#include <cmath>
 
 #include "LinkCell.h"
 

--- a/cpp/locality/LinkCell.h
+++ b/cpp/locality/LinkCell.h
@@ -5,12 +5,12 @@
 #define LINKCELL_H
 
 #include <memory>
-#include <vector>
 #include <tbb/concurrent_hash_map.h>
+#include <vector>
 
 #include "Box.h"
-#include "NeighborList.h"
 #include "Index1D.h"
+#include "NeighborList.h"
 #include "NeighborQuery.h"
 
 /*! \file LinkCell.h

--- a/cpp/locality/NearestNeighbors.cc
+++ b/cpp/locality/NearestNeighbors.cc
@@ -9,7 +9,7 @@
 #include <vector>
 
 #include "NearestNeighbors.h"
-#include "HOOMDMatrix.h"
+#include "Index1D.h"
 
 using namespace std;
 using namespace tbb;

--- a/cpp/locality/NearestNeighbors.h
+++ b/cpp/locality/NearestNeighbors.h
@@ -8,10 +8,8 @@
 #include <memory>
 
 #include "Box.h"
-#include "VectorMath.h"
 #include "LinkCell.h"
-#include "Index1D.h"
-
+#include "VectorMath.h"
 #include "tbb/atomic.h"
 
 /*! \file NearestNeighbors.h

--- a/cpp/locality/NeighborQuery.h
+++ b/cpp/locality/NeighborQuery.h
@@ -4,11 +4,12 @@
 #ifndef NEIGHBOR_QUERY_H
 #define NEIGHBOR_QUERY_H
 
+#include <memory>
+#include <stdexcept>
+#include <tbb/tbb.h>
+
 #include "Box.h"
 #include "NeighborList.h"
-#include <stdexcept>
-#include <memory>
-#include <tbb/tbb.h>
 
 /*! \file NeighborQuery.h
     \brief Defines the abstract API for collections of points that can be

--- a/cpp/order/CubaticOrderParameter.cc
+++ b/cpp/order/CubaticOrderParameter.cc
@@ -8,6 +8,7 @@
 #endif
 
 #include "CubaticOrderParameter.h"
+#include "Index1D.h"
 
 using namespace std;
 using namespace tbb;

--- a/cpp/order/CubaticOrderParameter.h
+++ b/cpp/order/CubaticOrderParameter.h
@@ -8,12 +8,9 @@
 #include <ostream>
 #include <tbb/tbb.h>
 
-#include "Box.h"
-#include "VectorMath.h"
 #include "TensorMath.h"
+#include "VectorMath.h"
 #include "saruprng.h"
-#include "NearestNeighbors.h"
-#include "Index1D.h"
 
 /*! \file CubaticOrderParameter.h
     \brief Compute the cubatic order parameter for each particle.

--- a/cpp/order/HexOrderParameter.h
+++ b/cpp/order/HexOrderParameter.h
@@ -11,8 +11,6 @@
 
 #include "Box.h"
 #include "VectorMath.h"
-#include "NearestNeighbors.h"
-#include "Index1D.h"
 
 /*! \file HexOrderParameter.h
     \brief Compute the hexatic order parameter for each particle.

--- a/cpp/order/HexOrderParameter.h
+++ b/cpp/order/HexOrderParameter.h
@@ -10,6 +10,7 @@
 #include <tbb/tbb.h>
 
 #include "Box.h"
+#include "NeighborList.h"
 #include "VectorMath.h"
 
 /*! \file HexOrderParameter.h

--- a/cpp/order/LocalQl.h
+++ b/cpp/order/LocalQl.h
@@ -11,6 +11,7 @@
 #include <tbb/tbb.h>
 
 #include "Box.h"
+#include "NeighborList.h"
 #include "VectorMath.h"
 #include "fsph/src/spherical_harmonics.hpp"
 

--- a/cpp/order/LocalQl.h
+++ b/cpp/order/LocalQl.h
@@ -12,7 +12,6 @@
 
 #include "Box.h"
 #include "VectorMath.h"
-#include "LinkCell.h"
 #include "fsph/src/spherical_harmonics.hpp"
 
 /*! \file LocalQl.h

--- a/cpp/order/NematicOrderParameter.cc
+++ b/cpp/order/NematicOrderParameter.cc
@@ -9,7 +9,6 @@
 #endif
 
 #include "Eigen/Eigen/Dense"
-
 #include "Index1D.h"
 #include "NematicOrderParameter.h"
 

--- a/cpp/order/NematicOrderParameter.cc
+++ b/cpp/order/NematicOrderParameter.cc
@@ -10,6 +10,7 @@
 
 #include "Eigen/Eigen/Dense"
 
+#include "Index1D.h"
 #include "NematicOrderParameter.h"
 
 using namespace std;

--- a/cpp/order/NematicOrderParameter.h
+++ b/cpp/order/NematicOrderParameter.h
@@ -10,9 +10,6 @@
 
 #include "Box.h"
 #include "VectorMath.h"
-#include "TensorMath.h"
-#include "NearestNeighbors.h"
-#include "Index1D.h"
 
 /*! \file NematicOrderParameter.h
     \brief Compute the nematic order parameter for each particle

--- a/cpp/order/RotationalAutocorrelation.h
+++ b/cpp/order/RotationalAutocorrelation.h
@@ -10,8 +10,6 @@
 #include <tbb/tbb.h>
 
 #include "VectorMath.h"
-#include "HOOMDMath.h"
-#include "Index1D.h"
 
 /*! \file RotationalAutocorrelation.h
     \brief Defines the RotationalAutocorrelation class, which computes the total

--- a/cpp/order/SolLiq.h
+++ b/cpp/order/SolLiq.h
@@ -14,9 +14,8 @@
 #include <vector>
 
 #include "Box.h"
-#include "VectorMath.h"
 #include "Cluster.h"
-#include "LinkCell.h"
+#include "VectorMath.h"
 #include "fsph/src/spherical_harmonics.hpp"
 
 namespace freud { namespace order {

--- a/cpp/order/TransOrderParameter.h
+++ b/cpp/order/TransOrderParameter.h
@@ -10,6 +10,7 @@
 #include <tbb/tbb.h>
 
 #include "Box.h"
+#include "NeighborList.h"
 #include "VectorMath.h"
 
 /*! \file TransOrderParameter.h

--- a/cpp/order/TransOrderParameter.h
+++ b/cpp/order/TransOrderParameter.h
@@ -11,8 +11,6 @@
 
 #include "Box.h"
 #include "VectorMath.h"
-#include "NearestNeighbors.h"
-#include "Index1D.h"
 
 /*! \file TransOrderParameter.h
     \brief Compute the translational order parameter for each particle

--- a/cpp/pmft/PMFT.h
+++ b/cpp/pmft/PMFT.h
@@ -10,9 +10,6 @@
 
 #include "Box.h"
 #include "VectorMath.h"
-#include "LinkCell.h"
-
-#include "Index1D.h"
 
 /*! \internal
     \file PMFT.h

--- a/cpp/pmft/PMFTR12.cc
+++ b/cpp/pmft/PMFTR12.cc
@@ -6,6 +6,7 @@
 #include <emmintrin.h>
 #endif
 
+#include "Index1D.h"
 #include "PMFTR12.h"
 
 using namespace std;

--- a/cpp/pmft/PMFTR12.h
+++ b/cpp/pmft/PMFTR12.h
@@ -9,9 +9,8 @@
 #include <tbb/tbb.h>
 
 #include "Box.h"
-#include "VectorMath.h"
-#include "LinkCell.h"
 #include "PMFT.h"
+#include "VectorMath.h"
 
 /*! \file PMFTR12.h
     \brief Routines for computing potential of mean force and torque in R12 coordinates

--- a/cpp/pmft/PMFTR12.h
+++ b/cpp/pmft/PMFTR12.h
@@ -9,6 +9,7 @@
 #include <tbb/tbb.h>
 
 #include "Box.h"
+#include "NeighborList.h"
 #include "PMFT.h"
 #include "VectorMath.h"
 

--- a/cpp/pmft/PMFTXY2D.cc
+++ b/cpp/pmft/PMFTXY2D.cc
@@ -6,6 +6,7 @@
 #include <emmintrin.h>
 #endif
 
+#include "Index1D.h"
 #include "PMFTXY2D.h"
 
 using namespace std;

--- a/cpp/pmft/PMFTXY2D.h
+++ b/cpp/pmft/PMFTXY2D.h
@@ -9,10 +9,8 @@
 #include <tbb/tbb.h>
 
 #include "Box.h"
-#include "VectorMath.h"
-#include "LinkCell.h"
-#include "Index1D.h"
 #include "PMFT.h"
+#include "VectorMath.h"
 
 /*! \file PMFTXY2D.h
     \brief Routines for computing 2D potential of mean force in XY coordinates

--- a/cpp/pmft/PMFTXY2D.h
+++ b/cpp/pmft/PMFTXY2D.h
@@ -9,6 +9,7 @@
 #include <tbb/tbb.h>
 
 #include "Box.h"
+#include "NeighborList.h"
 #include "PMFT.h"
 #include "VectorMath.h"
 

--- a/cpp/pmft/PMFTXYT.cc
+++ b/cpp/pmft/PMFTXYT.cc
@@ -6,6 +6,7 @@
 #include <emmintrin.h>
 #endif
 
+#include "Index1D.h"
 #include "PMFTXYT.h"
 
 using namespace std;

--- a/cpp/pmft/PMFTXYT.h
+++ b/cpp/pmft/PMFTXYT.h
@@ -9,6 +9,7 @@
 #include <tbb/tbb.h>
 
 #include "Box.h"
+#include "NeighborList.h"
 #include "PMFT.h"
 #include "VectorMath.h"
 

--- a/cpp/pmft/PMFTXYT.h
+++ b/cpp/pmft/PMFTXYT.h
@@ -9,9 +9,8 @@
 #include <tbb/tbb.h>
 
 #include "Box.h"
-#include "VectorMath.h"
-#include "LinkCell.h"
 #include "PMFT.h"
+#include "VectorMath.h"
 
 /*! \file PMFTXYT.h
     \brief Routines for computing potential of mean force and torque in XYT coordinates

--- a/cpp/pmft/PMFTXYZ.cc
+++ b/cpp/pmft/PMFTXYZ.cc
@@ -6,6 +6,7 @@
 #include <emmintrin.h>
 #endif
 
+#include "Index1D.h"
 #include "PMFTXYZ.h"
 
 using namespace std;

--- a/cpp/pmft/PMFTXYZ.h
+++ b/cpp/pmft/PMFTXYZ.h
@@ -9,6 +9,7 @@
 #include <tbb/tbb.h>
 
 #include "Box.h"
+#include "NeighborList.h"
 #include "PMFT.h"
 #include "VectorMath.h"
 

--- a/cpp/pmft/PMFTXYZ.h
+++ b/cpp/pmft/PMFTXYZ.h
@@ -9,10 +9,8 @@
 #include <tbb/tbb.h>
 
 #include "Box.h"
-#include "VectorMath.h"
-#include "LinkCell.h"
-#include "Index1D.h"
 #include "PMFT.h"
+#include "VectorMath.h"
 
 /*! \file PMFTXYZ.h
     \brief Routines for computing 3D potential of mean force in XYZ coordinates

--- a/cpp/util/BiMap.h
+++ b/cpp/util/BiMap.h
@@ -1,14 +1,14 @@
 #ifndef BIMAP_H
 #define BIMAP_H
 
-#include <set>
-#include <vector>
-#include <memory>
-#include <utility>
-#include <cstddef>
-#include <assert.h>
 #include <algorithm>
+#include <assert.h>
+#include <cstddef>
+#include <memory>
+#include <set>
 #include <type_traits>
+#include <utility>
+#include <vector>
 
 /* BiMap container modelled after Boost::BiMap with templatization.
  *

--- a/cpp/util/TensorMath.h
+++ b/cpp/util/TensorMath.h
@@ -4,7 +4,7 @@
 #ifndef TENSOR_MATH_H
 #define TENSOR_MATH_H
 
-#include "HOOMDMath.h"
+#include "VectorMath.h"
 
 template < class Real >
 struct tensor4

--- a/doc/source/environment.rst
+++ b/doc/source/environment.rst
@@ -29,7 +29,7 @@ Local Descriptors
 =================
 
 .. autoclass:: freud.environment.LocalDescriptors(num_neighbors, lmax, rmax, negative_m=True)
-    :members: compute, computeNList
+    :members: compute
 
 Match Environments
 ==================

--- a/freud/_environment.pxd
+++ b/freud/_environment.pxd
@@ -41,16 +41,11 @@ cdef extern from "LocalDescriptors.h" namespace "freud::environment":
 
     cdef cppclass LocalDescriptors:
         LocalDescriptors(unsigned int,
-                         unsigned int,
-                         float,
                          bool)
         unsigned int getNSphs() const
         unsigned int getLMax() const
         unsigned int getSphWidth() const
         unsigned int getNP()
-        void computeNList(const freud._box.Box &,
-                          const vec3[float]*, unsigned int,
-                          const vec3[float]*, unsigned int) nogil except +
         void compute(
             const freud._box.Box &, const freud._locality.NeighborList*,
             unsigned int, const vec3[float]*,

--- a/freud/environment.pyx
+++ b/freud/environment.pyx
@@ -339,11 +339,6 @@ cdef class LocalDescriptors:
     than this number, the last one or more rows of bond spherical
     harmonics for each particle will not be set.
 
-    .. note: **You must always call computeNList before calling compute, the
-             NeighborList will not be populated until this is called. However,
-             the compute method must be called to actually calculate the
-             descriptors.**
-
     .. moduleauthor:: Matthew Spellings <mspells@umich.edu>
 
     Args:
@@ -384,7 +379,7 @@ cdef class LocalDescriptors:
 
     def __cinit__(self, num_neighbors, lmax, rmax, negative_m=True):
         self.thisptr = new freud._environment.LocalDescriptors(
-            num_neighbors, lmax, rmax, negative_m)
+            lmax, negative_m)
         self.num_neigh = num_neighbors
         self.rmax = rmax
         self.lmax = lmax
@@ -393,57 +388,16 @@ cdef class LocalDescriptors:
     def __dealloc__(self):
         del self.thisptr
 
-    def computeNList(self, box, points_ref, points=None):
-        R"""Compute the neighbor list for bonds from a set of source points to
-        a set of destination points.
-
-        Args:
-            box (:class:`freud.box.Box`):
-                Simulation box.
-            points_ref ((:math:`N_{particles}`, 3) :class:`numpy.ndarray`):
-                Source points to calculate the order parameter.
-            points ((:math:`N_{particles}`, 3) :class:`numpy.ndarray`, optional):
-                Destination points to calculate the order parameter
-                (Default value = :code:`None`).
-        """  # noqa: E501
-        cdef freud.box.Box b = freud.common.convert_box(box)
-
-        points_ref = freud.common.convert_array(
-            points_ref, 2, dtype=np.float32, contiguous=True,
-            array_name="points_ref")
-        if points_ref.shape[1] != 3:
-            raise TypeError('points_ref should be an Nx3 array')
-
-        if points is None:
-            points = points_ref
-
-        points = freud.common.convert_array(
-            points, 2, dtype=np.float32, contiguous=True, array_name="points")
-        if points.shape[1] != 3:
-            raise TypeError('points should be an Nx3 array')
-
-        cdef const float[:, ::1] l_points_ref = points_ref
-        cdef unsigned int nRef = l_points_ref.shape[0]
-        cdef const float[:, ::1] l_points = points
-        cdef unsigned int nP = l_points.shape[0]
-        with nogil:
-            self.thisptr.computeNList(
-                dereference(b.thisptr), <vec3[float]*> &l_points_ref[0, 0],
-                nRef, <vec3[float]*> &l_points[0, 0], nP)
-        return self
-
     def compute(self, box, unsigned int num_neighbors, points_ref, points=None,
                 orientations=None, mode='neighborhood', nlist=None):
         R"""Calculates the local descriptors of bonds from a set of source
         points to a set of destination points.
 
-        .. note: **You must always call computeNList before this method.**
-
         Args:
             box (:class:`freud.box.Box`):
                 Simulation box.
             num_neighbors (unsigned int):
-                Number of neighbors to compute with or to limit to, if the
+                Number of nearest neighbors to compute with or to limit to, if the
                 neighbor list is precomputed.
             points_ref ((:math:`N_{particles}`, 3) :class:`numpy.ndarray`):
                 Source points to calculate the order parameter.
@@ -460,8 +414,7 @@ cdef class LocalDescriptors:
                 particle orientations, or :code:`'global'` to not rotate
                 environments (Default value = :code:`'neighborhood'`).
             nlist (:class:`freud.locality.NeighborList`, optional):
-                NeighborList to use to find bonds or :code:`'precomputed'` if
-                using :meth:`~.computeNList` (Default value = :code:`None`).
+                NeighborList to use to find bonds (Default value = :code:`None`).
         """  # noqa: E501
         cdef freud.box.Box b = freud.common.convert_box(box)
 
@@ -515,17 +468,15 @@ cdef class LocalDescriptors:
 
         self.num_neigh = num_neighbors
 
-        cdef freud.locality.NeighborList nlist_ = None
-        if not nlist == 'precomputed':
-            defaulted_nlist = freud.locality.make_default_nlist_nn(
-                b, points_ref, points, self.num_neigh, nlist,
-                True, self.rmax)
-            nlist_ = defaulted_nlist[0]
+        defaulted_nlist = freud.locality.make_default_nlist_nn(
+            b, points_ref, points, self.num_neigh, nlist,
+            True, self.rmax)
+        cdef freud.locality.NeighborList nlist_ = defaulted_nlist[0]
 
         with nogil:
             self.thisptr.compute(
                 dereference(b.thisptr),
-                nlist_.get_ptr() if nlist_ is not None else NULL,
+                nlist_.get_ptr(),
                 num_neighbors,
                 <vec3[float]*> &l_points_ref[0, 0],
                 nRef, <vec3[float]*> &l_points[0, 0], nP,

--- a/setup.py
+++ b/setup.py
@@ -341,20 +341,15 @@ modules = [m.replace(os.path.sep, '.') for m in modules]
 
 # Source files required for all modules.
 sources_in_all = [
-    os.path.join("cpp", "util", "HOOMDMatrix.cc"),
-    os.path.join("cpp", "locality", "NeighborQuery.cc"),
-    os.path.join("cpp", "locality", "AABBQuery.cc"),
-    os.path.join("cpp", "locality", "LinkCell.cc"),
-    os.path.join("cpp", "locality", "NearestNeighbors.cc"),
     os.path.join("cpp", "locality", "NeighborList.cc"),
-    os.path.join("cpp", "box", "Box.cc")
 ]
 
 # Any source files required only for specific modules.
 # Dict keys should be specified as the module name without
 # "freud.", i.e. not the fully qualified name.
 extra_module_sources = dict(
-    order=[os.path.join("cpp", "cluster", "Cluster.cc")]
+    environment=[os.path.join("cpp", "util", "HOOMDMatrix.cc")],
+    order=[os.path.join("cpp", "cluster", "Cluster.cc")],
 )
 
 extensions = []

--- a/setup.py
+++ b/setup.py
@@ -340,16 +340,29 @@ modules = [f.replace(ext, '') for f in files]
 modules = [m.replace(os.path.sep, '.') for m in modules]
 
 # Source files required for all modules.
-sources_in_all = [
-    os.path.join("cpp", "locality", "NeighborList.cc"),
-]
+sources_in_all = []
 
 # Any source files required only for specific modules.
 # Dict keys should be specified as the module name without
 # "freud.", i.e. not the fully qualified name.
 extra_module_sources = dict(
-    environment=[os.path.join("cpp", "util", "HOOMDMatrix.cc")],
-    order=[os.path.join("cpp", "cluster", "Cluster.cc")],
+    cluster=[
+        os.path.join("cpp", "locality", "NeighborList.cc"),
+    ],
+    density=[
+        os.path.join("cpp", "locality", "NeighborList.cc"),
+    ],
+    environment=[
+        os.path.join("cpp", "util", "HOOMDMatrix.cc"),
+        os.path.join("cpp", "locality", "NeighborList.cc"),
+    ],
+    order=[
+        os.path.join("cpp", "cluster", "Cluster.cc"),
+        os.path.join("cpp", "locality", "NeighborList.cc"),
+    ],
+    pmft=[
+        os.path.join("cpp", "locality", "NeighborList.cc"),
+    ],
 )
 
 extensions = []

--- a/tests/test_environment_LocalDescriptors.py
+++ b/tests/test_environment_LocalDescriptors.py
@@ -18,7 +18,6 @@ class TestLocalDescriptors(unittest.TestCase):
         positions.flags['WRITEABLE'] = False
 
         comp = LocalDescriptors(Nneigh, lmax, rmax, True)
-        comp.computeNList(box, positions)
         comp.compute(box, Nneigh, positions)
 
         self.assertEqual(comp.sph.shape[0], N*Nneigh)
@@ -40,7 +39,6 @@ class TestLocalDescriptors(unittest.TestCase):
                                       size=(N, 3)).astype(np.float32)
 
         comp = LocalDescriptors(Nneigh, lmax, .5, True)
-        comp.computeNList(box, positions)
         comp.compute(box, Nneigh, positions, mode='global')
 
         sphs = comp.sph
@@ -61,7 +59,6 @@ class TestLocalDescriptors(unittest.TestCase):
                                        axis=-1))[:, np.newaxis]
 
         comp = LocalDescriptors(Nneigh, lmax, .5, True)
-        comp.computeNList(box, positions)
 
         with self.assertRaises(RuntimeError):
             comp.compute(box, Nneigh, positions, mode='particle_local')
@@ -84,7 +81,6 @@ class TestLocalDescriptors(unittest.TestCase):
                                       size=(N, 3)).astype(np.float32)
 
         comp = LocalDescriptors(Nneigh, lmax, .5, True)
-        comp.computeNList(box, positions)
 
         with self.assertRaises(RuntimeError):
             comp.compute(box, Nneigh, positions, mode='particle_local_wrong')
@@ -102,7 +98,6 @@ class TestLocalDescriptors(unittest.TestCase):
                                        size=(N//3, 3)).astype(np.float32)
 
         comp = LocalDescriptors(Nneigh, lmax, .5, True)
-        comp.computeNList(box, positions, positions2)
         comp.compute(box, Nneigh, positions, positions2)
         sphs = comp.sph
         self.assertEqual(sphs.shape[0], N*Nneigh)


### PR DESCRIPTION
## Motivation and Context
Build times of `freud` are unnecessarily long, partly because we're including and compiling more code than we really need for the library to function. I removed a bunch of extra includes.

I also removed the `computeNList` function from `LocalDescriptors` since it is superseded by newer ways of handling neighbor finding.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds or improves functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/glotzerlab/freud/blob/master/CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have updated the [Changelog](https://github.com/glotzerlab/freud/blob/master/ChangeLog.md).
