### PR TITLE
Always call setNumThreads at import time

### DIFF
--- a/freud/parallel.pyx
+++ b/freud/parallel.pyx
@@ -4,16 +4,12 @@
 R"""
 The :class:`freud.parallel` module controls the parallelization behavior of
 freud, determining how many threads the TBB-enabled parts of freud will use.
-By default, freud tries to use all available threads for parallelization unless
-directed otherwise.
+freud uses all available threads for parallelization unless directed otherwise.
 """
 
 cimport freud._parallel
 
-# Override TBB's default autoselection. This is necessary because once the
-# automatic selection runs, the user cannot change it.
 _numThreads = 0
-setNumThreads(_numThreads)
 
 
 def getNumThreads():
@@ -62,3 +58,8 @@ class NumThreads:
 
     def __exit__(self, *args):
         setNumThreads(self.restore_N)
+
+
+# Override TBB's default autoselection. This is necessary because once the
+# automatic selection runs, the user cannot change it.
+setNumThreads(0)

--- a/freud/parallel.pyx
+++ b/freud/parallel.pyx
@@ -5,21 +5,20 @@ R"""
 The :class:`freud.parallel` module controls the parallelization behavior of
 freud, determining how many threads the TBB-enabled parts of freud will use.
 By default, freud tries to use all available threads for parallelization unless
-directed otherwise, with one exception.
+directed otherwise.
 """
 
-import platform
-import re
 cimport freud._parallel
 
 # Override TBB's default autoselection. This is necessary because once the
 # automatic selection runs, the user cannot change it.
-
-# On nyx/flux, default to 1 thread. On all other systems, default to as many
-# cores as are available. Users on nyx/flux can opt in to more threads by
-# calling setNumThreads again after initialization.
-
 _numThreads = 0
+setNumThreads(_numThreads)
+
+
+def getNumThreads():
+    global _numThreads
+    return _numThreads
 
 
 def setNumThreads(nthreads=None):
@@ -40,11 +39,6 @@ def setNumThreads(nthreads=None):
 
     cdef unsigned int cNthreads = nthreads
     freud._parallel.setNumThreads(cNthreads)
-
-
-if (re.match("flux.", platform.node()) is not None) or (
-        re.match("nyx.", platform.node()) is not None):
-    setNumThreads(1)
 
 
 class NumThreads:

--- a/tests/test_parallel.py
+++ b/tests/test_parallel.py
@@ -24,6 +24,17 @@ class TestParallel(unittest.TestCase):
             self.assertEqual(freud.parallel._numThreads, 10)
         self.assertEqual(freud.parallel._numThreads, 0)
 
+        self.assertEqual(freud.parallel.getNumThreads(), 0)
+
+        freud.parallel.setNumThreads(3)
+        self.assertEqual(freud.parallel.getNumThreads(), 3)
+
+        freud.parallel.setNumThreads(1)
+        self.assertEqual(freud.parallel.getNumThreads(), 1)
+        with freud.parallel.NumThreads(2):
+            self.assertEqual(freud.parallel.getNumThreads(), 2)
+        self.assertEqual(freud.parallel.getNumThreads(), 1)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Description
We must call `setNumThreads` at import time, to ensure that the thread count can be altered at runtime.

I added a function `getNumThreads`. I also removed the code that is specific to setting 1 thread for nyx/flux.

## Motivation
Currently parallelism isn't working as expected in freud. See #283. 

## How Has This Been Tested?
@jinsoo960 will test this. 😄
- [x] Write a test that ensures get/setNumThreads work as expected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds or improves functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/glotzerlab/freud/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the [Changelog](https://github.com/glotzerlab/freud/blob/master/ChangeLog.md).
