### PR TITLE
Fix issue with multiple computes of LocalQl

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 * Repeated Cubatic Order Parameter computations use the correct number of replicates.
+* Repeated calls to LocalQl.computeNorm properly reset the underlying data.
 
 ## v1.2.0 - 2019-06-27
 

--- a/cpp/order/LocalQl.cc
+++ b/cpp/order/LocalQl.cc
@@ -38,6 +38,7 @@ void LocalQl::computeYlm(const float theta, const float phi, std::vector<std::co
 void LocalQl::compute(const locality::NeighborList* nlist, const vec3<float>* points, unsigned int Np)
 {
     nlist->validate(Np, Np);
+    m_Qlm_local.reset();
 
     if (m_Np != Np)
     {

--- a/tests/test_order_LocalQl.py
+++ b/tests/test_order_LocalQl.py
@@ -98,6 +98,18 @@ class TestLocalQl(unittest.TestCase):
         comp.computeNorm(positions)
         comp.plot(mode="norm_Ql")
 
+    def test_compute_twice_norm(self):
+        """Test that computing norm twice works as expected."""
+        L = 5
+        num_points = 100
+        box, points = util.make_box_and_random_points(L, num_points, seed=0)
+
+        ql = freud.order.LocalQl(box, 1.5, 6)
+        first_result = ql.computeNorm(points).norm_Ql.copy()
+        second_result = ql.computeNorm(points).norm_Ql
+
+        npt.assert_array_almost_equal(first_result, second_result)
+
 
 class TestLocalQlNear(unittest.TestCase):
     def test_init_kwargs(self):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Reset the ThreadStorage object used to store Qlm.

## Motivation and Context
Calling compute multiple times does not reset the array accumulate Qlm values, so the normalized values accumulate over many calls. We need to reset the thread local arrays. This issue is also present in the Steinhardt class, but since that class is still not part of the public API I've opted to fix this for future releases instead. That class has been switched to the new ThreadStorage object on the `next` branch of development, so it will be much easier than adding the thread specific logic to this code.

## How Has This Been Tested?
I added a test that calls the relevant compute function twice and checks that the outputs are the same. This test failed before.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds or improves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/glotzerlab/freud/blob/master/CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the [Changelog](https://github.com/glotzerlab/freud/blob/master/ChangeLog.md).
