### PR TITLE
Add optional bond weights to Steinhardt order parameters.

### DIFF
--- a/cpp/order/Steinhardt.h
+++ b/cpp/order/Steinhardt.h
@@ -122,6 +122,24 @@ public:
         return m_norm;
     }
 
+    //!< Whether to take a second shell average
+    bool isAverage()
+    {
+        return m_average;
+    }
+
+    //!< Whether to use the third-order invariant Wl
+    bool isWl()
+    {
+        return m_Wl;
+    }
+
+    //!< Whether to use neighbor weights in computing Qlmi
+    bool isWeighted()
+    {
+        return m_weighted;
+    }
+
     //! Compute the order parameter
     virtual void compute(const freud::locality::NeighborList* nlist,
                                   const freud::locality::NeighborQuery* points, freud::locality::QueryArgs qargs);

--- a/cpp/order/Steinhardt.h
+++ b/cpp/order/Steinhardt.h
@@ -65,8 +65,8 @@ public:
      *                         Allows looking at, for instance, only the second shell,
      *                         or some other arbitrary rdf region.
      */
-    Steinhardt(float rmax, unsigned int l, float rmin = 0, bool average = false, bool Wl = false)
-        : m_Np(0), m_rmax(rmax), m_l(l), m_rmin(rmin), m_average(average), m_Wl(Wl), m_Qlm_local(2 * l + 1)
+    Steinhardt(float rmax, unsigned int l, float rmin = 0, bool average = false, bool Wl = false, bool weighted = false)
+        : m_Np(0), m_rmax(rmax), m_l(l), m_rmin(rmin), m_average(average), m_Wl(Wl), m_weighted(weighted), m_Qlm_local(2 * l + 1)
     {
         // Error Checking
         if (m_rmax < 0.0f || m_rmin < 0.0f)
@@ -167,6 +167,7 @@ private:
     // Flags
     bool m_average; //!< Whether to take a second shell average (default false)
     bool m_Wl;      //!< Whether to use the third-order invariant Wl (default false)
+    bool m_weighted;      //!< Whether to use neighbor weights in computing Qlmi (default false)
 
     std::shared_ptr<std::complex<float>> m_Qlmi; //!< Qlm for each particle i
     std::shared_ptr<std::complex<float>> m_Qlm;  //!< Normalized Qlm(Ave) for the whole system

--- a/freud/_order.pxd
+++ b/freud/_order.pxd
@@ -80,6 +80,9 @@ cdef extern from "Steinhardt.h" namespace "freud::order":
         shared_ptr[float] getQl()
         shared_ptr[float] getOrder()
         float getNorm()
+        bool isAverage()
+        bool isWl()
+        bool isWeighted()
 
 cdef extern from "SolLiq.h" namespace "freud::order":
     cdef cppclass SolLiq:

--- a/freud/_order.pxd
+++ b/freud/_order.pxd
@@ -72,7 +72,7 @@ cdef extern from "HexTransOrderParameter.h" namespace "freud::order":
 cdef extern from "Steinhardt.h" namespace "freud::order":
     cdef cppclass Steinhardt:
         Steinhardt(float, unsigned int, float,
-                   bool, bool) except +
+                   bool, bool, bool) except +
         unsigned int getNP()
         void compute(const freud._locality.NeighborList*,
                      const freud._locality.NeighborQuery*,

--- a/freud/order.pyx
+++ b/freud/order.pyx
@@ -677,7 +677,7 @@ cdef class Steinhardt(Compute):
     def _repr_png_(self):
         import plot
         try:
-            return plot.ax_to_bytes(self.plot(mode=self.plot_mode))
+            return plot.ax_to_bytes(self.plot())
         except AttributeError:
             return None
 

--- a/freud/order.pyx
+++ b/freud/order.pyx
@@ -666,7 +666,7 @@ cdef class Steinhardt(Compute):
             (:class:`matplotlib.axes.Axes`): Axis with the plot.
         """
         import plot
-        mode_letter = 'W' if self.stptr.getUseWl() else 'Q'
+        mode_letter = 'W' if self.stptr.isWl() else 'Q'
         xlabel = r"${}_{{{}}}$".format(mode_letter, self.sph_l)
         return plot.histogram_plot(self.order,
                                    title="Steinhardt Order Parameter",

--- a/freud/order.pyx
+++ b/freud/order.pyx
@@ -665,19 +665,19 @@ cdef class Steinhardt(Compute):
         Returns:
             (:class:`matplotlib.axes.Axes`): Axis with the plot.
         """
-        import plot
+        import freud.plot
         mode_letter = 'W' if self.stptr.isWl() else 'Q'
         xlabel = r"${}_{{{}}}$".format(mode_letter, self.sph_l)
-        return plot.histogram_plot(self.order,
-                                   title="Steinhardt Order Parameter",
-                                   xlabel=xlabel,
-                                   ylabel=r"Number of particles",
-                                   ax=ax)
+        return freud.plot.histogram_plot(self.order,
+                                         title="Steinhardt Order Parameter",
+                                         xlabel=xlabel,
+                                         ylabel=r"Number of particles",
+                                         ax=ax)
 
     def _repr_png_(self):
-        import plot
+        import freud.plot
         try:
-            return plot.ax_to_bytes(self.plot())
+            return freud.plot.ax_to_bytes(self.plot())
         except AttributeError:
             return None
 

--- a/tests/test_order_Steinhardt.py
+++ b/tests/test_order_Steinhardt.py
@@ -256,6 +256,10 @@ class TestSteinhardt(unittest.TestCase):
     def test_repr(self):
         comp = freud.order.Steinhardt(1.5, 6)
         self.assertEqual(str(comp), str(eval(repr(comp))))
+        # Use non-default arguments for all parameters
+        comp = freud.order.Steinhardt(1.5, 6, 0.1, average=True, Wl=True,
+                                      weighted=True, num_neighbors=7)
+        self.assertEqual(str(comp), str(eval(repr(comp))))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Description
Weighted bonds enable the use of _Minkowski structure metrics_ by defining Steinhardt order parameters over a Voronoi neighborhood weighted by Voronoi polytope facet areas, discussed in ref. 1 below.

## Motivation and Context
This PR resolves #45.

This PR changes the normalization done by the Steinhardt class to use bond weights if the `weighted` flag is set to True. Alternatively, we could _always_ enable weights without expecting a significant change in behavior, since the NeighborQuery and NeighborList default behavior is to assign a weight of 1 to each bond.

## How Has This Been Tested?
New tests have been added (todo: not yet finalized/pushed).

## References
[1] Shortcomings of the bond orientational order parameters for the analysis of disordered particulate matter
J. Chem. Phys. **138**, 044501 (2013); https://doi.org/10.1063/1.4774084
Walter Mickel, Sebastian C. Kapfer, Gerd E. Schröder-Turk, and Klaus Mecke

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds or improves functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have read the [**CONTRIBUTING**](https://github.com/glotzerlab/freud/blob/master/CONTRIBUTING.md) document.
- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation (if relevant).
- [ ] I have added tests that cover my changes (if relevant).
- [ ] All new and existing tests passed.
- [ ] I have updated the [Changelog](https://github.com/glotzerlab/freud/blob/master/ChangeLog.md).
