### PR TITLE
Fix/duplicate cell shells

### DIFF
--- a/cpp/locality/LinkCell.cc
+++ b/cpp/locality/LinkCell.cc
@@ -398,6 +398,8 @@ NeighborPoint LinkCellQueryBallIterator::next()
     while (cur_p < m_N)
     {
         vec3<unsigned int> point_cell(m_linkcell->getCellCoord(m_points[cur_p]));
+        const unsigned int point_cell_index = get_neighbor_cell_index(m_linkcell, point_cell, *m_neigh_cell_iter);
+        m_searched_cells.insert(point_cell_index);
 
         // Loop over cell list neighbor shells relative to this point's cell.
         while (true)
@@ -483,7 +485,6 @@ NeighborPoint LinkCellQueryIterator::next()
     while (cur_p < m_N)
     {
         vec3<unsigned int> point_cell(m_linkcell->getCellCoord(m_points[cur_p]));
-        m_searched_cells.clear();
         const unsigned int point_cell_index = get_neighbor_cell_index(m_linkcell, point_cell, *m_neigh_cell_iter);
         m_searched_cells.insert(point_cell_index);
 
@@ -566,6 +567,7 @@ NeighborPoint LinkCellQueryIterator::next()
         m_current_neighbors.clear();
         m_neigh_cell_iter = IteratorCellShell(0, m_neighbor_query->getBox().is2D());
         m_cell_iter = m_linkcell->itercell(m_linkcell->getCell(m_points[cur_p]));
+        m_searched_cells.clear();
     }
 
     m_finished = true;

--- a/cpp/locality/LinkCell.cc
+++ b/cpp/locality/LinkCell.cc
@@ -151,21 +151,6 @@ unsigned int get_neighbor_cell_index(const LinkCell* linkcell, const vec3<unsign
         (d + point_cell.z + cell_delta.z) % d);
 }
 
-bool check_double_range_shell(const LinkCell* linkcell, const vec3<int> cell_delta)
-{
-    bool range_check = false;
-    unsigned int w = linkcell->getCellIndexer().getW();
-    unsigned int h = linkcell->getCellIndexer().getH();
-    unsigned int d = linkcell->getCellIndexer().getD();
-    if (2 * cell_delta.x + 1 > (int) w)
-        range_check = true;
-    else if (2 * cell_delta.y + 1 > (int) h)
-        range_check = true;
-    else if (2 * cell_delta.z + 1 > (int) d)
-        range_check = true;
-    return range_check;
-}
-
 void LinkCell::computeCellList(const box::Box& box, const vec3<float>* points, unsigned int Np)
 {
     updateBox(box);
@@ -433,12 +418,6 @@ NeighborPoint LinkCellQueryBallIterator::next()
                     break;
                 }
 
-                // In cases where we need to check the entire box, make sure
-                // that we don't check the same cell on the positive and
-                // negative sides of the IteratorCellShell cube.
-                if (check_double_range_shell(m_linkcell, *m_neigh_cell_iter))
-                    continue;
-
                 const unsigned int neighbor_cell = get_neighbor_cell_index(m_linkcell, point_cell, *m_neigh_cell_iter);
 
                 auto searched_cell_iter = m_searched_cells.find(neighbor_cell);
@@ -523,12 +502,6 @@ NeighborPoint LinkCellQueryIterator::next()
                     {
                         break;
                     }
-
-                    // In cases where we need to check the entire box, make sure
-                    // that we don't check the same cell on the positive and
-                    // negative sides of the IteratorCellShell cube.
-                    if (check_double_range_shell(m_linkcell, *m_neigh_cell_iter))
-                        continue;
 
                     const unsigned int neighbor_cell = get_neighbor_cell_index(m_linkcell, point_cell, *m_neigh_cell_iter);
 

--- a/cpp/locality/LinkCell.cc
+++ b/cpp/locality/LinkCell.cc
@@ -397,7 +397,6 @@ NeighborPoint LinkCellQueryBallIterator::next()
 
     while (cur_p < m_N)
     {
-        printf("Starting cur_p loop, cur_p = %i; m_N = %i.\n", cur_p, m_N);
         vec3<unsigned int> point_cell(m_linkcell->getCellCoord(m_points[cur_p]));
 
         // Loop over cell list neighbor shells relative to this point's cell.
@@ -413,8 +412,6 @@ NeighborPoint LinkCellQueryBallIterator::next()
 
                 if (rsq < r_cutsq && (!m_exclude_ii || cur_p != j))
                 {
-                    const unsigned int neighbor_cell = get_neighbor_cell_index(m_linkcell, point_cell, *m_neigh_cell_iter);
-                    printf("Found (%i, %i) in cell %i.\n", cur_p, j, neighbor_cell);
                     return NeighborPoint(cur_p, j, sqrt(rsq));
                 }
             }
@@ -430,7 +427,6 @@ NeighborPoint LinkCellQueryBallIterator::next()
 
                 if ((m_neigh_cell_iter.getRange() - m_extra_search_width) * m_linkcell->getCellWidth() > m_r)
                 {
-                    printf("Hitting out-of-range.\n");
                     out_of_range = true;
                     break;
                 }
@@ -449,13 +445,6 @@ NeighborPoint LinkCellQueryBallIterator::next()
                     // This cell has not been searched yet, so we will iterate
                     // over its contents. Otherwise, we loop back, increment
                     // the cell shell iterator, and try the next one.
-                    printf("Already searched cells: ");
-                    for (auto it = m_searched_cells.begin(); it != m_searched_cells.end(); it++)
-                    {
-                        printf("%i, ", *it);
-                    }
-                    printf("\n");
-                    printf("Searching cell %i\n.", neighbor_cell);
                     m_searched_cells.insert(neighbor_cell);
                     m_cell_iter = m_linkcell->itercell(neighbor_cell);
                     break;
@@ -466,7 +455,6 @@ NeighborPoint LinkCellQueryBallIterator::next()
                 break;
             }
         }
-        printf("Incrementing particle counter: %i\n", cur_p);
         cur_p++;
         m_neigh_cell_iter = IteratorCellShell(0, m_neighbor_query->getBox().is2D());
         m_cell_iter = m_linkcell->itercell(m_linkcell->getCell(m_points[cur_p]));

--- a/cpp/locality/LinkCell.cc
+++ b/cpp/locality/LinkCell.cc
@@ -403,6 +403,17 @@ NeighborPoint LinkCellQueryBallIterator::next()
                     break;
                 }
 
+                // In cases where we need to check the entire box, make sure
+                // that we don't check the same cell on the positive and
+                // negative sides of the IteratorCellShell cube.
+                const vec3<int> neighbor_cell_delta(*m_neigh_cell_iter);
+                if (2 * neighbor_cell_delta.x + 1 > (int) m_linkcell->getCellIndexer().getW())
+                    continue;
+                else if (2 * neighbor_cell_delta.y + 1 > (int) m_linkcell->getCellIndexer().getH())
+                    continue;
+                else if (2 * neighbor_cell_delta.z + 1 > (int) m_linkcell->getCellIndexer().getD())
+                    continue;
+
                 const unsigned int neighbor_cell = m_linkcell->getCellIndexer()(
                     // Need to increment each dimension by the width to avoid taking the modulus
                     // of a negative number.
@@ -457,6 +468,16 @@ NeighborPoint LinkCellQueryIterator::next()
     {
         vec3<unsigned int> point_cell(m_linkcell->getCellCoord(m_points[cur_p]));
         m_searched_cells.clear();
+        const unsigned int point_cell_index = m_linkcell->getCellIndexer()(
+            // Need to increment each dimension by the width to avoid taking the modulus
+            // of a negative number.
+            (m_linkcell->getCellIndexer().getW() + point_cell.x + (*m_neigh_cell_iter).x)
+                % m_linkcell->getCellIndexer().getW(),
+            (m_linkcell->getCellIndexer().getH() + point_cell.y + (*m_neigh_cell_iter).y)
+                % m_linkcell->getCellIndexer().getH(),
+            (m_linkcell->getCellIndexer().getD() + point_cell.z + (*m_neigh_cell_iter).z)
+                % m_linkcell->getCellIndexer().getD());
+        m_searched_cells.insert(point_cell_index);
 
         // Loop over cell list neighbor shells relative to this point's cell.
         if (!m_current_neighbors.size())
@@ -493,6 +514,17 @@ NeighborPoint LinkCellQueryIterator::next()
                     {
                         break;
                     }
+
+                    // In cases where we need to check the entire box, make sure
+                    // that we don't check the same cell on the positive and
+                    // negative sides of the IteratorCellShell cube.
+                    const vec3<int> neighbor_cell_delta(*m_neigh_cell_iter);
+                    if (2 * neighbor_cell_delta.x + 1 > (int) m_linkcell->getCellIndexer().getW())
+                        continue;
+                    else if (2 * neighbor_cell_delta.y + 1 > (int) m_linkcell->getCellIndexer().getH())
+                        continue;
+                    else if (2 * neighbor_cell_delta.z + 1 > (int) m_linkcell->getCellIndexer().getD())
+                        continue;
 
                     const unsigned int neighbor_cell = m_linkcell->getCellIndexer()(
                         // Need to increment each dimension by the width to avoid taking the modulus

--- a/cpp/locality/LinkCell.cc
+++ b/cpp/locality/LinkCell.cc
@@ -368,8 +368,9 @@ NeighborPoint LinkCellQueryBallIterator::next()
 
     while (cur_p < m_N)
     {
-        vec3<int> point_cell(m_linkcell->getCellCoord(m_points[cur_p]));
-        const unsigned int point_cell_index = m_linkcell->getCellIndex(point_cell + *m_neigh_cell_iter);
+        vec3<unsigned int> point_cell(m_linkcell->getCellCoord(m_points[cur_p]));
+        const unsigned int point_cell_index = m_linkcell->getCellIndex(
+                vec3<int>(point_cell.x, point_cell.y, point_cell.z) + (*m_neigh_cell_iter));
         m_searched_cells.insert(point_cell_index);
 
         // Loop over cell list neighbor shells relative to this point's cell.
@@ -404,8 +405,8 @@ NeighborPoint LinkCellQueryBallIterator::next()
                     break;
                 }
 
-                const unsigned int neighbor_cell_index = m_linkcell->getCellIndex(point_cell + *m_neigh_cell_iter);
-
+                const unsigned int neighbor_cell_index = m_linkcell->getCellIndex(
+                        vec3<int>(point_cell.x, point_cell.y, point_cell.z) + (*m_neigh_cell_iter));
                 // Insertion to an unordered set returns a pair, the second
                 // element indicates insertion success or failure (if it
                 // already exists)
@@ -414,7 +415,7 @@ NeighborPoint LinkCellQueryBallIterator::next()
                     // This cell has not been searched yet, so we will iterate
                     // over its contents. Otherwise, we loop back, increment
                     // the cell shell iterator, and try the next one.
-                    m_cell_iter = m_linkcell->itercell(neighbor_cell);
+                    m_cell_iter = m_linkcell->itercell(neighbor_cell_index);
                     break;
                 }
             }
@@ -450,8 +451,10 @@ NeighborPoint LinkCellQueryIterator::next()
 
     while (cur_p < m_N)
     {
-        vec3<int> point_cell(m_linkcell->getCellCoord(m_points[cur_p]));
-        const unsigned int point_cell_index = m_linkcell->getCellIndex(point_cell + *m_neigh_cell_iter);
+
+        vec3<unsigned int> point_cell(m_linkcell->getCellCoord(m_points[cur_p]));
+        const unsigned int point_cell_index = m_linkcell->getCellIndex(
+                vec3<int>(point_cell.x, point_cell.y, point_cell.z) + (*m_neigh_cell_iter));
         m_searched_cells.insert(point_cell_index);
 
         // Loop over cell list neighbor shells relative to this point's cell.
@@ -490,8 +493,8 @@ NeighborPoint LinkCellQueryIterator::next()
                         break;
                     }
 
-                    const unsigned int neighbor_cell_index = m_linkcell->getCellIndex(point_cell + *m_neigh_cell_iter);
-
+                    const unsigned int neighbor_cell_index = m_linkcell->getCellIndex(
+                            vec3<int>(point_cell.x, point_cell.y, point_cell.z) + (*m_neigh_cell_iter));
                     // Insertion to an unordered set returns a pair, the second
                     // element indicates insertion success or failure (if it
                     // already exists)
@@ -501,7 +504,7 @@ NeighborPoint LinkCellQueryIterator::next()
                         // iterate over its contents. Otherwise, we loop back,
                         // increment the cell shell iterator, and try the next
                         // one.
-                        m_cell_iter = m_linkcell->itercell(neighbor_cell);
+                        m_cell_iter = m_linkcell->itercell(neighbor_cell_index);
                         break;
                     }
                 }

--- a/cpp/locality/LinkCell.cc
+++ b/cpp/locality/LinkCell.cc
@@ -489,6 +489,11 @@ NeighborPoint LinkCellQueryIterator::next()
                 {
                     ++m_neigh_cell_iter;
 
+                    if (m_neigh_cell_iter == IteratorCellShell(max_range, m_neighbor_query->getBox().is2D()))
+                    {
+                        break;
+                    }
+
                     const unsigned int neighbor_cell = m_linkcell->getCellIndexer()(
                         // Need to increment each dimension by the width to avoid taking the modulus
                         // of a negative number.
@@ -500,17 +505,13 @@ NeighborPoint LinkCellQueryIterator::next()
                             % m_linkcell->getCellIndexer().getD());
 
                     auto searched_cell_iter = m_searched_cells.find(neighbor_cell);
-                    if (searched_cell_iter == m_searched_cells.end() || m_neigh_cell_iter == IteratorCellShell(max_range, m_neighbor_query->getBox().is2D()))
+                    if (searched_cell_iter == m_searched_cells.end())
                     {
                         // This cell has not been searched yet, so we will iterate
                         // over its contents. Otherwise, we loop back, increment
                         // the cell shell iterator, and try the next one.
                         m_searched_cells.insert(neighbor_cell);
                         m_cell_iter = m_linkcell->itercell(neighbor_cell);
-                        break;
-                    }
-                    if (m_neigh_cell_iter == IteratorCellShell(max_range, m_neighbor_query->getBox().is2D()))
-                    {
                         break;
                     }
                 }

--- a/cpp/locality/LinkCell.h
+++ b/cpp/locality/LinkCell.h
@@ -381,7 +381,7 @@ public:
     }
 
     //! Compute cell id from cell coordinates
-    unsigned int getCellIndex(const vec3<int> cellCoord)
+    unsigned int getCellIndex(const vec3<int> cellCoord) const
     {
         int w = (int) getCellIndexer().getW();
         int h = (int) getCellIndexer().getH();

--- a/cpp/locality/LinkCell.h
+++ b/cpp/locality/LinkCell.h
@@ -7,6 +7,7 @@
 #include <cassert>
 #include <memory>
 #include <tbb/concurrent_hash_map.h>
+#include <unordered_set>
 #include <vector>
 
 #include "Box.h"
@@ -505,6 +506,8 @@ protected:
         m_neigh_cell_iter; //!< The shell iterator indicating how far out we're currently searching.
     LinkCell::iteratorcell
         m_cell_iter; //!< The cell iterator indicating which cell we're currently searching.
+    std::unordered_set<unsigned int>
+        m_searched_cells; //!< Set of cells that have already been searched by the cell shell iterator.
 };
 
 //! Iterator that gets nearest neighbors from LinkCell tree structures

--- a/cpp/locality/LinkCell.h
+++ b/cpp/locality/LinkCell.h
@@ -380,6 +380,23 @@ public:
         return m_cell_index;
     }
 
+    //! Compute cell id from cell coordinates
+    unsigned int getCellIndex(const vec3<int> cellCoord)
+    {
+        int w = (int) getCellIndexer().getW();
+        int h = (int) getCellIndexer().getH();
+        int d = (int) getCellIndexer().getD();
+
+        int x = cellCoord.x % w;
+        x += (x < 0 ? w : 0);
+        int y = cellCoord.y % h;
+        y += (y < 0 ? h : 0);
+        int z = cellCoord.z % d;
+        z += (z < 0 ? d : 0);
+
+        return getCellIndexer()(x, y, z);
+    }
+
     //! Get the number of cells
     unsigned int getNumCells() const
     {

--- a/tests/test_locality_NeighborQuery.py
+++ b/tests/test_locality_NeighborQuery.py
@@ -454,6 +454,18 @@ class TestNeighborQuery(object):
                     assert ([i, i] == nlist_array).all(axis=1).any()
 
     def test_duplicate_cell_shells(self):
+        box = freud.box.Box.square(5)
+        points = [[-1.5, 0, 0]]
+        ref_points = [[0.9, 0, 0]]
+        rmax = 2.45
+        cell_width = 1
+        nq = self.build_query_object(box, ref_points, cell_width)
+        q = nq.queryBall(points, rmax)
+        self.assertEqual(len(list(q)), 1)
+        q = nq.query(points, 1000)
+        self.assertEqual(len(list(q)), 1)
+
+    def test_duplicate_cell_shells2(self):
         positions = [[1.5132198, 6.67087, 3.1856632],
                      [1.3913784, -2.3667011, 4.5227165],
                      [-3.6133137, 9.043476, 0.8957424]]

--- a/tests/test_locality_NeighborQuery.py
+++ b/tests/test_locality_NeighborQuery.py
@@ -453,6 +453,18 @@ class TestNeighborQuery(object):
                 for i in range(N):
                     assert ([i, i] == nlist_array).all(axis=1).any()
 
+    def test_duplicate_cell_shells(self):
+        positions = [[1.5132198, 6.67087, 3.1856632],
+                     [1.3913784, -2.3667011, 4.5227165],
+                     [-3.6133137, 9.043476, 0.8957424]]
+        box = freud.box.Box.cube(21)
+        rmax = 10
+        nq = self.build_query_object(box, positions, rmax)
+        q = nq.queryBall(positions[0], rmax)
+        self.assertEqual(len(list(q)), 3)
+        q = nq.query(positions[0], 1000)
+        self.assertEqual(len(list(q)), 3)
+
 
 class TestNeighborQueryAABB(TestNeighborQuery, unittest.TestCase):
     @classmethod


### PR DESCRIPTION
## Description
This PR attempts to solve #343. I'm not yet fully convinced of this solution's correctness, but it passes tests and seems to work as I expect.

Questions for discussion:
1. @vyasr is there a reason why the QueryBall didn't have the same check to prevent the IteratorCellShell from duplicating a cell on the positive and negative sides? I had to add that from Query to QueryBall to make it work properly.
2. Should we refactor the `neighbor_cell` computation so that it's not duplicated several times? We would just need a single function to calculate the cell index from `vec3<unsigned int> point_cell` and the current state of `m_neigh_cell_iter`.
3. If the IteratorCellShell can prevent duplication in the positive and negative directions as mentioned above, do we even need to track the cells we've queried? It seems like we've already addressed this problem in a different way than tracking previously-queried cells, but it didn't seem to work (otherwise this bug wouldn't show up for the `query` methods too). Is there another case that I'm missing?

## Motivation and Context
Resolves #343.

## How Has This Been Tested?
The test case mentioned in #343 has been turned into an actual test.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the [**CONTRIBUTING**](https://github.com/glotzerlab/freud/blob/master/CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have updated the [Changelog](https://github.com/glotzerlab/freud/blob/master/ChangeLog.md).
