### PR TITLE
Fix possible out of bounds access in LinkCell

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,6 +2,13 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Next
+
+### Fixed
+* Reduced various compiler warnings.
+* Possible out of bounds LinkCell access.
+
+
 ## v1.2.1 - 2019-07-26
 
 ### Changed

--- a/cpp/locality/LinkCell.cc
+++ b/cpp/locality/LinkCell.cc
@@ -366,7 +366,7 @@ NeighborPoint LinkCellQueryBallIterator::next()
 {
     float r_cutsq = m_r * m_r;
 
-    while (cur_p < m_N)
+    while (true)
     {
         vec3<unsigned int> point_cell(m_linkcell->getCellCoord(m_points[cur_p]));
         const unsigned int point_cell_index = m_linkcell->getCellIndex(
@@ -425,6 +425,8 @@ NeighborPoint LinkCellQueryBallIterator::next()
             }
         }
         cur_p++;
+        if (cur_p >= m_N)
+            break;
         m_neigh_cell_iter = IteratorCellShell(0, m_neighbor_query->getBox().is2D());
         m_cell_iter = m_linkcell->itercell(m_linkcell->getCell(m_points[cur_p]));
         m_searched_cells.clear();
@@ -449,7 +451,7 @@ NeighborPoint LinkCellQueryIterator::next()
     }
     unsigned int max_range = ceil(min_plane_distance / (2 * m_linkcell->getCellWidth())) + 1;
 
-    while (cur_p < m_N)
+    while (true)
     {
         vec3<unsigned int> point_cell(m_linkcell->getCellCoord(m_points[cur_p]));
         const unsigned int point_cell_index = m_linkcell->getCellIndex(
@@ -527,6 +529,8 @@ NeighborPoint LinkCellQueryIterator::next()
             return m_current_neighbors[m_count - 1];
         }
         cur_p++;
+        if (cur_p >= m_N)
+            break;
         m_count = 0;
         m_current_neighbors.clear();
         m_neigh_cell_iter = IteratorCellShell(0, m_neighbor_query->getBox().is2D());

--- a/tests/test_locality_NeighborQuery.py
+++ b/tests/test_locality_NeighborQuery.py
@@ -118,7 +118,7 @@ class TestNeighborQuery(object):
         # now move particle 0 out of range...
         points[0] = 5
 
-        nq = freud.locality.LinkCell(box, rcut, points)
+        nq = self.build_query_object(box, points, rcut)
         nlist = nq._queryGeneric(points, dict(mode='ball', rmax=rcut))
         nlist_neighbors = sorted(list(zip(nlist.index_i, nlist.index_j)))
         # particle 0 has 0 bonds


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The termination condition for the iteration loop has been changed; instead of placing it in the while condition, it's now a separate conditional at the end of the loop.

## Motivation and Context
The old method allowed the line `m_cell_iter = m_linkcell->itercell(m_linkcell->getCell(m_points[cur_p]));` to access one element out of bounds. This bug never caused an actual problem because I suspect that the access of junk memory gave some valid cell, and that cell was never used because the condition in the while loop immediately stopped it.

## How Has This Been Tested?
This bug arose in the context of a different branch. That branch explicitly triggers this failure, so it will be automatically tested when that feature is merged.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds or improves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/glotzerlab/freud/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] I have updated the documentation (if relevant).
- [x] I have added tests that cover my changes (if relevant).
- [x] All new and existing tests passed.
- [x] I have updated the [Changelog](https://github.com/glotzerlab/freud/blob/master/ChangeLog.md).
