### PR TITLE
Use rowan for quaternions in testing.

### DIFF
--- a/tests/test_environment_AngularSeparation.py
+++ b/tests/test_environment_AngularSeparation.py
@@ -1,41 +1,9 @@
 import numpy.testing as npt
 import numpy as np
 import freud
+import rowan
 import unittest
 from util import make_box_and_random_points
-
-
-def quatRandom():
-    """Returns a random quaternion culled from a uniform distribution on the
-    surface of a 3-sphere. Uses the Marsaglia (1972) method (a la HOOMD).
-    Note that generating a random rotation via a random angle about a random
-    axis of rotation is INCORRECT. See K. Shoemake, "Uniform Random Rotations,"
-    1992, for a nice explanation for this.
-
-    The output quaternion is an array of four numbers: [q0, q1, q2, q3]"""
-
-    # np.random.uniform(low, high) gives a number from the interval [low, high)
-    v1 = np.random.uniform(-1, 1)
-    v2 = np.random.uniform(-1, 1)
-    v3 = np.random.uniform(-1, 1)
-    v4 = np.random.uniform(-1, 1)
-
-    s1 = v1*v1 + v2*v2
-    s2 = v3*v3 + v4*v4
-
-    while (s1 >= 1.):
-        v1 = np.random.uniform(-1, 1)
-        v2 = np.random.uniform(-1, 1)
-        s1 = v1*v1 + v2*v2
-
-    while (s2 >= 1. or s2 == 0.):
-        v3 = np.random.uniform(-1, 1)
-        v4 = np.random.uniform(-1, 1)
-        s2 = v3*v3 + v4*v4
-
-    s3 = np.sqrt((1.-s1)/s2)
-
-    return np.array([v1, v2, v3*s3, v4*s3])
 
 
 class TestAngularSeparation(unittest.TestCase):
@@ -47,16 +15,8 @@ class TestAngularSeparation(unittest.TestCase):
 
         box, points = make_box_and_random_points(boxlen, N, True)
         _, query_points = make_box_and_random_points(boxlen, N//3, True)
-
-        ors = []
-        for i in range(N):
-            ors.append(quatRandom())
-
-        query_ors = []
-        for i in range(N//3):
-            query_ors.append(quatRandom())
-
-        ors = np.asarray(ors, dtype=np.float32)
+        ors = rowan.random.rand(N)
+        query_ors = rowan.random.rand(N//3)
 
         ang = freud.environment.AngularSeparation(rmax, num_neigh)
 
@@ -86,11 +46,7 @@ class TestAngularSeparation(unittest.TestCase):
         num_neigh = 8
         rmax = 3
 
-        ors = []
-        for i in range(N):
-            ors.append(quatRandom())
-
-        ors = np.asarray(ors, dtype=np.float32)
+        ors = rowan.random.rand(N)
         equiv_quats = np.asarray([[1, 0, 0, 0]], dtype=np.float32)
         global_ors = np.array([[1, 0, 0, 0]], dtype=np.float32)
 
@@ -105,12 +61,7 @@ class TestAngularSeparation(unittest.TestCase):
         rmax = 3
 
         box, points = make_box_and_random_points(boxlen, N, True)
-
-        ors = []
-        for i in range(N):
-            ors.append(quatRandom())
-
-        ors = np.asarray(ors, dtype=np.float32)
+        ors = rowan.random.rand(N)
 
         ang = freud.environment.AngularSeparation(rmax, num_neigh)
         ang.computeNeighbor(box, points, ors, query_orientations=ors)

--- a/tests/test_environment_BondOrder.py
+++ b/tests/test_environment_BondOrder.py
@@ -1,5 +1,6 @@
 import numpy as np
 import freud
+import rowan
 import unittest
 import util
 
@@ -8,8 +9,7 @@ class TestBondOrder(unittest.TestCase):
     def test_bond_order(self):
         """Test the bond order diagram calculation."""
         (box, positions) = util.make_fcc(4, 4, 4)
-        quats = np.zeros((len(positions), 4), dtype=np.float32)
-        quats[:, 0] = 1
+        quats = np.array([[1, 0, 0, 0]] * len(positions))
 
         r_cut = 1.5
         num_neighbors = 12
@@ -71,8 +71,7 @@ class TestBondOrder(unittest.TestCase):
 
             # Test that normal bod looks ordered for randomized orientations.
             np.random.seed(10893)
-            random_quats = np.random.rand(len(positions), 4)
-            random_quats /= np.linalg.norm(random_quats, axis=1)[:, np.newaxis]
+            random_quats = rowan.random.rand(len(positions))
             bo.compute(box, ts[0], random_quats, nlist=ts[1])
             self.assertTrue(np.allclose(bo.bond_order, op_value))
 

--- a/tests/test_environment_LocalBondProjection.py
+++ b/tests/test_environment_LocalBondProjection.py
@@ -1,43 +1,9 @@
 import unittest
 import numpy.testing as npt
 import numpy as np
-import random
 import freud
+import rowan
 from util import make_box_and_random_points
-
-
-random.seed(0)
-
-
-# Returns a random quaternion culled from a uniform distribution on the surface
-# of a 3-sphere. Uses the MARSAGLIA (1972) method (a la hoomd) NOTE THAT
-# generating a random rotation via a random angle about a random axis of
-# rotation is INCORRECT. See K. Shoemake, "Uniform Random Rotations," 1992,
-# for a nice explanation for this. Output quat is an array of four numbers:
-# [q0, q1, q2, q3]
-def quatRandom():
-    # random.uniform(a,b) gives number in [a,b]
-    v1 = random.uniform(-1, 1)
-    v2 = random.uniform(-1, 1)
-    v3 = random.uniform(-1, 1)
-    v4 = random.uniform(-1, 1)
-
-    s1 = v1*v1 + v2*v2
-    s2 = v3*v3 + v4*v4
-
-    while (s1 >= 1.):
-        v1 = random.uniform(-1, 1)
-        v2 = random.uniform(-1, 1)
-        s1 = v1*v1 + v2*v2
-
-    while (s2 >= 1. or s2 == 0.):
-        v3 = random.uniform(-1, 1)
-        v4 = random.uniform(-1, 1)
-        s2 = v3*v3 + v4*v4
-
-    s3 = np.sqrt((1.-s1)/s2)
-
-    return np.array([v1, v2, v3*s3, v4*s3])
 
 
 class TestLocalBondProjection(unittest.TestCase):
@@ -51,12 +17,7 @@ class TestLocalBondProjection(unittest.TestCase):
 
         box, points = make_box_and_random_points(boxlen, N, True)
         _, query_points = make_box_and_random_points(boxlen, N_query, True)
-
-        ors = []
-        for i in range(N):
-            ors.append(quatRandom())
-
-        ors = np.asarray(ors, dtype=np.float32)
+        ors = rowan.random.rand(N)
         proj_vecs = np.asarray([[0, 0, 1]])
 
         ang = freud.environment.LocalBondProjection(rmax, num_neigh)
@@ -71,12 +32,7 @@ class TestLocalBondProjection(unittest.TestCase):
         rmax = 3
 
         box, points = make_box_and_random_points(boxlen, N, True)
-
-        ors = []
-        for i in range(N):
-            ors.append(quatRandom())
-
-        ors = np.asarray(ors, dtype=np.float32)
+        ors = rowan.random.rand(N)
         proj_vecs = np.asarray([[0, 0, 1]])
 
         ang = freud.environment.LocalBondProjection(rmax, num_neigh)
@@ -90,12 +46,7 @@ class TestLocalBondProjection(unittest.TestCase):
         rmax = 3
 
         box, points = make_box_and_random_points(boxlen, N)
-
-        ors = []
-        for i in range(N):
-            ors.append(quatRandom())
-
-        ors = np.asarray(ors, dtype=np.float32)
+        ors = rowan.random.rand(N)
         proj_vecs = np.asarray([[0, 0, 1]])
 
         ang = freud.environment.LocalBondProjection(rmax, num_neigh)
@@ -115,12 +66,7 @@ class TestLocalBondProjection(unittest.TestCase):
         rmax = 3
 
         box, points = make_box_and_random_points(boxlen, N, True)
-
-        ors = []
-        for i in range(N):
-            ors.append(quatRandom())
-
-        ors = np.asarray(ors, dtype=np.float32)
+        ors = rowan.random.rand(N)
         proj_vecs = np.asarray([[0, 0, 1]])
 
         ang = freud.environment.LocalBondProjection(rmax, num_neigh)

--- a/tests/test_order_Nematic.py
+++ b/tests/test_order_Nematic.py
@@ -1,18 +1,8 @@
 import numpy as np
 import numpy.testing as npt
 import freud
+import rowan
 import unittest
-
-
-def gen_quaternions(n, axes, angles):
-    q = np.zeros(shape=(n, 4), dtype=np.float32)
-    for i, (axis, angle) in enumerate(zip(axes, angles)):
-        q[i] = [np.cos(angle/2.0),
-                np.sin(angle/2.0) * axis[0],
-                np.sin(angle/2.0) * axis[1],
-                np.sin(angle/2.0) * axis[2]]
-        q[i] /= np.linalg.norm(q[i])
-    return q
 
 
 class TestNematicOrder(unittest.TestCase):
@@ -22,7 +12,7 @@ class TestNematicOrder(unittest.TestCase):
         axes = np.zeros(shape=(N, 3), dtype=np.float32)
         angles = np.zeros(shape=N, dtype=np.float32)
         axes[:, 0] = 1.0
-        orientations = gen_quaternions(N, axes, angles)
+        orientations = rowan.from_axis_angle(axes, angles)
 
         # Test for parallel to molecular axis
         u = np.array([1, 0, 0])
@@ -70,13 +60,11 @@ class TestNematicOrder(unittest.TestCase):
         to the ideal case.
         """
         N = 1000
-        axes = np.zeros(shape=(N, 3), dtype=np.float32)
         np.random.seed(0)
-        v = 0.005
-        orientations = np.random.multivariate_normal(mean=[1, 0, 0, 0],
-                                                     cov=v*np.eye(4),
-                                                     size=axes.shape[0])
-        orientations /= np.linalg.norm(orientations, axis=1)[:, np.newaxis]
+
+        # Generate orientations close to the identity quaternion
+        orientations = \
+            rowan.interpolate.slerp([1, 0, 0, 0], rowan.random.rand(N), 0.1)
 
         u = np.array([1, 0, 0])
         op = freud.order.NematicOrderParameter(u)


### PR DESCRIPTION
## Description
This uses rowan for generating quaternions in testing code.

## Motivation and Context
Resolves #376.

## How Has This Been Tested?
Existing tests pass. I also re-enabled a test that used to fail intermittently -- I think we might have fixed a bug in the Cubatic code that was causing it to fail.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds or improves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have read the [**CONTRIBUTING**](https://github.com/glotzerlab/freud/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] I have updated the documentation (if relevant).
- [x] I have added tests that cover my changes (if relevant).
- [x] All new and existing tests passed.
- [ ] I have updated the [Changelog](https://github.com/glotzerlab/freud/blob/master/ChangeLog.md).
