### PR TITLE
Remove versions added/changed from docs

### DIFF
--- a/freud/box.pyx
+++ b/freud/box.pyx
@@ -267,8 +267,6 @@ cdef class Box:
     def getImage(self, vecs):
         R"""Returns the image corresponding to a wrapped vector.
 
-        .. versionadded:: 0.8
-
         Args:
             vecs (:math:`\left(3\right)` or :math:`\left(N, 3\right)` :class:`numpy.ndarray`):
                 Coordinates of a single vector or array of :math:`N` unwrapped vectors.
@@ -660,8 +658,6 @@ cdef class ParticleBuffer:
 
     .. moduleauthor:: Ben Schultz <baschult@umich.edu>
     .. moduleauthor:: Bradley Dice <bdice@bradleydice.com>
-
-    .. versionadded:: 0.11
 
     Args:
         box (:py:class:`freud.box.Box`): Simulation box.

--- a/freud/box.pyx
+++ b/freud/box.pyx
@@ -40,9 +40,6 @@ cdef class Box:
     .. moduleauthor:: Carl Simon Adorf <csadorf@umich.edu>
     .. moduleauthor:: Bradley Dice <bdice@bradleydice.com>
 
-    .. versionchanged:: 0.7.0
-       Added box periodicity interface
-
     The Box class is defined according to the conventions of the
     HOOMD-blue simulation software.
     For more information, please see:

--- a/freud/density.pyx
+++ b/freud/density.pyx
@@ -827,9 +827,6 @@ cdef class RDF(Compute):
             The centers of each bin.
         n_r ((:math:`N_{bins}`,) :class:`numpy.ndarray`):
             Histogram of cumulative RDF values (*i.e.* the integrated RDF).
-
-    .. versionchanged:: 0.7.0
-       Added optional `r_min` argument.
     """
     cdef freud._density.RDF * thisptr
     cdef r_max

--- a/freud/environment.pyx
+++ b/freud/environment.pyx
@@ -1090,8 +1090,6 @@ cdef class LocalBondProjection(Compute):
 
     .. moduleauthor:: Erin Teich <erteich@umich.edu>
 
-    .. versionadded:: 0.11
-
     Args:
         r_max (float):
             Cutoff radius.

--- a/freud/locality.pyx
+++ b/freud/locality.pyx
@@ -167,8 +167,6 @@ cdef class NeighborQueryResult:
     object.
 
     .. moduleauthor:: Vyas Ramasubramani <vramasub@umich.edu>
-
-    .. versionadded:: 1.1.0
     """
 
     def __iter__(self):
@@ -233,8 +231,6 @@ cdef class AABBQueryResult(NeighborQueryResult):
     to call the C++ query function with the correct set of arguments.
 
     .. moduleauthor:: Vyas Ramasubramani <vramasub@umich.edu>
-
-    .. versionadded:: 1.1.0
     """
 
     cdef shared_ptr[
@@ -275,8 +271,6 @@ cdef class NeighborQuery:
     data structure.
 
     .. moduleauthor:: Vyas Ramasubramani <vramasub@umich.edu>
-
-    .. versionadded:: 1.1.0
 
     Args:
         box (:class:`freud.box.Box`):
@@ -417,8 +411,6 @@ cdef class NeighborList:
     :meth:`find_first_index`.
 
     .. moduleauthor:: Matthew Spellings <mspells@umich.edu>
-
-    .. versionadded:: 0.6.4
 
     .. note::
 
@@ -878,9 +870,6 @@ cdef class RawPoints(NeighborQuery):
             The simulation box.
         points (:class:`np.ndarray`):
             The points associated with this class.
-
-    .. versionadded:: 1.1.0
-
     """  # noqa: E501
 
     def __cinit__(self, box, points):
@@ -906,8 +895,6 @@ cdef class AABBQuery(NeighborQuery):
 
     .. moduleauthor:: Bradley Dice <bdice@bradleydice.com>
     .. moduleauthor:: Vyas Ramasubramani <vramasub@umich.edu>
-
-    .. versionadded:: 1.1.0
 
     Attributes:
         box (:class:`freud.locality.Box`):
@@ -1697,8 +1684,6 @@ cdef class _Voronoi:
     def volumes(self):
         R"""Returns an array of volumes (areas in 2D) corresponding to Voronoi
         cells.
-
-        .. versionadded:: 0.8
 
         Must call :meth:`freud.locality.Voronoi.compute()` before this
         method.

--- a/freud/msd.pyx
+++ b/freud/msd.pyx
@@ -137,8 +137,6 @@ cdef class MSD(Compute):
 
     .. moduleauthor:: Vyas Ramasubramani <vramasub@umich.edu>
 
-    .. versionadded:: 1.0
-
     Args:
         box (:class:`freud.box.Box`, optional):
             If not provided, the class will assume that all positions provided

--- a/freud/order.pyx
+++ b/freud/order.pyx
@@ -211,8 +211,6 @@ cdef class NematicOrderParameter(Compute):
 
     .. moduleauthor:: Jens Glaser <jsglaser@umich.edu>
 
-    .. versionadded:: 0.7.0
-
     Args:
         u (:math:`\left(3 \right)` :class:`numpy.ndarray`):
             The nematic director of a single particle in the reference state
@@ -1895,8 +1893,6 @@ cdef class RotationalAutocorrelation(Compute):
 
     .. moduleauthor:: Andrew Karas <askaras@umich.edu>
     .. moduleauthor:: Vyas Ramasubramani <vramasub@umich.edu>
-
-    .. versionadded:: 1.0
 
     Args:
         l (int):


### PR DESCRIPTION
## Description
Removes `.. versionadded` and `.. versionchanged` blocks. They're only used in a couple places, they don't carry enough details, and the Changelog communicates the information more effectively.

## Motivation and Context
Resolves #365.

## How Has This Been Tested?
Existing tests pass.

## Types of changes
- Just docs 📝 

## Checklist:
- [x] I have read the [**CONTRIBUTING**](https://github.com/glotzerlab/freud/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] I have updated the documentation (if relevant).
- [x] I have added tests that cover my changes (if relevant).
- [x] All new and existing tests passed.
- [ ] I have updated the [Changelog](https://github.com/glotzerlab/freud/blob/master/ChangeLog.md).