### PR TITLE
Fix rotational invariance tests on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -287,6 +287,7 @@ references:
             for VERSION in ${PY_VERSIONS[@]}; do
               pyenv global ${VERSION}
               pip install freud_analysis --no-deps --no-index -f ~/ci/freud/wheelhouse
+              pip install rowan sympy
               cd ~/ci/freud/tests
               python -m unittest discover . -v
             done

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -213,6 +213,7 @@ references:
             # Install from and test all wheels
             for PYBIN in /opt/python/*/bin/; do
               "${PYBIN}/python" -m pip install freud_analysis --no-deps --no-index -f ~/ci/freud/wheelhouse
+              "${PYBIN}/python" -m pip install rowan sympy
               cd ~/ci/freud/tests
               "${PYBIN}/python" -m unittest discover . -v
             done

--- a/tests/test_order_LocalQl.py
+++ b/tests/test_order_LocalQl.py
@@ -140,8 +140,8 @@ class TestLocalQl(unittest.TestCase):
             quat = rowan.random.rand()
             positions_rotated = rowan.rotate(quat, positions)
             q6.compute(positions_rotated, nlist=nlist)
-            npt.assert_almost_equal(q6.Ql[0], q6_unrotated_order)
-            npt.assert_almost_equal(q6.Ql[0], PERFECT_FCC_Q6)
+            npt.assert_allclose(q6.Ql[0], q6_unrotated_order, rtol=1e-5)
+            npt.assert_allclose(q6.Ql[0], PERFECT_FCC_Q6, rtol=1e-5)
 
 
 class TestLocalQlNear(unittest.TestCase):
@@ -282,8 +282,8 @@ class TestLocalQlNear(unittest.TestCase):
             quat = rowan.random.rand()
             positions_rotated = rowan.rotate(quat, positions)
             q6.compute(positions_rotated, nlist=nlist)
-            npt.assert_almost_equal(q6.Ql[0], q6_unrotated_order)
-            npt.assert_almost_equal(q6.Ql[0], PERFECT_FCC_Q6)
+            npt.assert_allclose(q6.Ql[0], q6_unrotated_order, rtol=1e-5)
+            npt.assert_allclose(q6.Ql[0], PERFECT_FCC_Q6, rtol=1e-5)
 
 
 if __name__ == '__main__':

--- a/tests/test_order_LocalWl.py
+++ b/tests/test_order_LocalWl.py
@@ -144,8 +144,8 @@ class TestLocalWl(unittest.TestCase):
             quat = rowan.random.rand()
             positions_rotated = rowan.rotate(quat, positions)
             w6.compute(positions_rotated, nlist=nlist)
-            npt.assert_almost_equal(w6.Wl[0], w6_unrotated_order)
-            npt.assert_almost_equal(w6.Wl[0], PERFECT_FCC_W6)
+            npt.assert_allclose(w6.Wl[0], w6_unrotated_order, rtol=1e-5)
+            npt.assert_allclose(w6.Wl[0], PERFECT_FCC_W6, rtol=1e-5)
 
 
 class TestLocalWlNear(unittest.TestCase):
@@ -278,8 +278,8 @@ class TestLocalWlNear(unittest.TestCase):
             quat = rowan.random.rand()
             positions_rotated = rowan.rotate(quat, positions)
             w6.compute(positions_rotated, nlist=nlist)
-            npt.assert_almost_equal(w6.Wl[0], w6_unrotated_order)
-            npt.assert_almost_equal(w6.Wl[0], PERFECT_FCC_W6)
+            npt.assert_allclose(w6.Wl[0], w6_unrotated_order, rtol=1e-5)
+            npt.assert_allclose(w6.Wl[0], PERFECT_FCC_W6, rtol=1e-5)
 
 
 if __name__ == '__main__':

--- a/tests/test_order_Steinhardt.py
+++ b/tests/test_order_Steinhardt.py
@@ -138,13 +138,13 @@ class TestSteinhardt(unittest.TestCase):
 
             # Ensure Q6 is rotationally invariant
             q6.compute(box, positions_rotated, nlist=nlist)
-            npt.assert_almost_equal(q6.order[0], q6_unrotated_order)
-            npt.assert_almost_equal(q6.order[0], PERFECT_FCC_Q6)
+            npt.assert_allclose(q6.order[0], q6_unrotated_order, rtol=1e-5)
+            npt.assert_allclose(q6.order[0], PERFECT_FCC_Q6, rtol=1e-5)
 
             # Ensure W6 is rotationally invariant
             w6.compute(box, positions_rotated, nlist=nlist)
-            npt.assert_almost_equal(w6.order[0], w6_unrotated_order)
-            npt.assert_almost_equal(w6.order[0], PERFECT_FCC_W6)
+            npt.assert_allclose(w6.order[0], w6_unrotated_order, rtol=1e-5)
+            npt.assert_allclose(w6.order[0], PERFECT_FCC_W6, rtol=1e-5)
 
     def test_repr(self):
         comp = freud.order.Steinhardt(1.5, 6)


### PR DESCRIPTION
## Description
Our CI builds for PyPI failed because of missing packages (rowan, sympy) and numerical precision. This PR fixes those issues.

## How Has This Been Tested?
I ran these tests on CI after installing rowan and sympy, and it appears to work correctly.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds or improves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have read the [**CONTRIBUTING**](https://github.com/glotzerlab/freud/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] I have updated the documentation (if relevant).
- [x] I have added tests that cover my changes (if relevant).
- [x] All new and existing tests passed.
- [ ] I have updated the [Changelog](https://github.com/glotzerlab/freud/blob/master/ChangeLog.md).
