### PR TITLE
Fix wheel building process

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -190,7 +190,8 @@ references:
               rm -f PKG-INFO
               "${PYBIN}/python" -m pip install . --no-deps --ignore-installed -v --progress-bar=off -q
 
-              "${PYBIN}/pip" install -r ~/ci/freud/requirements.txt --progress-bar=off
+              # Force installation of version of SciPy that works with old NumPy.
+              "${PYBIN}/pip" install scipy==1.2.1 --progress-bar=off
               "${PYBIN}/pip" wheel ~/ci/freud/ -w ~/wheelhouse/ --no-deps --no-build-isolation --no-use-pep517
             done
 
@@ -248,6 +249,7 @@ references:
                 pyenv install ${VERSION}
                 pyenv global ${VERSION}
 
+                pip install --upgrade pip
                 pip install cython --no-deps --ignore-installed -q --progress-bar=off
                 rm -rf numpy-1.10.4
                 curl -sSLO https://github.com/numpy/numpy/archive/v1.10.4.tar.gz
@@ -255,10 +257,11 @@ references:
                 cd numpy-1.10.4
                 rm -f numpy/random/mtrand/mtrand.c
                 rm -f PKG-INFO
-                "${PYBIN}/python" -m pip install . --no-deps --ignore-installed -v --progress-bar=off -q
+                pip install . --no-deps --ignore-installed -v -q --progress-bar=off
 
-                pip install -r ~/ci/freud/requirements.txt
-                pip install wheel delocate
+              # Force installation of version of SciPy that works with old NumPy.
+                pip install scipy==1.2.1 --progress-bar=off
+                pip install wheel delocate --progress-bar=off
                 pip wheel ~/ci/freud/ -w ~/wheelhouse/ --no-deps --no-build-isolation --no-use-pep517
             done
 
@@ -299,6 +302,9 @@ jobs:
     <<: *build_and_test_with_cov
 
   pypi-linux-wheels:
+    environment:
+      # Force clone over https instead of git.
+      CIRCLE_REPOSITORY_URL: https://github.com/glotzerlab/freud
     <<: *container_manylinux
     <<: *build_linux_wheels
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -197,14 +197,14 @@ references:
 
             # Update RPath for wheels
             for whl in ~/wheelhouse/freud*.whl; do
-                auditwheel repair "$whl" -w ~/ci/freud/wheelhouse/
+              auditwheel repair "$whl" -w ~/ci/freud/wheelhouse/
             done
 
             # Install from and test all wheels
             for PYBIN in /opt/python/*/bin/; do
-                "${PYBIN}/python" -m pip install freud_analysis --no-deps --no-index -f ~/ci/freud/wheelhouse
-                cd ~/ci/freud/tests
-                "${PYBIN}/python" -m unittest discover . -v
+              "${PYBIN}/python" -m pip install freud_analysis --no-deps --no-index -f ~/ci/freud/wheelhouse
+              cd ~/ci/freud/tests
+              "${PYBIN}/python" -m unittest discover . -v
             done
 
             # Build source distribution using whichever Python appears last
@@ -245,37 +245,37 @@ references:
 
             # Build wheels
             for VERSION in ${PY_VERSIONS[@]}; do
-                echo "Building for Python ${VERSION}"
-                pyenv install ${VERSION}
-                pyenv global ${VERSION}
+              echo "Building for Python ${VERSION}"
+              pyenv install ${VERSION}
+              pyenv global ${VERSION}
 
-                pip install --upgrade pip
-                pip install cython --no-deps --ignore-installed -q --progress-bar=off
-                rm -rf numpy-1.10.4
-                curl -sSLO https://github.com/numpy/numpy/archive/v1.10.4.tar.gz
-                tar -xzf v1.10.4.tar.gz
-                cd numpy-1.10.4
-                rm -f numpy/random/mtrand/mtrand.c
-                rm -f PKG-INFO
-                pip install . --no-deps --ignore-installed -v -q --progress-bar=off
+              pip install --upgrade pip
+              pip install cython --no-deps --ignore-installed -q --progress-bar=off
+              rm -rf numpy-1.10.4
+              curl -sSLO https://github.com/numpy/numpy/archive/v1.10.4.tar.gz
+              tar -xzf v1.10.4.tar.gz
+              cd numpy-1.10.4
+              rm -f numpy/random/mtrand/mtrand.c
+              rm -f PKG-INFO
+              pip install . --no-deps --ignore-installed -v -q --progress-bar=off
 
-              # Force installation of version of SciPy that works with old NumPy.
-                pip install scipy==1.2.1 --progress-bar=off
-                pip install wheel delocate --progress-bar=off
-                pip wheel ~/ci/freud/ -w ~/wheelhouse/ --no-deps --no-build-isolation --no-use-pep517
+              # Force installation of SciPy version that works with old NumPy.
+              pip install scipy==1.2.1 --progress-bar=off
+              pip install wheel delocate --progress-bar=off
+              pip wheel ~/ci/freud/ -w ~/wheelhouse/ --no-deps --no-build-isolation --no-use-pep517
             done
 
             # Update RPath for wheels
             for whl in ~/wheelhouse/freud*.whl; do
-                delocate-wheel "$whl" -w ~/ci/freud/wheelhouse/
+              delocate-wheel "$whl" -w ~/ci/freud/wheelhouse/
             done
 
             # Install from and test all wheels
             for VERSION in ${PY_VERSIONS[@]}; do
-                pyenv global ${VERSION}
-                pip install freud_analysis --no-deps --no-index -f ~/ci/freud/wheelhouse
-                cd ~/ci/freud/tests
-                python -m unittest discover . -v
+              pyenv global ${VERSION}
+              pip install freud_analysis --no-deps --no-index -f ~/ci/freud/wheelhouse
+              cd ~/ci/freud/tests
+              python -m unittest discover . -v
             done
 
             pip install --user twine
@@ -303,7 +303,7 @@ jobs:
 
   pypi-linux-wheels:
     environment:
-      # Force clone over https instead of git.
+      # Force clone over https instead of ssh.
       CIRCLE_REPOSITORY_URL: https://github.com/glotzerlab/freud
     <<: *container_manylinux
     <<: *build_linux_wheels

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 numpy
 scipy
-six


### PR DESCRIPTION
Use correct Python binary in Mac and update pip to support progress bars. Force linux wheels to clone over http instead of ssh (default changed in CircleCI v2). Remove unnecessary requirement six