### PR TITLE
Initialize TBB explicitly at import.

### DIFF
--- a/freud/__init__.py
+++ b/freud/__init__.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2010-2019 The Regents of the University of Michigan
 # This file is from the freud project, released under the BSD 3-Clause License.
 
-from . import parallel
 from . import box
 from . import cluster
 from . import common
@@ -11,7 +10,28 @@ from . import interface
 from . import locality
 from . import msd
 from . import order
+from . import parallel
 from . import pmft
 from . import voronoi
 
+# Override TBB's default autoselection. This is necessary because once the
+# automatic selection runs, the user cannot change it.
+parallel.setNumThreads(0)
+
 __version__ = '1.2.1'
+
+__all__ = [
+    '__version__',
+    'box',
+    'cluster',
+    'common',
+    'density',
+    'environment',
+    'interface',
+    'locality',
+    'msd',
+    'order',
+    'parallel',
+    'pmft',
+    'voronoi',
+]

--- a/freud/parallel.pyx
+++ b/freud/parallel.pyx
@@ -66,8 +66,3 @@ class NumThreads:
 
     def __exit__(self, *args):
         setNumThreads(self.restore_N)
-
-
-# Override TBB's default autoselection. This is necessary because once the
-# automatic selection runs, the user cannot change it.
-setNumThreads(0)


### PR DESCRIPTION
## Description
I think it's more transparent to initialize TBB in the `__init__.py` file than in `parallel.pyx`. This is a small change that I think would fit into v2.0.

## How Has This Been Tested?
Existing tests (which address changing the number of threads) pass.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature (non-breaking change which adds or improves functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have read the [**CONTRIBUTING**](https://github.com/glotzerlab/freud/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] I have updated the documentation (if relevant).
- [x] I have added tests that cover my changes (if relevant).
- [x] All new and existing tests passed.
- [ ] I have updated the [Changelog](https://github.com/glotzerlab/freud/blob/master/ChangeLog.md).
