### PR TITLE
Fix cubatic replicates.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,6 +2,11 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## next
+
+### Fixed
+* Repeated Cubatic Order Parameter computations use the correct number of replicates.
+
 ## v1.2.0 - 2019-06-27
 
 ### Added

--- a/cpp/order/CubaticOrderParameter.cc
+++ b/cpp/order/CubaticOrderParameter.cc
@@ -157,8 +157,8 @@ quat<float> CubaticOrderParameter::calcRandomQuaternion(Saru& saru, float angle_
     return quat<float>::fromAxisAngle(axis, angle);
 }
 
-void CubaticOrderParameter::compute(quat<float> *orientations, unsigned int n)
-    {
+void CubaticOrderParameter::compute(quat<float>* orientations, unsigned int n)
+{
     // change the size of the particle tensor if the number of particles
     if (m_n != n)
     {
@@ -328,6 +328,6 @@ void CubaticOrderParameter::compute(quat<float> *orientations, unsigned int n)
     });
     // save the last computed number of particles
     m_n = n;
-    }
+}
 
 }; }; // end namespace freud::order

--- a/cpp/order/CubaticOrderParameter.cc
+++ b/cpp/order/CubaticOrderParameter.cc
@@ -157,8 +157,8 @@ quat<float> CubaticOrderParameter::calcRandomQuaternion(Saru& saru, float angle_
     return quat<float>::fromAxisAngle(axis, angle);
 }
 
-void CubaticOrderParameter::compute(quat<float>* orientations, unsigned int n, unsigned int replicates)
-{
+void CubaticOrderParameter::compute(quat<float> *orientations, unsigned int n)
+    {
     // change the size of the particle tensor if the number of particles
     if (m_n != n)
     {
@@ -328,7 +328,6 @@ void CubaticOrderParameter::compute(quat<float>* orientations, unsigned int n, u
     });
     // save the last computed number of particles
     m_n = n;
-    m_replicates = replicates;
-}
+    }
 
 }; }; // end namespace freud::order

--- a/cpp/order/CubaticOrderParameter.h
+++ b/cpp/order/CubaticOrderParameter.h
@@ -34,7 +34,7 @@ public:
     void reset();
 
     //! Compute the cubatic order parameter
-    void compute(quat<float>* orientations, unsigned int n, unsigned int replicates);
+    void compute(quat<float>* orientations, unsigned int n);
 
     //! Calculate the cubatic tensor
     void calcCubaticTensor(float* cubatic_tensor, quat<float> orientation);

--- a/freud/_order.pxd
+++ b/freud/_order.pxd
@@ -21,7 +21,6 @@ cdef extern from "CubaticOrderParameter.h" namespace "freud::order":
                               unsigned int) except +
         void reset()
         void compute(quat[float]*,
-                     unsigned int,
                      unsigned int) nogil except +
         unsigned int getNumParticles()
         float getCubaticOrderParameter()

--- a/freud/order.pyx
+++ b/freud/order.pyx
@@ -130,7 +130,7 @@ cdef class CubaticOrderParameter(Compute):
 
         with nogil:
             self.thisptr.compute(
-                <quat[float]*> &l_orientations[0, 0], num_particles, 1)
+                <quat[float]*> &l_orientations[0, 0], num_particles)
         return self
 
     @property


### PR DESCRIPTION
## Description
The number of replicates used by the Cubatic Order Parameter was unintentionally reset after the first compute call.

## Motivation and Context
Resolves #325.

## How Has This Been Tested?
@jinsoo960 did you identify the original error by looking at the runtimes? I don't think there is a way we can make this appear in the freud tests, since the Python API behavior did not reflect this problem.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/glotzerlab/freud/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] I have updated the [Changelog](https://github.com/glotzerlab/freud/blob/master/ChangeLog.md).
