### PR TITLE
Opt/rot acorr

### DIFF
--- a/cpp/order/RotationalAutocorrelation.cc
+++ b/cpp/order/RotationalAutocorrelation.cc
@@ -74,15 +74,16 @@ void RotationalAutocorrelation::compute(const quat<float>* ref_ors, const quat<f
     // Precompute the hyperspherical harmonics for the unit quaternion. The
     // default quaternion constructor gives a unit quaternion. We will assume
     // the same iteration order here as in the loop below to save ourselves
-    // from having to use a more expensive process (like a map).
-    std::complex<float> ang = std::complex<float>(0, 0);
+    // from having to use a more expensive process (i.e. a map).
+    std::complex<float> xi = std::complex<float>(0, 0);
+    std::complex<float> zeta = std::complex<float>(0, 1);
     std::vector<std::complex<float>> unit_harmonics;
     for (unsigned int a = 0; a <= m_l; a++)
     {
         for (unsigned int b = 0; b <= m_l; b++)
         {
             unit_harmonics.push_back(
-                std::conj(hypersphere_harmonic(ang, ang, m_l, a, b)));
+                std::conj(hypersphere_harmonic(xi, zeta, m_l, a, b)));
         }
     }
 

--- a/cpp/order/RotationalAutocorrelation.cc
+++ b/cpp/order/RotationalAutocorrelation.cc
@@ -55,7 +55,7 @@ inline std::pair<std::complex<float>, std::complex<float>> quat_to_greek(const q
 }
 
 inline std::complex<float> hypersphere_harmonic(const std::complex<float> xi, std::complex<float> zeta,
-                                                const int l, const unsigned int a, const unsigned int b)
+                                                const unsigned int l, const unsigned int a, const unsigned int b)
 {
     const std::complex<float> xi_conj = std::conj(xi);
     const std::complex<float> zeta_conj = std::conj(zeta);
@@ -94,12 +94,12 @@ void RotationalAutocorrelation::compute(const quat<float>* ref_ors, const quat<f
     // from having to use a more expensive process (like a map).
     std::pair<std::complex<float>, std::complex<float>> angle_0 = quat_to_greek(quat<float>());
     std::vector<std::complex<float>> unit_harmonics;
-    for (int a = (int) m_l; a >= 0; a--)
+    for (unsigned int a = 0; a <= m_l; a++)
     {
-        for (int b = (int) m_l; b >= 0; b--)
+        for (unsigned int b = 0; b <= m_l; b++)
         {
             unit_harmonics.push_back(
-                std::conj(hypersphere_harmonic(angle_0.first, angle_0.second, (int) m_l, (unsigned int) a, (unsigned int) b)));
+                std::conj(hypersphere_harmonic(angle_0.first, angle_0.second, m_l, a, b)));
         }
     }
 
@@ -114,12 +114,12 @@ void RotationalAutocorrelation::compute(const quat<float>* ref_ors, const quat<f
             // Loop through the valid quantum numbers.
             m_RA_array.get()[i] = std::complex<float>(0, 0);
             unsigned int uh_index = 0;
-            for (int a = (int) m_l; a >= 0; a--)
+            for (unsigned int a = 0; a <= m_l; a++)
             {
-                for (int b = (int) m_l; b >= 0; b--)
+                for (unsigned int b = 0; b <= m_l; b++)
                 {
                     std::complex<float> combined_value = unit_harmonics[uh_index]
-                        * hypersphere_harmonic(angle_1.first, angle_1.second, (int) m_l, (unsigned int) a, (unsigned int) b);
+                        * hypersphere_harmonic(angle_1.first, angle_1.second, m_l, a, b);
                     m_RA_array.get()[i] += combined_value;
                     uh_index += 1;
                 }

--- a/cpp/order/RotationalAutocorrelation.cc
+++ b/cpp/order/RotationalAutocorrelation.cc
@@ -41,7 +41,10 @@ inline std::complex<float> cpow(std::complex<float> base, unsigned int p)
 // the appropriate shift by 1.
 inline float factorial(int n)
 {
-    return std::tgamma(n + 1);
+    if (n == 0)
+        return 1;
+    else
+        return n*factorial(n-1);
 }
 
 inline std::pair<std::complex<float>, std::complex<float>> quat_to_greek(const quat<float>& q)

--- a/cpp/order/RotationalAutocorrelation.cc
+++ b/cpp/order/RotationalAutocorrelation.cc
@@ -37,16 +37,6 @@ inline std::complex<float> cpow(std::complex<float> base, unsigned int p)
     }
 }
 
-// This convenience function wraps std's gamma function for factorials, with
-// the appropriate shift by 1.
-inline float factorial(int n)
-{
-    if (n == 0)
-        return 1;
-    else
-        return n*factorial(n-1);
-}
-
 inline std::pair<std::complex<float>, std::complex<float>> quat_to_greek(const quat<float>& q)
 {
     std::complex<float> xi(q.v.x, q.v.y);
@@ -54,7 +44,7 @@ inline std::pair<std::complex<float>, std::complex<float>> quat_to_greek(const q
     return std::pair<std::complex<float>, std::complex<float>>(xi, zeta);
 }
 
-inline std::complex<float> hypersphere_harmonic(const std::complex<float> xi, std::complex<float> zeta,
+inline std::complex<float> RotationalAutocorrelation::hypersphere_harmonic(const std::complex<float> xi, std::complex<float> zeta,
                                                 const unsigned int l, const unsigned int a, const unsigned int b)
 {
     const std::complex<float> xi_conj = std::conj(xi);
@@ -64,12 +54,11 @@ inline std::complex<float> hypersphere_harmonic(const std::complex<float> xi, st
     std::complex<float> sum_tracker(0, 0);
     for (unsigned int k = (a+b < l ? 0 : a+b-l); k <= std::min(a, b); k++)
     {
-        sum_tracker += cpow(xi_conj, k) * cpow(zeta, b - k) * cpow(zeta_conj, a - k)
-            * cpow(-xi, l + k - a - b) / factorial(k) / factorial(l + k - a - b) / factorial(a - k)
-            / factorial(b - k);
+        float fact_product = m_factorials.get()[k] * m_factorials.get()[l + k - a - b] * m_factorials.get()[a - k] * m_factorials.get()[b - k];
+        sum_tracker += cpow(xi_conj, k) * cpow(zeta, b - k) * cpow(zeta_conj, a - k) * cpow(-xi, l + k - a - b) / fact_product;
     }
     sum_tracker
-        *= std::sqrt(factorial(a) * factorial(l - a) * factorial(b) * factorial(l - b) / (float(l) + 1));
+        *= std::sqrt(m_factorials.get()[a] * m_factorials.get()[l - a] * m_factorials.get()[b] * m_factorials.get()[l - b] / (float(l) + 1));
     return sum_tracker;
 }
 

--- a/cpp/order/RotationalAutocorrelation.h
+++ b/cpp/order/RotationalAutocorrelation.h
@@ -35,16 +35,6 @@ namespace freud { namespace order {
  */
 std::pair<std::complex<float>, std::complex<float>> quat_to_greek(const quat<float>& q);
 
-// This convenience function wraps std's gamma function for factorials, with
-// the appropriate shift by 1.
-inline unsigned int factorial(int n)
-{
-    if (n == 0)
-        return 1;
-    else
-        return n*factorial(n-1);
-}
-
 //! Compute the total rotational autocorrelation for a set of orientations.
 /*! The desired autocorrelation function is the rotational analog of the
  *  dynamic structure factor, which provides information on the dynamics of
@@ -69,9 +59,10 @@ public:
         // For efficiency, precompute all required factorials;
         m_factorials = std::shared_ptr<unsigned int>(new unsigned int[m_l+1], std::default_delete<unsigned int[]>());
         memset((void*) m_factorials.get(), 0, sizeof(unsigned int) * (m_l+1));
-        for (unsigned int i = 0; i <= m_l; i++)
+        m_factorials.get()[0] = 1;
+        for (unsigned int i = 1; i <= m_l; i++)
         {
-            m_factorials.get()[i] = factorial(i);
+            m_factorials.get()[i] = i*m_factorials.get()[i-1];
         }
     }
 

--- a/cpp/order/RotationalAutocorrelation.h
+++ b/cpp/order/RotationalAutocorrelation.h
@@ -7,9 +7,7 @@
 #include <cassert>
 #include <complex>
 #include <memory>
-#include <iostream>
 #include <tbb/tbb.h>
-#include <map>
 
 #include "VectorMath.h"
 

--- a/cpp/order/RotationalAutocorrelation.h
+++ b/cpp/order/RotationalAutocorrelation.h
@@ -68,7 +68,7 @@ public:
     //! Constructor
     /*! \param l The order of the spherical harmonic.
      */
-    RotationalAutocorrelation(int l) : m_l(l), m_N(0), m_Ft(0) {}
+    RotationalAutocorrelation(unsigned int l) : m_l(l), m_N(0), m_Ft(0) {}
 
     //! Destructor
     ~RotationalAutocorrelation() {}
@@ -113,7 +113,7 @@ public:
     void compute(const quat<float>* ref_ors, const quat<float>* ors, unsigned int N);
 
 private:
-    int m_l;          //!< Order of the hyperspherical harmonic.
+    unsigned int m_l;          //!< Order of the hyperspherical harmonic.
     unsigned int m_N; //!< Last number of orientations used in compute.
     float m_Ft;       //!< Real value of calculated RA function.
 

--- a/freud/_order.pxd
+++ b/freud/_order.pxd
@@ -148,7 +148,7 @@ cdef extern from "SolLiq.h" namespace "freud::order":
 cdef extern from "RotationalAutocorrelation.h" namespace "freud::order":
     cdef cppclass RotationalAutocorrelation:
         RotationalAutocorrelation()
-        RotationalAutocorrelation(int)
+        RotationalAutocorrelation(unsigned int)
         unsigned int getL()
         unsigned int getN()
         shared_ptr[float complex] getRAArray()

--- a/freud/order.pyx
+++ b/freud/order.pyx
@@ -1851,7 +1851,7 @@ cdef class RotationalAutocorrelation(Compute):
             The autocorrelation computed in the last call to compute.
     """
     cdef freud._order.RotationalAutocorrelation * thisptr
-    cdef int l
+    cdef unsigned int l
 
     def __cinit__(self, l):
         if l % 2 or l < 0:


### PR DESCRIPTION
Further optimizations for rotational autocorrelation. Gives another 5x speedup over the old method. Also gets rid of the usage of signed ints for quantities that should be unsigned.