### PR TITLE
Fix compiler warnings

### DIFF
--- a/cpp/cluster/Cluster.cc
+++ b/cpp/cluster/Cluster.cc
@@ -44,7 +44,7 @@ void Cluster::computeClusters(const freud::locality::NeighborQuery* nq,
 
     freud::locality::loopOverNeighbors(
         nq, points, Np, qargs, nlist,
-        [this, &dj, points](const freud::locality::NeighborBond& neighbor_bond) {
+        [this, &dj](const freud::locality::NeighborBond& neighbor_bond) {
             // compute r between the two particles
             if (neighbor_bond.distance < m_rcut)
             {

--- a/cpp/environment/AngularSeparation.cc
+++ b/cpp/environment/AngularSeparation.cc
@@ -35,7 +35,7 @@ float computeSeparationAngle(const quat<float> ref_q, const quat<float> q)
         R.s = -1.0;
     }
 
-    float theta = 2.0 * acos(R.s);
+    float theta = float(2.0 * acos(R.s));
 
     return theta;
 }

--- a/cpp/environment/LocalDescriptors.cc
+++ b/cpp/environment/LocalDescriptors.cc
@@ -130,7 +130,7 @@ void LocalDescriptors::compute(const box::Box& box,
                 const float magR(sqrt(rsq));
                 float theta(atan2(bond_ij.y, bond_ij.x)); // theta in [-pi..pi] initially
                 if (theta < 0)
-                    theta += 2 * M_PI;             // move theta into [0..2*pi]
+                    theta += float(2 * M_PI);             // move theta into [0..2*pi]
                 float phi(acos(bond_ij.z / magR)); // phi in [0..pi]
 
                 // catch cases where bond_ij.z/magR falls outside [-1, 1]

--- a/cpp/environment/MatchEnv.h
+++ b/cpp/environment/MatchEnv.h
@@ -240,7 +240,7 @@ private:
     box::Box m_box; //!< Simulation box
     float m_rmax;   //!< Maximum cutoff radius at which to determine local environment
     float m_rmaxsq; //!< Square of m_rmax
-    float m_k;      //!< Default number of nearest neighbors used to determine which environments are compared
+    unsigned int m_k;      //!< Default number of nearest neighbors used to determine which environments are compared
                //!< during local environment clustering. If hard_r=false, this is also the number of neighbors
                //!< in each local environment.
     unsigned int m_maxk; //!< Maximum number of neighbors in any particle's local environment. If

--- a/cpp/locality/AABBQuery.h
+++ b/cpp/locality/AABBQuery.h
@@ -114,13 +114,13 @@ protected:
                 throw std::runtime_error("You must set nn in the query arguments.");
             if (args.scale == -1)
             {
-                args.scale = 1.1;
+                args.scale = float(1.1);
             }
             if (args.rmax == -1)
             {
                 vec3<float> L = this->getBox().getL();
                 float rmax = std::min(L.x, L.y);
-                args.rmax = this->getBox().is2D() ? 0.1 * rmax : 0.1 * std::min(rmax, L.z);
+                args.rmax = this->getBox().is2D() ? float(0.1) * rmax : float(0.1) * std::min(rmax, L.z);
             }
         }
     }
@@ -164,6 +164,9 @@ protected:
 class AABBQueryIterator : virtual public NeighborQueryQueryIterator, virtual public AABBIterator
 {
 public:
+    // Explicitly indicate which toNeighborList function is used.
+    using NeighborQueryQueryIterator::toNeighborList;
+
     //! Constructor
     AABBQueryIterator(const AABBQuery* neighbor_query, const vec3<float>* points, unsigned int N,
                       unsigned int k, float r, float scale, bool exclude_ii)

--- a/cpp/locality/LinkCell.h
+++ b/cpp/locality/LinkCell.h
@@ -418,11 +418,11 @@ public:
     {
         vec3<float> alpha = m_box.makeFraction(p);
         vec3<unsigned int> c;
-        c.x = floorf(alpha.x * float(m_cell_index.getW()));
+        c.x = (unsigned int) floorf(alpha.x * float(m_cell_index.getW()));
         c.x %= m_cell_index.getW();
-        c.y = floorf(alpha.y * float(m_cell_index.getH()));
+        c.y = (unsigned int) floorf(alpha.y * float(m_cell_index.getH()));
         c.y %= m_cell_index.getH();
-        c.z = floorf(alpha.z * float(m_cell_index.getD()));
+        c.z = (unsigned int) floorf(alpha.z * float(m_cell_index.getD()));
         c.z %= m_cell_index.getD();
         return c;
     }
@@ -528,6 +528,9 @@ protected:
 class LinkCellQueryIterator : virtual public NeighborQueryQueryIterator, virtual public LinkCellIterator
 {
 public:
+    // Explicitly indicate which toNeighborList function is used.
+    using NeighborQueryQueryIterator::toNeighborList;
+
     //! Constructor
     LinkCellQueryIterator(const LinkCell* neighbor_query, const vec3<float>* query_points, unsigned int n_query_points,
                           unsigned int num_neighbors, bool exclude_ii)

--- a/cpp/locality/NeighborQuery.h
+++ b/cpp/locality/NeighborQuery.h
@@ -284,8 +284,7 @@ protected:
     unsigned int m_n_query_points;                      //!< Number of query_points.
     unsigned int cur_p;                    //!< The current index into the points (bounded by m_n_query_points).
 
-    unsigned int
-        m_finished;    //!< Flag to indicate that iteration is complete (must be set by next on termination).
+    bool m_finished;    //!< Flag to indicate that iteration is complete (must be set by next on termination).
     bool m_exclude_ii; //!< Flag to indicate whether or not to include self bonds.
 };
 

--- a/cpp/locality/Voronoi.cc
+++ b/cpp/locality/Voronoi.cc
@@ -71,7 +71,7 @@ void Voronoi::compute(const box::Box &box, const vec3<double>* vertices,
 
                 // compute distances bewteen two points
                 vec3<double> rij(expanded_points[j] - expanded_points[i]);
-                float distance = sqrt(dot(rij, rij));
+                float distance = sqrtf(dot(rij, rij));
 
                 // Reject bonds between two image particles
                 if (i >= N && j >= N)
@@ -107,7 +107,7 @@ void Voronoi::compute(const box::Box &box, const vec3<double>* vertices,
                         vec3<double> v2 = current_ridge_vertex[1];
                         // not necessary to have double precision in weight calculation
                         vec3<float> rij(box.wrap(v1 - v2));
-                        weight = sqrt(dot(rij, rij));
+                        weight = sqrtf(dot(rij, rij));
                     }
                     else
                     {

--- a/cpp/order/LocalWl.cc
+++ b/cpp/order/LocalWl.cc
@@ -39,7 +39,7 @@ void LocalWl::computeYlm(const float theta, const float phi, std::vector<std::co
     }
     for (unsigned int i = 1; i <= m_l; i++)
     {
-        Ylm[-i + m_l] = Ylm[i + m_l];
+        Ylm[m_l - i] = Ylm[i + m_l];
     }
 }
 
@@ -61,7 +61,7 @@ void LocalWl::compute(const locality::NeighborList* nlist, const vec3<float>* po
     // the quantity is multiplied by the normalization factor
     // and then the result is square rooted, so here we just
     // divide by the square root.
-    float normalizationfactor = sqrt(4 * M_PI / (2 * m_l + 1));
+    float normalizationfactor = sqrtf(4 * M_PI / (2 * m_l + 1));
 
     // Get wigner3j coefficients from wigner3j.cc
     m_wigner3jvalues = getWigner3j(m_l);

--- a/cpp/order/Steinhardt.cc
+++ b/cpp/order/Steinhardt.cc
@@ -36,7 +36,7 @@ void Steinhardt::computeYlm(const float theta, const float phi, std::vector<std:
         }
         for (unsigned int i = 1; i <= m_l; i++)
         {
-            Ylm[-i + m_l] = Ylm[i + m_l];
+            Ylm[m_l - i] = Ylm[i + m_l];
         }
     }
     else
@@ -130,7 +130,7 @@ void Steinhardt::baseCompute(const freud::locality::NeighborList* nlist,
                              const freud::locality::NeighborQuery* points,
                              freud::locality::QueryArgs qargs)
 {
-    const float normalizationfactor = 4 * M_PI / (2 * m_l + 1);
+    const float normalizationfactor = float(4 * M_PI / (2 * m_l + 1));
     // For consistency, this reset is done here regardless of whether the array
     // is populated in baseCompute or computeAve.
     m_Qlm_local.reset();

--- a/cpp/pmft/PMFTXYZ.cc
+++ b/cpp/pmft/PMFTXYZ.cc
@@ -22,7 +22,7 @@ namespace freud { namespace pmft {
 PMFTXYZ::PMFTXYZ(float x_max, float y_max, float z_max, unsigned int n_x, unsigned int n_y, unsigned int n_z,
                  vec3<float> shiftvec)
     : PMFT(), m_x_max(x_max), m_y_max(y_max), m_z_max(z_max), m_n_x(n_x), m_n_y(n_y), m_n_z(n_z),
-      m_n_faces(0), m_shiftvec(shiftvec)
+      m_shiftvec(shiftvec)
 {
     if (n_x < 1)
         throw invalid_argument("PMFTXYZ requires at least 1 bin in X.");
@@ -38,9 +38,9 @@ PMFTXYZ::PMFTXYZ(float x_max, float y_max, float z_max, unsigned int n_x, unsign
         throw invalid_argument("PMFTXYZ requires that z_max must be positive.");
 
     // calculate dx, dy, dz
-    m_dx = 2.0 * m_x_max / float(m_n_x);
-    m_dy = 2.0 * m_y_max / float(m_n_y);
-    m_dz = 2.0 * m_z_max / float(m_n_z);
+    m_dx = float(2.0) * m_x_max / float(m_n_x);
+    m_dy = float(2.0) * m_y_max / float(m_n_y);
+    m_dz = float(2.0) * m_z_max / float(m_n_z);
 
     if (m_dx > x_max)
         throw invalid_argument("PMFTXYZ requires that dx is less than or equal to x_max.");

--- a/cpp/pmft/PMFTXYZ.h
+++ b/cpp/pmft/PMFTXYZ.h
@@ -88,7 +88,6 @@ private:
     unsigned int m_n_x; //!< Number of x bins to compute pcf over
     unsigned int m_n_y; //!< Number of y bins to compute pcf over
     unsigned int m_n_z; //!< Number of z bins to compute pcf over
-    unsigned int m_n_faces;
     float m_jacobian;
     vec3<float> m_shiftvec; //!< vector that points from [0,0,0] to the origin of the pmft
 


### PR DESCRIPTION
Removes some of the warnings that have appeared over the course of our changes. It intentionally does not fix all of them. In general, there are two classes of warnings that I didn't fix. One is cases that will be fixed by adding proper support for double precision, for example because there are floats multiplying the outputs of dot products. The other is implicit size_t <--> unsigned int conversions; I don't think there's anything we should do about this, it's simply the way that tbb exposes the iterator variable in parallel for loops.