### PR TITLE
Update formatting of several repo documents and remove unused imports.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,10 +12,6 @@ freud.egg-info
 __pycache__
 build
 dist
-cpp/CMakeLists.txt.orig
-cpp/module.cc.orig
-py/freud/__init__.py.orig
-py/freud/trajectory.py.orig
 doc/build/*
 doc/_build/*
 *.so

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,7 +34,9 @@ of _freud_.
 
 ## Base your work off the correct branch
 
-Bug fixes should be based on `maint`. New features should be based on `master`.
+Use the [OneFlow](https://www.endoflineblog.com/oneflow-a-git-branching-model-and-workflow) model of development:
+  * Both new features and bug fixes should be developed in branches based on `master`.
+  * Hotfixes (critical bugs that need to be released *fast*) should be developed in a branch based on the latest tagged release.
 
 ## Propose a single set of related changes
 
@@ -93,7 +95,7 @@ Include examples on using new functionality.
 
 ## Document version status
 
-Each user-facing python class, method, etc... with a docstring should have [versionadded, versionchanged, and
+Each user-facing Python class, method, etc... with a docstring should have [versionadded, versionchanged, and
 deprecated sphinx paragraphs](https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html#directive-versionadded) so that users will be aware of
 how functionality changes from version to version.
 

--- a/ContributorAgreement.md
+++ b/ContributorAgreement.md
@@ -1,29 +1,28 @@
-freud Contributor Agreement
+# freud Contributor Agreement
 
 These terms apply to your contribution to the freud Open Source Project ("Project") owned or managed by the Regents of the University of Michigan ("Michigan"), and set out the intellectual property rights you grant to Michigan in the contributed materials. If this contribution is on behalf of a company, the term "you" will also mean the company you identify below. If you agree to be bound by these terms, fill in the information requested below and provide your signature.
 
 1. The term "contribution" means any source code, object code, patch, tool, sample, graphic, specification, manual, documentation, or any other material posted or submitted by you to a project.
-1. With respect to any worldwide copyrights, or copyright applications and registrations, in your contribution:
+2. With respect to any worldwide copyrights, or copyright applications and registrations, in your contribution:
     * you hereby assign to Michigan joint ownership, and to the extent that such assignment is or becomes invalid, ineffective or unenforceable, you hereby grant to Michigan a perpetual, irrevocable, non-exclusive, worldwide, no-charge, royalty-free, unrestricted license to exercise all rights under those copyrights. This includes, at Michigan's option, the right to sublicense these same rights to third parties through multiple levels of sublicensees or other licensing arrangements;
     * you agree that both Michigan and you can do all things in relation to your contribution as if each of us were the sole owners, and if one of us makes a derivative work of your contribution, the one who makes the derivative work (or has it made) will be the sole owner of that derivative work;
     * you agree that you will not assert any moral rights in your contribution against us, our licensees or transferees;
     * you agree that we may register a copyright in your contribution and exercise all ownership rights associated with it; and
     * you agree that neither of us has any duty to consult with, obtain the consent of, pay or render an accounting to the other for any use or distribution of your contribution.
-1. With respect to any patents you own, or that you can license without payment to any third party, you hereby grant to Michigan a perpetual, irrevocable, non-exclusive, worldwide, no-charge, royalty-free license to:
+3. With respect to any patents you own, or that you can license without payment to any third party, you hereby grant to Michigan a perpetual, irrevocable, non-exclusive, worldwide, no-charge, royalty-free license to:
     * make, have made, use, sell, offer to sell, import, and otherwise transfer your contribution in whole or in part, alone or in combination with or included in any product, work or materials arising out of the project to which your contribution was submitted; and
     * at Michigan's option, to sublicense these same rights to third parties through multiple levels of sublicensees or other licensing arrangements.
-1. Except as set out above, you keep all right, title, and interest in your contribution. The rights that you grant to Michigan under these terms are effective on the date you first submitted a contribution to Michigan, even if your submission took place before the date you sign these terms. Any contribution Michigan makes available under any license will also be made available under a suitable Free Software Foundation or Open Source Initiative approved license.
-1. With respect to your contribution, you represent that:
+4. Except as set out above, you keep all right, title, and interest in your contribution. The rights that you grant to Michigan under these terms are effective on the date you first submitted a contribution to Michigan, even if your submission took place before the date you sign these terms. Any contribution Michigan makes available under any license will also be made available under a suitable Free Software Foundation or Open Source Initiative approved license.
+5. With respect to your contribution, you represent that:
     * it is an original work and that you can legally grant the rights set out in these terms;
     * it does not to the best of your knowledge violate any third party's copyrights, trademarks, patents, or other intellectual property rights; and
 you are authorized to sign this contract on behalf of your company (if identified below).
-1. The terms will be governed by the laws of the State of Michigan and applicable U.S. Federal Law. Any choice of law rules will not apply.
+6. The terms will be governed by the laws of the State of Michigan and applicable U.S. Federal Law. Any choice of law rules will not apply.
 
-** By making contribution, you electronically sign and agree to the terms of the freud Contributor Agreement.**
+**By making contribution, you electronically sign and agree to the terms of the freud Contributor Agreement.**
 
 ![by-sa.png](https://licensebuttons.net/l/by-sa/3.0/88x31.png)
 
 Based on the Sun Contributor Agreement - version 1.5.
 This document is licensed under a Creative Commons Attribution-Share Alike 3.0 Unported License
 https://creativecommons.org/licenses/by-sa/3.0/
-

--- a/benchmarks/benchmarker.py
+++ b/benchmarks/benchmarker.py
@@ -1,10 +1,8 @@
-import numpy as np
 import git
 import json
 import os
 import argparse
 import sys
-import unittest
 import importlib
 
 

--- a/freud/box.pyx
+++ b/freud/box.pyx
@@ -485,8 +485,8 @@ cdef class Box:
                            [0, 0, self.Lz]])
 
     def __repr__(self):
-        return ("freud.box.{cls}(Lx={Lx}, Ly={Ly}, Lz={Lz}, " +
-                "xy={xy}, xz={xz}, yz={yz}, " +
+        return ("freud.box.{cls}(Lx={Lx}, Ly={Ly}, Lz={Lz}, "
+                "xy={xy}, xz={xz}, yz={yz}, "
                 "is2D={is2D})").format(cls=type(self).__name__,
                                        **self.to_dict(),
                                        is2D=self.is2D())

--- a/freud/cluster.pyx
+++ b/freud/cluster.pyx
@@ -159,7 +159,7 @@ cdef class Cluster(Compute):
         return cluster_keys
 
     def __repr__(self):
-        return ("freud.cluster.{cls}(box={box}, " +
+        return ("freud.cluster.{cls}(box={box}, "
                 "rcut={rcut})").format(cls=type(self).__name__,
                                        box=self.m_box.__repr__(),
                                        rcut=self.rmax)

--- a/freud/density.pyx
+++ b/freud/density.pyx
@@ -559,13 +559,13 @@ cdef class GaussianDensity(Compute):
 
     def __repr__(self):
         if len(self.arglist) == 3:
-            return ("freud.density.{cls}({width}, " +
+            return ("freud.density.{cls}({width}, "
                     "{r_cut}, {sigma})").format(cls=type(self).__name__,
                                                 width=self.arglist[0],
                                                 r_cut=self.arglist[1],
                                                 sigma=self.arglist[2])
         elif len(self.arglist) == 5:
-            return ("freud.density.{cls}({width_x}, {width_y}, {width_z}, " +
+            return ("freud.density.{cls}({width_x}, {width_y}, {width_z}, "
                     "{r_cut}, {sigma})").format(cls=type(self).__name__,
                                                 width_x=self.arglist[0],
                                                 width_y=self.arglist[1],
@@ -709,7 +709,7 @@ cdef class LocalDensity(Compute):
         return np.asarray(num_neighbors)
 
     def __repr__(self):
-        return ("freud.density.{cls}(r_cut={r_cut}, volume={volume}, " +
+        return ("freud.density.{cls}(r_cut={r_cut}, volume={volume}, "
                 "diameter={diameter})").format(cls=type(self).__name__,
                                                r_cut=self.r_cut,
                                                volume=self.volume,
@@ -874,7 +874,7 @@ cdef class RDF(Compute):
         return np.asarray(n_r)
 
     def __repr__(self):
-        return ("freud.density.{cls}(rmax={rmax}, dr={dr}, " +
+        return ("freud.density.{cls}(rmax={rmax}, dr={dr}, "
                 "rmin={rmin})").format(cls=type(self).__name__,
                                        rmax=self.rmax,
                                        dr=self.dr,

--- a/freud/environment.pyx
+++ b/freud/environment.pyx
@@ -1206,7 +1206,7 @@ cdef class LocalBondProjection(Compute):
         return freud.box.BoxFromCPP(<freud._box.Box> self.thisptr.getBox())
 
     def __repr__(self):
-        return ("freud.environment.{cls}(rmax={rmax}, " +
+        return ("freud.environment.{cls}(rmax={rmax}, "
                 "num_neigh={num_neigh})").format(cls=type(self).__name__,
                                                  rmax=self.rmax,
                                                  num_neigh=self.num_neigh)

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,7 +7,9 @@ message = Bump up to version {new_version}.
 [flake8]
 filename = *.py,*.pyx,*.pxi,*.pxd
 exclude = .eggs,*.egg,build,extern,doc/source/examples
-ignore = E901,E225,E226,E227,E999,W503,W504,F401
+ignore = E225,E226,E227,E999,W504
+per-file-ignores =
+    freud/__init__.py: F401
 
 [bumpversion:file:freud/__init__.py]
 

--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -2,7 +2,6 @@ import numpy as np
 import freud
 import unittest
 import util
-import warnings
 
 
 class TestCluster(unittest.TestCase):

--- a/tests/test_density_ComplexCF.py
+++ b/tests/test_density_ComplexCF.py
@@ -2,8 +2,6 @@ import numpy as np
 import numpy.testing as npt
 import freud
 import unittest
-import warnings
-import os
 
 
 class TestComplexCF(unittest.TestCase):

--- a/tests/test_density_FloatCF.py
+++ b/tests/test_density_FloatCF.py
@@ -2,8 +2,6 @@ import numpy as np
 import numpy.testing as npt
 import freud
 import unittest
-import warnings
-import os
 
 
 class TestFloatCF(unittest.TestCase):

--- a/tests/test_density_LocalDensity.py
+++ b/tests/test_density_LocalDensity.py
@@ -1,9 +1,7 @@
 import numpy as np
 import numpy.testing as npt
 import freud
-import warnings
 import unittest
-import os
 
 
 class TestLD(unittest.TestCase):

--- a/tests/test_density_RDF.py
+++ b/tests/test_density_RDF.py
@@ -3,7 +3,6 @@ from __future__ import division
 import numpy as np
 import numpy.testing as npt
 import freud
-import warnings
 import unittest
 
 

--- a/tests/test_environment_AngularSeparation.py
+++ b/tests/test_environment_AngularSeparation.py
@@ -1,7 +1,6 @@
 import numpy.testing as npt
 import numpy as np
 import freud
-import warnings
 import unittest
 
 

--- a/tests/test_environment_BondOrder.py
+++ b/tests/test_environment_BondOrder.py
@@ -1,7 +1,6 @@
 import numpy as np
 import freud
 import unittest
-import warnings
 import util
 
 

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -1,6 +1,5 @@
 import freud
 import unittest
-import warnings
 
 
 class TestIndex(unittest.TestCase):

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -1,5 +1,4 @@
 import numpy as np
-import numpy.testing as npt
 import freud
 import unittest
 import util

--- a/tests/test_locality_LinkCell.py
+++ b/tests/test_locality_LinkCell.py
@@ -5,7 +5,6 @@ from collections import Counter
 import itertools
 import sys
 import unittest
-import warnings
 
 
 class TestLinkCell(unittest.TestCase):

--- a/tests/test_locality_NeighborQuery.py
+++ b/tests/test_locality_NeighborQuery.py
@@ -3,9 +3,7 @@ import numpy.testing as npt
 import freud
 from collections import Counter
 import itertools
-import sys
 import unittest
-import warnings
 
 """
 Define helper functions for getting the neighbors of a point. Note that

--- a/tests/test_order_Cubatic.py
+++ b/tests/test_order_Cubatic.py
@@ -1,7 +1,6 @@
 import numpy as np
 import numpy.testing as npt
 import freud
-import warnings
 import unittest
 
 

--- a/tests/test_order_LocalQl.py
+++ b/tests/test_order_LocalQl.py
@@ -2,7 +2,6 @@ import numpy as np
 import numpy.testing as npt
 import freud
 import unittest
-import warnings
 import util
 
 

--- a/tests/test_order_Nematic.py
+++ b/tests/test_order_Nematic.py
@@ -1,7 +1,6 @@
 import numpy as np
 import numpy.testing as npt
 import freud
-import warnings
 import unittest
 
 

--- a/tests/test_order_SolLiq.py
+++ b/tests/test_order_SolLiq.py
@@ -2,7 +2,6 @@ import numpy as np
 import numpy.testing as npt
 import freud
 import unittest
-import warnings
 import util
 
 

--- a/tests/test_order_TransOrderParameter.py
+++ b/tests/test_order_TransOrderParameter.py
@@ -2,7 +2,6 @@ import numpy as np
 import numpy.testing as npt
 import freud
 import unittest
-import warnings
 import itertools
 
 

--- a/tests/test_parallel.py
+++ b/tests/test_parallel.py
@@ -1,6 +1,5 @@
 import freud
 import unittest
-import warnings
 
 
 class TestParallel(unittest.TestCase):


### PR DESCRIPTION
## Description
A handful of minor fixes:

- Updated the formatting of the Contributor Agreement to match HOOMD-blue
- Clarified flake8 configuration to ignore fewer relevant errors
- Removed unused imports
- Specify that we use OneFlow for `freud` branches
- Standardized `repr` formatting

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the [**CONTRIBUTING**](https://github.com/glotzerlab/freud/blob/master/CONTRIBUTING.md) document.
- [x] All new and existing tests passed.