### PR TITLE
Force Cython rebuild on RTD.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -163,7 +163,11 @@ sys.argv = ['setup.py'] + extras
 
 on_rtd = os.environ.get('READTHEDOCS') == 'True'
 if on_rtd:
+    logger.warning('Building on Read the Docs with Cython enabled.')
     args.use_cython = True
+    for cython_cpp_file in glob.glob('freud/*.cpp'):
+        logger.warning('Deleting {}'.format(cython_cpp_file))
+        os.remove(cython_cpp_file)
 
 
 ################################


### PR DESCRIPTION
## Motivation and Context
Sometimes our builds on Read the Docs fail, if the Cythonized .cpp files in `freud/*.cpp` aren't up to date. This fixes that problem by forcing RTD to re-Cythonize on every build.

## How Has This Been Tested?
I ran RTD on a branch off of `next` which is currently failing from outdated cpp files, then I cherry-picked the commit back to `master` so it can be merged up to `next` later.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the [**CONTRIBUTING**](https://github.com/glotzerlab/freud/blob/master/CONTRIBUTING.md) document.