### PR TITLE
Feature/standardize query args

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -7,6 +7,7 @@ Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to
 ### Added
 * Ability to specify NeighborQuery objects as points for neighbor-based pair computes.
 * Various validation tests.
+* Added standard method for preprocessing arguments of pair computations.
 
 ### Changed
 * All compute objects that perform neighbor computations now use NeighborQuery internally.
@@ -22,8 +23,6 @@ Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to
 
 ### Removed
 * The freud.util module.
-
-### Removed
 * Python 2 is no longer supported. Python 3.5+ is required.
 
 ## v1.2.2 - 2019-08-15

--- a/cpp/locality/AABBQuery.h
+++ b/cpp/locality/AABBQuery.h
@@ -110,18 +110,18 @@ protected:
         inferMode(args);
         if (args.mode == QueryArgs::ball)
         {
-            if (args.r_max == -1)
+            if (args.r_max == QueryArgs::DEFAULT_R_MAX)
                 throw std::runtime_error("You must set r_max in the query arguments when performing ball queries.");
         }
         else if (args.mode == QueryArgs::nearest)
         {
-            if (args.num_neigh == -1)
+            if (args.num_neigh == QueryArgs::DEFAULT_NUM_NEIGH)
                 throw std::runtime_error("You must set num_neigh in the query arguments when performing number of neighbor queries.");
-            if (args.scale == -1)
+            if (args.scale == QueryArgs::DEFAULT_SCALE)
             {
                 args.scale = float(1.1);
             }
-            if (args.r_max == -1)
+            if (args.r_max == QueryArgs::DEFAULT_R_MAX)
             {
                 vec3<float> L = this->getBox().getL();
                 float r_max = std::min(L.x, L.y);

--- a/cpp/locality/AABBQuery.h
+++ b/cpp/locality/AABBQuery.h
@@ -123,9 +123,11 @@ protected:
             }
             if (args.r_max == QueryArgs::DEFAULT_R_MAX)
             {
+                // By default, we use 1/10 the smallest box dimension as the guessed query distance.
                 vec3<float> L = this->getBox().getL();
                 float r_max = std::min(L.x, L.y);
-                args.r_max = this->getBox().is2D() ? float(0.1) * r_max : float(0.1) * std::min(r_max, L.z);
+                r_max = this->getBox().is2D() ? r_max : std::min(r_max, L.z);
+                args.r_max = float(0.1) * r_max;
             }
         }
     }

--- a/cpp/locality/AABBQuery.h
+++ b/cpp/locality/AABBQuery.h
@@ -59,7 +59,7 @@ public:
         }
         else if (args.mode == QueryArgs::nearest)
         {
-            return query(query_points, n_query_points, args.num_neigh, args.r_max, args.scale, args.exclude_ii);
+            return query(query_points, n_query_points, args.num_neighbors, args.r_max, args.scale, args.exclude_ii);
         }
         else
         {
@@ -115,8 +115,8 @@ protected:
         }
         else if (args.mode == QueryArgs::nearest)
         {
-            if (args.num_neigh == QueryArgs::DEFAULT_NUM_NEIGH)
-                throw std::runtime_error("You must set num_neigh in the query arguments when performing number of neighbor queries.");
+            if (args.num_neighbors == QueryArgs::DEFAULT_NUM_NEIGHBORS)
+                throw std::runtime_error("You must set num_neighbors in the query arguments when performing number of neighbor queries.");
             if (args.scale == QueryArgs::DEFAULT_SCALE)
             {
                 args.scale = float(1.1);

--- a/cpp/locality/AABBQuery.h
+++ b/cpp/locality/AABBQuery.h
@@ -112,6 +112,8 @@ protected:
         {
             if (args.r_max == QueryArgs::DEFAULT_R_MAX)
                 throw std::runtime_error("You must set r_max in the query arguments when performing ball queries.");
+            if (args.num_neighbors != QueryArgs::DEFAULT_NUM_NEIGHBORS)
+                throw std::runtime_error("You cannot set num_neighbors in the query arguments when performing ball queries.");
         }
         else if (args.mode == QueryArgs::nearest)
         {

--- a/cpp/locality/AABBQuery.h
+++ b/cpp/locality/AABBQuery.h
@@ -102,23 +102,14 @@ public:
 
 protected:
     //! Validate the combination of specified arguments.
-    /*! Override parent function to account for the various arguments
+    /*! Add to parent function to account for the various arguments
      *  specifically required for AABBQuery nearest neighbor queries.
      */
     virtual void validateQueryArgs(QueryArgs& args) const
     {
-        inferMode(args);
-        if (args.mode == QueryArgs::ball)
+        NeighborQuery::validateQueryArgs(args);
+        if (args.mode == QueryArgs::nearest)
         {
-            if (args.r_max == QueryArgs::DEFAULT_R_MAX)
-                throw std::runtime_error("You must set r_max in the query arguments when performing ball queries.");
-            if (args.num_neighbors != QueryArgs::DEFAULT_NUM_NEIGHBORS)
-                throw std::runtime_error("You cannot set num_neighbors in the query arguments when performing ball queries.");
-        }
-        else if (args.mode == QueryArgs::nearest)
-        {
-            if (args.num_neighbors == QueryArgs::DEFAULT_NUM_NEIGHBORS)
-                throw std::runtime_error("You must set num_neighbors in the query arguments when performing number of neighbor queries.");
             if (args.scale == QueryArgs::DEFAULT_SCALE)
             {
                 args.scale = float(1.1);

--- a/cpp/locality/AABBQuery.h
+++ b/cpp/locality/AABBQuery.h
@@ -107,16 +107,16 @@ protected:
      */
     virtual void validateQueryArgs(QueryArgs& args) const
     {
-        args.inferMode();
+        inferMode(args);
         if (args.mode == QueryArgs::ball)
         {
             if (args.r_max == -1)
-                throw std::runtime_error("You must set r_max in the query arguments.");
+                throw std::runtime_error("You must set r_max in the query arguments when performing ball queries.");
         }
         else if (args.mode == QueryArgs::nearest)
         {
             if (args.num_neigh == -1)
-                throw std::runtime_error("You must set nn in the query arguments.");
+                throw std::runtime_error("You must set num_neigh in the query arguments when performing number of neighbor queries.");
             if (args.scale == -1)
             {
                 args.scale = float(1.1);

--- a/cpp/locality/NeighborComputeFunctional.h
+++ b/cpp/locality/NeighborComputeFunctional.h
@@ -116,7 +116,7 @@ public:
         // the number of neighbors to look for.
         if(qargs.exclude_ii && (qargs.mode == QueryArgs::QueryType::nearest))
         {
-            ++m_qargs.nn;
+            ++m_qargs.num_neigh;
         }
 
         // check if nq is a pointer to a RawPoints object
@@ -309,7 +309,7 @@ void loopOverNeighborQuery(const NeighborQuery* neighbor_query, const vec3<float
     // the number of neighbors to look for.
     if(qargs.exclude_ii && (qargs.mode == QueryArgs::QueryType::nearest))
     {
-        ++qargs.nn;
+        ++qargs.num_neigh;
     }
     // if nlist does not exist, check if neighbor_query is an actual NeighborQuery
     std::shared_ptr<NeighborQueryIterator> iter;

--- a/cpp/locality/NeighborComputeFunctional.h
+++ b/cpp/locality/NeighborComputeFunctional.h
@@ -116,7 +116,7 @@ public:
         // the number of neighbors to look for.
         if(qargs.exclude_ii && (qargs.mode == QueryArgs::QueryType::nearest))
         {
-            ++m_qargs.num_neigh;
+            ++m_qargs.num_neighbors;
         }
 
         // check if nq is a pointer to a RawPoints object
@@ -309,7 +309,7 @@ void loopOverNeighborQuery(const NeighborQuery* neighbor_query, const vec3<float
     // the number of neighbors to look for.
     if(qargs.exclude_ii && (qargs.mode == QueryArgs::QueryType::nearest))
     {
-        ++qargs.num_neigh;
+        ++qargs.num_neighbors;
     }
     // if nlist does not exist, check if neighbor_query is an actual NeighborQuery
     std::shared_ptr<NeighborQueryIterator> iter;

--- a/cpp/locality/NeighborQuery.cc
+++ b/cpp/locality/NeighborQuery.cc
@@ -7,4 +7,9 @@ namespace freud { namespace locality {
 
 const NeighborBond NeighborQueryIterator::ITERATOR_TERMINATOR(-1, -1, 0);
 
+const QueryArgs::QueryType QueryArgs::DEFAULT_MODE(QueryArgs::QueryType::none);
+const int QueryArgs::DEFAULT_NUM_NEIGH(-1);
+const float QueryArgs::DEFAULT_R_MAX(-1);
+const float QueryArgs::DEFAULT_SCALE(-1);
+const bool QueryArgs::DEFAULT_EXCLUDE_II(false);
 }; }; // end namespace freud::locality

--- a/cpp/locality/NeighborQuery.cc
+++ b/cpp/locality/NeighborQuery.cc
@@ -7,9 +7,9 @@ namespace freud { namespace locality {
 
 const NeighborBond NeighborQueryIterator::ITERATOR_TERMINATOR(-1, -1, 0);
 
-const QueryArgs::QueryType QueryArgs::DEFAULT_MODE(QueryArgs::QueryType::none);
-const int QueryArgs::DEFAULT_NUM_NEIGH(-1);
-const float QueryArgs::DEFAULT_R_MAX(-1);
-const float QueryArgs::DEFAULT_SCALE(-1);
+const QueryArgs::QueryType QueryArgs::DEFAULT_MODE(QueryArgs::none);
+const unsigned int QueryArgs::DEFAULT_NUM_NEIGH(0xffffffff);
+const float QueryArgs::DEFAULT_R_MAX(-1.0);
+const float QueryArgs::DEFAULT_SCALE(-1.0);
 const bool QueryArgs::DEFAULT_EXCLUDE_II(false);
 }; }; // end namespace freud::locality

--- a/cpp/locality/NeighborQuery.cc
+++ b/cpp/locality/NeighborQuery.cc
@@ -8,7 +8,7 @@ namespace freud { namespace locality {
 const NeighborBond NeighborQueryIterator::ITERATOR_TERMINATOR(-1, -1, 0);
 
 const QueryArgs::QueryType QueryArgs::DEFAULT_MODE(QueryArgs::none);
-const unsigned int QueryArgs::DEFAULT_NUM_NEIGH(0xffffffff);
+const unsigned int QueryArgs::DEFAULT_NUM_NEIGHBORS(0xffffffff);
 const float QueryArgs::DEFAULT_R_MAX(-1.0);
 const float QueryArgs::DEFAULT_SCALE(-1.0);
 const bool QueryArgs::DEFAULT_EXCLUDE_II(false);

--- a/cpp/locality/NeighborQuery.h
+++ b/cpp/locality/NeighborQuery.h
@@ -43,17 +43,17 @@ struct QueryArgs
     };
 
     QueryType mode; //! Whether to perform a ball or k-nearest neighbor query.
-    int num_neigh;         //! The number of nearest neighbors to find.
+    unsigned int num_neigh;         //! The number of nearest neighbors to find.
     float r_max;     //! The cutoff distance within which to find neighbors
     float scale; //! The scale factor to use when performing repeated ball queries to find a specified number
                  //! of nearest neighbors.
     bool exclude_ii; //! If true, exclude self-neighbors.
 
-    static const QueryType DEFAULT_MODE;       //!< Default mode.
+    static const QueryType DEFAULT_MODE;                //!< Default mode.
     static const unsigned int DEFAULT_NUM_NEIGH;        //!< Default number of neighbors.
-    static const float DEFAULT_R_MAX;          //!< Default query distance.
-    static const float DEFAULT_SCALE;          //!< Default scaling parameter for AABB nearest neighbor queries.
-    static const bool DEFAULT_EXCLUDE_II;      //!< Default for whether or not to include self-neighbors.
+    static const float DEFAULT_R_MAX;                   //!< Default query distance.
+    static const float DEFAULT_SCALE;                   //!< Default scaling parameter for AABB nearest neighbor queries.
+    static const bool DEFAULT_EXCLUDE_II;               //!< Default for whether or not to include self-neighbors.
 };
 
 // Forward declare the iterator
@@ -162,12 +162,12 @@ protected:
         // Validate remaining arguments.
         if (args.mode == QueryArgs::ball)
         {
-            if (args.r_max == -1)
+            if (args.r_max == QueryArgs::DEFAULT_R_MAX)
                 throw std::runtime_error("You must set r_max in the query arguments when performing ball queries.");
         }
         else if (args.mode == QueryArgs::nearest)
         {
-            if (args.num_neigh == -1)
+            if (args.num_neigh == QueryArgs::DEFAULT_NUM_NEIGH)
                 throw std::runtime_error("You must set num_neigh in the query arguments when performing number of neighbor queries.");
         }
     }
@@ -183,11 +183,11 @@ protected:
         // Infer mode if possible.
         if (args.mode == QueryArgs::none)
         {
-            if (args.num_neigh != -1)
+            if (args.num_neigh != QueryArgs::DEFAULT_NUM_NEIGH)
             {
                 args.mode = QueryArgs::nearest;
             }
-            else if (args.r_max != -1)
+            else if (args.r_max != QueryArgs::DEFAULT_R_MAX)
             {
                 args.mode = QueryArgs::ball;
             }

--- a/cpp/locality/NeighborQuery.h
+++ b/cpp/locality/NeighborQuery.h
@@ -164,6 +164,8 @@ protected:
         {
             if (args.r_max == QueryArgs::DEFAULT_R_MAX)
                 throw std::runtime_error("You must set r_max in the query arguments when performing ball queries.");
+            if (args.num_neighbors != QueryArgs::DEFAULT_NUM_NEIGHBORS)
+                throw std::runtime_error("You cannot set num_neighbors in the query arguments when performing ball queries.");
         }
         else if (args.mode == QueryArgs::nearest)
         {

--- a/cpp/locality/NeighborQuery.h
+++ b/cpp/locality/NeighborQuery.h
@@ -40,22 +40,6 @@ struct QueryArgs
         nearest //! Query based on number of requested neighbors.
     };
 
-    void inferMode()
-    {
-        // Infer mode if possible.
-        if (mode == QueryArgs::none)
-        {
-            if (num_neigh != -1)
-            {
-                mode = QueryArgs::nearest;
-            }
-            else if (r_max != -1)
-            {
-                mode = QueryArgs::ball;
-            }
-        }
-    }
-
     QueryType mode; //! Whether to perform a ball or k-nearest neighbor query.
     int num_neigh;         //! The number of nearest neighbors to find.
     float r_max;     //! The cutoff distance within which to find neighbors
@@ -166,7 +150,7 @@ protected:
      */
     virtual void validateQueryArgs(QueryArgs& args) const
     {
-        args.inferMode();
+        inferMode(args);
         // Validate remaining arguments.
         if (args.mode == QueryArgs::ball)
         {
@@ -177,6 +161,28 @@ protected:
         {
             if (args.num_neigh == -1)
                 throw std::runtime_error("You must set num_neigh in the query arguments when performing number of neighbor queries.");
+        }
+    }
+
+    //! Try to determine the query mode if one is not specified.
+    /*! If no mode is specified and a number of neighbors is specified, the
+     *  query mode must be a nearest neighbors query (all other arguments can
+     *  reasonably modify that query). Otherwise, if a max distance is set we
+     *  can assume a ball query is desired.
+     */
+    virtual void inferMode(QueryArgs& args) const
+    {
+        // Infer mode if possible.
+        if (args.mode == QueryArgs::none)
+        {
+            if (args.num_neigh != -1)
+            {
+                args.mode = QueryArgs::nearest;
+            }
+            else if (args.r_max != -1)
+            {
+                args.mode = QueryArgs::ball;
+            }
         }
     }
 

--- a/cpp/locality/NeighborQuery.h
+++ b/cpp/locality/NeighborQuery.h
@@ -31,7 +31,7 @@ struct QueryArgs
     //! Default constructor.
     /*! We set default values for all parameters here.
      */
-    QueryArgs() : mode(DEFAULT_MODE), num_neigh(DEFAULT_NUM_NEIGH), r_max(DEFAULT_R_MAX),
+    QueryArgs() : mode(DEFAULT_MODE), num_neighbors(DEFAULT_NUM_NEIGHBORS), r_max(DEFAULT_R_MAX),
                   scale(DEFAULT_SCALE), exclude_ii(DEFAULT_EXCLUDE_II) {}
 
     //! Enumeration for types of queries.
@@ -43,14 +43,14 @@ struct QueryArgs
     };
 
     QueryType mode; //! Whether to perform a ball or k-nearest neighbor query.
-    unsigned int num_neigh;         //! The number of nearest neighbors to find.
+    unsigned int num_neighbors;         //! The number of nearest neighbors to find.
     float r_max;     //! The cutoff distance within which to find neighbors
     float scale; //! The scale factor to use when performing repeated ball queries to find a specified number
                  //! of nearest neighbors.
     bool exclude_ii; //! If true, exclude self-neighbors.
 
     static const QueryType DEFAULT_MODE;                //!< Default mode.
-    static const unsigned int DEFAULT_NUM_NEIGH;        //!< Default number of neighbors.
+    static const unsigned int DEFAULT_NUM_NEIGHBORS;        //!< Default number of neighbors.
     static const float DEFAULT_R_MAX;                   //!< Default query distance.
     static const float DEFAULT_SCALE;                   //!< Default scaling parameter for AABB nearest neighbor queries.
     static const bool DEFAULT_EXCLUDE_II;               //!< Default for whether or not to include self-neighbors.
@@ -102,7 +102,7 @@ public:
         }
         else if (args.mode == QueryArgs::nearest)
         {
-            return this->query(query_points, n_query_points, args.num_neigh, args.exclude_ii);
+            return this->query(query_points, n_query_points, args.num_neighbors, args.exclude_ii);
         }
         else
         {
@@ -167,8 +167,8 @@ protected:
         }
         else if (args.mode == QueryArgs::nearest)
         {
-            if (args.num_neigh == QueryArgs::DEFAULT_NUM_NEIGH)
-                throw std::runtime_error("You must set num_neigh in the query arguments when performing number of neighbor queries.");
+            if (args.num_neighbors == QueryArgs::DEFAULT_NUM_NEIGHBORS)
+                throw std::runtime_error("You must set num_neighbors in the query arguments when performing number of neighbor queries.");
         }
     }
 
@@ -183,7 +183,7 @@ protected:
         // Infer mode if possible.
         if (args.mode == QueryArgs::none)
         {
-            if (args.num_neigh != QueryArgs::DEFAULT_NUM_NEIGH)
+            if (args.num_neighbors != QueryArgs::DEFAULT_NUM_NEIGHBORS)
             {
                 args.mode = QueryArgs::nearest;
             }

--- a/cpp/locality/NeighborQuery.h
+++ b/cpp/locality/NeighborQuery.h
@@ -31,13 +31,15 @@ struct QueryArgs
     //! Default constructor.
     /*! We set default values for all parameters here.
      */
-    QueryArgs() : mode(none), num_neigh(-1), r_max(-1), scale(-1), exclude_ii(false) {}
+    QueryArgs() : mode(DEFAULT_MODE), num_neigh(DEFAULT_NUM_NEIGH), r_max(DEFAULT_R_MAX),
+                  scale(DEFAULT_SCALE), exclude_ii(DEFAULT_EXCLUDE_II) {}
 
+    //! Enumeration for types of queries.
     enum QueryType
     {
-        none,   //! Default query type to avoid implicit default types.
-        ball,   //! Query based on distance cutoff.
-        nearest //! Query based on number of requested neighbors.
+        none,    //! Default query type to avoid implicit default types.
+        ball,    //! Query based on distance cutoff.
+        nearest, //! Query based on number of requested neighbors.
     };
 
     QueryType mode; //! Whether to perform a ball or k-nearest neighbor query.
@@ -46,6 +48,12 @@ struct QueryArgs
     float scale; //! The scale factor to use when performing repeated ball queries to find a specified number
                  //! of nearest neighbors.
     bool exclude_ii; //! If true, exclude self-neighbors.
+
+    static const QueryType DEFAULT_MODE;       //!< Default mode.
+    static const unsigned int DEFAULT_NUM_NEIGH;        //!< Default number of neighbors.
+    static const float DEFAULT_R_MAX;          //!< Default query distance.
+    static const float DEFAULT_SCALE;          //!< Default scaling parameter for AABB nearest neighbor queries.
+    static const bool DEFAULT_EXCLUDE_II;      //!< Default for whether or not to include self-neighbors.
 };
 
 // Forward declare the iterator

--- a/freud/_locality.pxd
+++ b/freud/_locality.pxd
@@ -19,6 +19,7 @@ cdef extern from "NeighborBond.h" namespace "freud::locality":
 cdef extern from "NeighborQuery.h" namespace "freud::locality":
 
     ctypedef enum QueryType "freud::locality::QueryArgs::QueryType":
+        none "freud::locality::QueryArgs::QueryType::none"
         ball "freud::locality::QueryArgs::QueryType::ball"
         nearest "freud::locality::QueryArgs::QueryType::nearest"
 
@@ -28,6 +29,7 @@ cdef extern from "NeighborQuery.h" namespace "freud::locality":
         float rmax
         float scale
         bool exclude_ii
+        void validate() except +
 
     cdef cppclass NeighborQuery:
         NeighborQuery()

--- a/freud/_locality.pxd
+++ b/freud/_locality.pxd
@@ -25,7 +25,7 @@ cdef extern from "NeighborQuery.h" namespace "freud::locality":
 
     cdef cppclass QueryArgs:
         QueryType mode
-        int num_neigh
+        int num_neighbors
         float r_max
         float scale
         bool exclude_ii

--- a/freud/_locality.pxd
+++ b/freud/_locality.pxd
@@ -25,11 +25,10 @@ cdef extern from "NeighborQuery.h" namespace "freud::locality":
 
     cdef cppclass QueryArgs:
         QueryType mode
-        int nn
-        float rmax
+        int num_neigh
+        float r_max
         float scale
         bool exclude_ii
-        void validate() except +
 
     cdef cppclass NeighborQuery:
         NeighborQuery()

--- a/freud/common.pxd
+++ b/freud/common.pxd
@@ -1,2 +1,5 @@
 cdef class Compute:
     cdef public _called_compute
+
+cdef class PairCompute(Compute):
+    pass

--- a/freud/common.pyx
+++ b/freud/common.pyx
@@ -6,11 +6,19 @@
 import numpy as np
 import freud.box
 
+cimport freud.box
+cimport freud.locality
+
 from functools import wraps
 
 cdef class Compute:
-    R"""Parent class implementing functions to prevent access of
-    uncomputed values.
+    R"""Parent class for all compute classes in freud.
+
+    Currently, the primary purpose of this class is implementing functions to
+    prevent access of uncomputed values. This is accomplished by maintaining a
+    dictionary of compute functions in a class that have been called and
+    decorating class properties with the names of the compute function that
+    must be called to populate that property.
 
     To use this class, one would do, for example,
 
@@ -123,6 +131,70 @@ cdef class Compute:
                 self._called_compute[k] = False
             func(self, *args, **kwargs)
         return wrapper
+
+
+cdef class PairCompute(Compute):
+    R"""Parent class for all compute classes in freud that depend on finding
+    nearest neighbors.
+
+    The purpose of this class is to consolidate some of the logic for parsing
+    the numerous possible inputs to the compute calls of such classes. In
+    particular, this class contains a helper function that calls the necessary
+    functions to create NeighborQuery and NeighborList classes as needed, as
+    well as dealing with boxes and query arguments.
+
+    .. moduleauthor:: Vyas Ramasubramani <vramasub@umich.edu>
+    """
+    def preprocess_arguments(self, box, points, query_points=None, nlist=None,
+                              query_args=None):
+        """Process standard compute arguments into freud's internal types by
+        calling all the required internal functions.
+
+        The preprocessing of boxes and points into NeighborQuery objects, the
+        determination of how to handle the NeighborList object, the creation
+        of default query arguments as needed, deciding what query_points are,
+        and setting the appropriate exclude_ii flag are all handled in this
+        function.
+
+        Args:
+            box (:class:`freud.box.Box`):
+                Simulation box.
+            points ((:math:`N_{points}`, 3) :class:`numpy.ndarray`):
+                Reference points used to calculate the RDF.
+            query_points ((:math:`N_{query_points}`, 3) :class:`numpy.ndarray`, optional):
+                Points used to calculate the RDF. Uses :code:`points` if
+                not provided or :code:`None`.
+            nlist (:class:`freud.locality.NeighborList`, optional):
+                NeighborList to use to find bonds (Default value =
+                :code:`None`).
+            query_args (dict): A dictionary of query arguments (Default value =
+                :code:`None`).
+        """
+        cdef freud.box.Box b = freud.common.convert_box(box)
+
+        cdef freud.locality.NeighborQuery nq = freud.locality.make_default_nq(
+            box, points)
+        cdef freud.locality.NlistptrWrapper nlistptr = \
+            freud.locality.NlistptrWrapper(nlist)
+
+        cdef freud.locality._QueryArgs qargs = \
+            freud.locality._QueryArgs.from_dict(
+                query_args if query_args else
+                self.get_default_query_args(query_points is None))
+        if query_points is None:
+            query_points = nq.points
+        query_points = freud.common.convert_array(
+            query_points, shape=(None, 3))
+        cdef const float[:, ::1] l_query_points = query_points
+        cdef unsigned int n_p = l_query_points.shape[0]
+        return (b, nq, nlistptr, qargs, l_query_points, n_p)
+
+    def get_default_query_args(self, exclude_ii):
+        raise RuntimeError(
+            "The {} class must must define a get_default_query_args function. "
+            "This is a bug in freud, please report at "
+            "https://github.com/glotzerlab/freud/issues.".format(
+            type(self).__name__))
 
 
 def convert_array(array, shape=None, dtype=np.float32):

--- a/freud/common.pyx
+++ b/freud/common.pyx
@@ -6,10 +6,10 @@
 import numpy as np
 import freud.box
 
+from functools import wraps
+
 cimport freud.box
 cimport freud.locality
-
-from functools import wraps
 
 cdef class Compute:
     R"""Parent class for all compute classes in freud.
@@ -145,8 +145,9 @@ cdef class PairCompute(Compute):
 
     .. moduleauthor:: Vyas Ramasubramani <vramasub@umich.edu>
     """
+
     def preprocess_arguments(self, box, points, query_points=None, nlist=None,
-                              query_args=None):
+                             query_args=None):
         """Process standard compute arguments into freud's internal types by
         calling all the required internal functions.
 
@@ -169,7 +170,7 @@ cdef class PairCompute(Compute):
                 :code:`None`).
             query_args (dict): A dictionary of query arguments (Default value =
                 :code:`None`).
-        """
+        """  # noqa E501
         cdef freud.box.Box b = freud.common.convert_box(box)
 
         cdef freud.locality.NeighborQuery nq = freud.locality.make_default_nq(
@@ -194,7 +195,7 @@ cdef class PairCompute(Compute):
             "The {} class must must define a get_default_query_args function. "
             "This is a bug in freud, please report at "
             "https://github.com/glotzerlab/freud/issues.".format(
-            type(self).__name__))
+                type(self).__name__))
 
 
 def convert_array(array, shape=None, dtype=np.float32):

--- a/freud/common.pyx
+++ b/freud/common.pyx
@@ -187,8 +187,8 @@ cdef class PairCompute(Compute):
                     self.default_query_args)
                 qargs.update({'exclude_ii': query_points is None})
             except ValueError:
-                # If a NeighborList was provided, then the user need not povide
-                # QueryArgs.
+                # If a NeighborList was provided, then the user need not
+                # provide QueryArgs.
                 if nlist is None:
                     raise
                 else:

--- a/freud/density.pyx
+++ b/freud/density.pyx
@@ -865,8 +865,9 @@ cdef class RDF(Compute):
         cdef freud.locality.NlistptrWrapper nlistptr = nq_nlist[1]
 
         cdef freud.locality._QueryArgs qargs = \
-            freud.locality._QueryArgs.from_dict(query_args if query_args else
-                    self.get_default_query_args(query_points is None))
+            freud.locality._QueryArgs.from_dict(
+                query_args if query_args else
+                self.get_default_query_args(query_points is None))
         points = nq.points
 
         if query_points is None:

--- a/freud/density.pyx
+++ b/freud/density.pyx
@@ -865,8 +865,9 @@ cdef class RDF(PairCompute):
             cdef freud.locality._QueryArgs qargs
             cdef const float[:, ::1] l_query_points
             cdef unsigned int n_p
-        b, nq, nlistptr, qargs, l_query_points, n_p = self.preprocess_arguments(
-            box, points, query_points, nlist, query_args)
+        b, nq, nlistptr, qargs, l_query_points, n_p = \
+            self.preprocess_arguments(box, points, query_points, nlist,
+                                      query_args)
 
         with nogil:
             self.thisptr.accumulate(

--- a/freud/density.pyx
+++ b/freud/density.pyx
@@ -860,12 +860,12 @@ cdef class RDF(PairCompute):
         """  # noqa E501
         cdef:
             freud.box.Box b
-            cdef freud.locality.NeighborQuery nq
-            cdef freud.locality.NlistptrWrapper nlistptr
-            cdef freud.locality._QueryArgs qargs
-            cdef const float[:, ::1] l_query_points
-            cdef unsigned int n_p
-        b, nq, nlistptr, qargs, l_query_points, n_p = \
+            freud.locality.NeighborQuery nq
+            freud.locality.NlistptrWrapper nlistptr
+            freud.locality._QueryArgs qargs
+            const float[:, ::1] l_query_points
+            unsigned int num_query_points
+        b, nq, nlistptr, qargs, l_query_points, num_query_points = \
             self.preprocess_arguments(box, points, query_points, nlist,
                                       query_args)
 
@@ -873,15 +873,17 @@ cdef class RDF(PairCompute):
             self.thisptr.accumulate(
                 nq.get_ptr(),
                 <vec3[float]*> &l_query_points[0, 0],
-                n_p, nlistptr.get_ptr(), dereference(qargs.thisptr))
+                num_query_points, nlistptr.get_ptr(),
+                dereference(qargs.thisptr))
         return self
 
-    def get_default_query_args(self, exclude_ii):
-        return dict(mode="ball", r_max=self.r_max, exclude_ii=exclude_ii)
+    @property
+    def default_query_args(self):
+        return dict(mode="ball", r_max=self.r_max)
 
     @Compute._compute()
     def compute(self, box, points, query_points=None, nlist=None,
-                query_args={}):
+                query_args=None):
         R"""Calculates the RDF for the specified points. Will overwrite the current
         histogram.
 

--- a/freud/environment.pyx
+++ b/freud/environment.pyx
@@ -175,7 +175,7 @@ cdef class BondOrder(Compute):
         cdef freud.locality.NlistptrWrapper nlistptr = nq_nlist[1]
 
         cdef freud.locality._QueryArgs qargs = freud.locality._QueryArgs(
-            mode="nearest", nn=self.num_neigh,
+            mode="nearest", num_neigh=self.num_neigh,
             r_max=self.r_max, exclude_ii=exclude_ii)
         points = nq.points
 

--- a/freud/environment.pyx
+++ b/freud/environment.pyx
@@ -116,7 +116,7 @@ cdef class BondOrder(Compute):
 
     """  # noqa: E501
     cdef freud._environment.BondOrder * thisptr
-    cdef num_neigh
+    cdef num_neighbors
     cdef r_max
     cdef n_bins_t
     cdef n_bins_p
@@ -130,7 +130,7 @@ cdef class BondOrder(Compute):
         self.thisptr = new freud._environment.BondOrder(
             r_max, num_neighbors, n_bins_t, n_bins_p)
         self.r_max = r_max
-        self.num_neigh = num_neighbors
+        self.num_neighbors = num_neighbors
         self.n_bins_t = n_bins_t
         self.n_bins_p = n_bins_p
 
@@ -175,7 +175,7 @@ cdef class BondOrder(Compute):
         cdef freud.locality.NlistptrWrapper nlistptr = nq_nlist[1]
 
         cdef freud.locality._QueryArgs qargs = freud.locality._QueryArgs(
-            mode="nearest", num_neigh=self.num_neigh,
+            mode="nearest", num_neighbors=self.num_neighbors,
             r_max=self.r_max, exclude_ii=exclude_ii)
         points = nq.points
 
@@ -300,12 +300,11 @@ cdef class BondOrder(Compute):
 
     def __repr__(self):
         return ("freud.environment.{cls}(r_max={r_max}, "
-                "num_neighbors={num_neigh}, n_bins_t={n_bins_t}, "
-                "n_bins_p={n_bins_p})").format(cls=type(self).__name__,
-                                               r_max=self.r_max,
-                                               num_neigh=self.num_neigh,
-                                               n_bins_t=self.n_bins_t,
-                                               n_bins_p=self.n_bins_p)
+                "num_neighbors={num_neighbors}, n_bins_t={n_bins_t}, "
+                "n_bins_p={n_bins_p})").format(
+                    cls=type(self).__name__, r_max=self.r_max,
+                    num_neighbors=self.num_neighbors, n_bins_t=self.n_bins_t,
+                    n_bins_p=self.n_bins_p)
 
     def __str__(self):
         return repr(self)
@@ -340,18 +339,20 @@ cdef class LocalDescriptors(Compute):
             A reference to the last computed spherical harmonic array.
         num_particles (unsigned int):
             The number of points passed to the last call to :meth:`~.compute`.
-        num_neighbors (unsigned int):
-            The number of neighbors used by the last call to compute. Bounded
-            from above by the number of reference points multiplied by the
-            lower of the num_neighbors arguments passed to the last compute
-            call or the constructor.
+        num_sphs (unsigned int):
+            The last number of spherical harmonics computed. This is equal to
+            the number of bonds in the last computation, which is bounded from
+            above by the number of reference points multiplied by the lower of
+            the num_neighbors arguments passed to the last compute call or the
+            constructor (the reason it's a bound and not an equality is because
+            there may not be enough neighbors for every particle).
         l_max (unsigned int):
             The maximum spherical harmonic :math:`l` to calculate for.
         r_max (float):
             The cutoff radius.
     """  # noqa: E501
     cdef freud._environment.LocalDescriptors * thisptr
-    cdef num_neigh
+    cdef num_neighbors
     cdef r_max
     cdef lmax
     cdef negative_m
@@ -363,7 +364,7 @@ cdef class LocalDescriptors(Compute):
     def __cinit__(self, num_neighbors, lmax, r_max, negative_m=True):
         self.thisptr = new freud._environment.LocalDescriptors(
             lmax, negative_m)
-        self.num_neigh = num_neighbors
+        self.num_neighbors = num_neighbors
         self.r_max = r_max
         self.lmax = lmax
         self.negative_m = negative_m
@@ -438,10 +439,10 @@ cdef class LocalDescriptors(Compute):
 
         l_mode = self.known_modes[mode]
 
-        self.num_neigh = num_neighbors
+        self.num_neighbors = num_neighbors
 
         defaulted_nlist = freud.locality.make_default_nlist_nn(
-            b, points, query_points, self.num_neigh, nlist,
+            b, points, query_points, self.num_neighbors, nlist,
             exclude_ii, self.r_max)
         cdef freud.locality.NeighborList nlist_ = defaulted_nlist[0]
 
@@ -470,7 +471,7 @@ cdef class LocalDescriptors(Compute):
         return self.thisptr.getNPoints()
 
     @Compute._computed_property()
-    def num_neighbors(self):
+    def num_sphs(self):
         return self.thisptr.getNSphs()
 
     @property
@@ -478,13 +479,12 @@ cdef class LocalDescriptors(Compute):
         return self.thisptr.getLMax()
 
     def __repr__(self):
-        return ("freud.environment.{cls}(num_neighbors={num_neigh}, "
+        return ("freud.environment.{cls}(num_neighbors={num_neighbors}, "
                 "lmax={lmax}, r_max={r_max}, "
-                "negative_m={negative_m})").format(cls=type(self).__name__,
-                                                   num_neigh=self.num_neigh,
-                                                   lmax=self.lmax,
-                                                   r_max=self.r_max,
-                                                   negative_m=self.negative_m)
+                "negative_m={negative_m})").format(
+                    cls=type(self).__name__, num_neighbors=self.num_neighbors,
+                    lmax=self.lmax, r_max=self.r_max,
+                    negative_m=self.negative_m)
 
     def __str__(self):
         return repr(self)
@@ -518,7 +518,7 @@ cdef class MatchEnv(Compute):
     """  # noqa: E501
     cdef freud._environment.MatchEnv * thisptr
     cdef r_max
-    cdef num_neigh
+    cdef num_neighbors
     cdef m_box
 
     def __cinit__(self, box, r_max, num_neighbors):
@@ -528,7 +528,7 @@ cdef class MatchEnv(Compute):
             dereference(b.thisptr), r_max, num_neighbors)
 
         self.r_max = r_max
-        self.num_neigh = num_neighbors
+        self.num_neighbors = num_neighbors
         self.m_box = box
 
     def __dealloc__(self):
@@ -592,12 +592,12 @@ cdef class MatchEnv(Compute):
             env_nlist_ = defaulted_env_nlist[0]
         else:
             defaulted_nlist = freud.locality.make_default_nlist_nn(
-                self.m_box, points, points, self.num_neigh, nlist,
+                self.m_box, points, points, self.num_neighbors, nlist,
                 True, self.r_max)
             nlist_ = defaulted_nlist[0]
 
             defaulted_env_nlist = freud.locality.make_default_nlist_nn(
-                self.m_box, points, points, self.num_neigh, env_nlist,
+                self.m_box, points, points, self.num_neighbors, env_nlist,
                 True, self.r_max)
             env_nlist_ = defaulted_env_nlist[0]
 
@@ -642,7 +642,7 @@ cdef class MatchEnv(Compute):
 
         defaulted_nlist = freud.locality.make_default_nlist_nn(
             self.m_box, points, points,
-            self.num_neigh, nlist, True, self.r_max)
+            self.num_neighbors, nlist, True, self.r_max)
         cdef freud.locality.NeighborList nlist_ = defaulted_nlist[0]
 
         self.thisptr.matchMotif(
@@ -686,7 +686,7 @@ cdef class MatchEnv(Compute):
 
         defaulted_nlist = freud.locality.make_default_nlist_nn(
             self.m_box, points, points,
-            self.num_neigh, nlist, True, self.r_max)
+            self.num_neighbors, nlist, True, self.r_max)
         cdef freud.locality.NeighborList nlist_ = defaulted_nlist[0]
 
         cdef vector[float] min_rmsd_vec = self.thisptr.minRMSDMotif(
@@ -835,7 +835,7 @@ cdef class MatchEnv(Compute):
         return ("freud.environment.{cls}(box={box}, "
                 "r_max={r}, num_neighbors={k})").format(
                     cls=type(self).__name__, box=self.m_box.__repr__(),
-                    r=self.r_max, k=self.num_neigh)
+                    r=self.r_max, k=self.num_neighbors)
 
     def __str__(self):
         return repr(self)
@@ -905,14 +905,14 @@ cdef class AngularSeparation(Compute):
             strict_cut=True
     """  # noqa: E501
     cdef freud._environment.AngularSeparation * thisptr
-    cdef unsigned int num_neigh
+    cdef unsigned int num_neighbors
     cdef float r_max
     cdef freud.locality.NeighborList nlist_
 
     def __cinit__(self, float r_max, unsigned int num_neighbors):
         self.thisptr = new freud._environment.AngularSeparation()
         self.r_max = r_max
-        self.num_neigh = num_neighbors
+        self.num_neighbors = num_neighbors
 
     def __dealloc__(self):
         del self.thisptr
@@ -975,7 +975,7 @@ cdef class AngularSeparation(Compute):
             equiv_orientations, shape=(None, 4))
 
         defaulted_nlist = freud.locality.make_default_nlist_nn(
-            b, points, query_points, self.num_neigh,
+            b, points, query_points, self.num_neighbors,
             nlist, exclude_ii, self.r_max)
         self.nlist_ = defaulted_nlist[0].copy()
 
@@ -1077,7 +1077,7 @@ cdef class AngularSeparation(Compute):
 
     def __repr__(self):
         return "freud.environment.{cls}(r_max={r}, num_neighbors={n})".format(
-            cls=type(self).__name__, r=self.r_max, n=self.num_neigh)
+            cls=type(self).__name__, r=self.r_max, n=self.num_neighbors)
 
     def __str__(self):
         return repr(self)
@@ -1115,13 +1115,13 @@ cdef class LocalBondProjection(Compute):
     """  # noqa: E501
     cdef freud._environment.LocalBondProjection * thisptr
     cdef float r_max
-    cdef unsigned int num_neigh
+    cdef unsigned int num_neighbors
     cdef freud.locality.NeighborList nlist_
 
     def __cinit__(self, r_max, num_neighbors):
         self.thisptr = new freud._environment.LocalBondProjection()
         self.r_max = r_max
-        self.num_neigh = int(num_neighbors)
+        self.num_neighbors = int(num_neighbors)
 
     def __dealloc__(self):
         del self.thisptr
@@ -1183,7 +1183,7 @@ cdef class LocalBondProjection(Compute):
         proj_vecs = freud.common.convert_array(proj_vecs, shape=(None, 3))
 
         defaulted_nlist = freud.locality.make_default_nlist_nn(
-            box, points, query_points, self.num_neigh, nlist,
+            box, points, query_points, self.num_neighbors, nlist,
             exclude_ii, self.r_max)
         self.nlist_ = defaulted_nlist[0].copy()
 
@@ -1248,9 +1248,9 @@ cdef class LocalBondProjection(Compute):
 
     def __repr__(self):
         return ("freud.environment.{cls}(r_max={r_max}, "
-                "num_neighbors={num_neigh})").format(cls=type(self).__name__,
-                                                     r_max=self.r_max,
-                                                     num_neigh=self.num_neigh)
+                "num_neighbors={num_neighbors})").format(
+                    cls=type(self).__name__, r_max=self.r_max,
+                    num_neighbors=self.num_neighbors)
 
     def __str__(self):
         return repr(self)

--- a/freud/environment.pyx
+++ b/freud/environment.pyx
@@ -326,7 +326,7 @@ cdef class LocalDescriptors(Compute):
     Args:
         num_neighbors (unsigned int):
             Maximum number of neighbors to compute descriptors for.
-        lmax (unsigned int):
+        l_max (unsigned int):
             Maximum spherical harmonic :math:`l` to consider.
         r_max (float):
             Initial guess of the maximum radius to looks for neighbors.
@@ -341,11 +341,10 @@ cdef class LocalDescriptors(Compute):
             The number of points passed to the last call to :meth:`~.compute`.
         num_sphs (unsigned int):
             The last number of spherical harmonics computed. This is equal to
-            the number of bonds in the last computation, which is bounded from
-            above by the number of reference points multiplied by the lower of
-            the num_neighbors arguments passed to the last compute call or the
-            constructor (the reason it's a bound and not an equality is because
-            there may not be enough neighbors for every particle).
+            the number of bonds in the last computation, which is at most the
+            number of `points` multiplied by the lower of the `num_neighbors`
+            arguments passed to the last compute call or the constructor (it
+            may be less if there are not enough neighbors for every particle).
         l_max (unsigned int):
             The maximum spherical harmonic :math:`l` to calculate for.
         r_max (float):
@@ -354,19 +353,17 @@ cdef class LocalDescriptors(Compute):
     cdef freud._environment.LocalDescriptors * thisptr
     cdef num_neighbors
     cdef r_max
-    cdef lmax
     cdef negative_m
 
     known_modes = {'neighborhood': freud._environment.LocalNeighborhood,
                    'global': freud._environment.Global,
                    'particle_local': freud._environment.ParticleLocal}
 
-    def __cinit__(self, num_neighbors, lmax, r_max, negative_m=True):
+    def __cinit__(self, num_neighbors, l_max, r_max, negative_m=True):
         self.thisptr = new freud._environment.LocalDescriptors(
-            lmax, negative_m)
+            l_max, negative_m)
         self.num_neighbors = num_neighbors
         self.r_max = r_max
-        self.lmax = lmax
         self.negative_m = negative_m
 
     def __dealloc__(self):
@@ -480,10 +477,10 @@ cdef class LocalDescriptors(Compute):
 
     def __repr__(self):
         return ("freud.environment.{cls}(num_neighbors={num_neighbors}, "
-                "lmax={lmax}, r_max={r_max}, "
+                "l_max={l_max}, r_max={r_max}, "
                 "negative_m={negative_m})").format(
                     cls=type(self).__name__, num_neighbors=self.num_neighbors,
-                    lmax=self.lmax, r_max=self.r_max,
+                    l_max=self.l_max, r_max=self.r_max,
                     negative_m=self.negative_m)
 
     def __str__(self):

--- a/freud/locality.pxd
+++ b/freud/locality.pxd
@@ -12,7 +12,7 @@ cdef class NeighborQueryResult:
     cdef NeighborQuery nq
     cdef const float[:, ::1] points
     cdef float r_max
-    cdef unsigned int num_neigh
+    cdef unsigned int num_neighbors
     cdef unsigned int Np
     cdef cbool exclude_ii
     cdef str query_type
@@ -30,9 +30,9 @@ cdef class NeighborQueryResult:
     @staticmethod
     cdef inline NeighborQueryResult init(
             NeighborQuery nq, const float[:, ::1] points,
-            cbool exclude_ii, float r_max=0, unsigned int num_neigh=0):
+            cbool exclude_ii, float r_max=0, unsigned int num_neighbors=0):
         # Internal API only
-        assert r_max != 0 or num_neigh != 0
+        assert r_max != 0 or num_neighbors != 0
 
         obj = NeighborQueryResult()
 
@@ -42,12 +42,12 @@ cdef class NeighborQueryResult:
         obj.Np = points.shape[0]
 
         obj.r_max = r_max
-        obj.num_neigh = num_neigh
+        obj.num_neighbors = num_neighbors
 
         if obj.r_max != 0:
             obj.query_type = 'ball'
         else:
-            obj.query_type = 'num_neigh'
+            obj.query_type = 'nearest'
 
         return obj
 
@@ -59,9 +59,11 @@ cdef class AABBQueryResult(NeighborQueryResult):
     @staticmethod
     cdef inline AABBQueryResult init_aabb_nn(
             AABBQuery aabbq, const float[:, ::1] points,
-            cbool exclude_ii, unsigned int num_neigh, float r_max, float scale):
+            cbool exclude_ii,
+            unsigned int num_neighbors, float r_max,
+            float scale):
         # Internal API only
-        assert num_neigh != 0
+        assert num_neighbors != 0
 
         obj = AABBQueryResult()
         obj.aabbq = obj.nq = aabbq
@@ -71,9 +73,9 @@ cdef class AABBQueryResult(NeighborQueryResult):
 
         # For AABBs, even kN queries require a distance cutoff
         obj.r_max = r_max
-        obj.num_neigh = num_neigh
+        obj.num_neighbors = num_neighbors
 
-        obj.query_type = 'num_neigh'
+        obj.query_type = 'nearest'
 
         obj.scale = scale
 

--- a/freud/locality.pxd
+++ b/freud/locality.pxd
@@ -32,7 +32,7 @@ cdef class NeighborQueryResult:
             NeighborQuery nq, const float[:, ::1] points,
             cbool exclude_ii, float r_max=0, unsigned int num_neighbors=0):
         # Internal API only
-        assert r_max != 0 or num_neighbors != 0
+        assert r_max > 0 or num_neighbors > 0
 
         obj = NeighborQueryResult()
 
@@ -63,7 +63,7 @@ cdef class AABBQueryResult(NeighborQueryResult):
             unsigned int num_neighbors, float r_max,
             float scale):
         # Internal API only
-        assert num_neighbors != 0
+        assert num_neighbors > 0
 
         obj = AABBQueryResult()
         obj.aabbq = obj.nq = aabbq

--- a/freud/locality.pxd
+++ b/freud/locality.pxd
@@ -11,8 +11,8 @@ cimport freud.box
 cdef class NeighborQueryResult:
     cdef NeighborQuery nq
     cdef const float[:, ::1] points
-    cdef float r
-    cdef unsigned int k
+    cdef float r_max
+    cdef unsigned int num_neigh
     cdef unsigned int Np
     cdef cbool exclude_ii
     cdef str query_type
@@ -30,9 +30,9 @@ cdef class NeighborQueryResult:
     @staticmethod
     cdef inline NeighborQueryResult init(
             NeighborQuery nq, const float[:, ::1] points,
-            cbool exclude_ii, float r=0, unsigned int k=0):
+            cbool exclude_ii, float r_max=0, unsigned int num_neigh=0):
         # Internal API only
-        assert r != 0 or k != 0
+        assert r_max != 0 or num_neigh != 0
 
         obj = NeighborQueryResult()
 
@@ -41,13 +41,13 @@ cdef class NeighborQueryResult:
         obj.exclude_ii = exclude_ii
         obj.Np = points.shape[0]
 
-        obj.r = r
-        obj.k = k
+        obj.r_max = r_max
+        obj.num_neigh = num_neigh
 
-        if obj.r != 0:
+        if obj.r_max != 0:
             obj.query_type = 'ball'
         else:
-            obj.query_type = 'nn'
+            obj.query_type = 'num_neigh'
 
         return obj
 
@@ -59,9 +59,9 @@ cdef class AABBQueryResult(NeighborQueryResult):
     @staticmethod
     cdef inline AABBQueryResult init_aabb_nn(
             AABBQuery aabbq, const float[:, ::1] points,
-            cbool exclude_ii, unsigned int k, float r, float scale):
+            cbool exclude_ii, unsigned int num_neigh, float r_max, float scale):
         # Internal API only
-        assert k != 0
+        assert num_neigh != 0
 
         obj = AABBQueryResult()
         obj.aabbq = obj.nq = aabbq
@@ -70,10 +70,10 @@ cdef class AABBQueryResult(NeighborQueryResult):
         obj.Np = points.shape[0]
 
         # For AABBs, even kN queries require a distance cutoff
-        obj.r = r
-        obj.k = k
+        obj.r_max = r_max
+        obj.num_neigh = num_neigh
 
-        obj.query_type = 'nn'
+        obj.query_type = 'num_neigh'
 
         obj.scale = scale
 

--- a/freud/locality.pyx
+++ b/freud/locality.pyx
@@ -78,6 +78,15 @@ cdef class _QueryArgs:
             else:
                 raise ValueError("You have passed an invalid query argument")
 
+    @classmethod
+    def from_dict(cls, mapping):
+        """Create QueryArgs from mapping."""
+        return cls(**mapping)
+
+    def validate(self):
+        """Validate this _QueryArgs object and infer parameters if possible."""
+        self.thisptr.validate()
+
     @property
     def mode(self):
         return self.thisptr.mode

--- a/freud/locality.pyx
+++ b/freud/locality.pyx
@@ -2,7 +2,7 @@
 # This file is from the freud project, released under the BSD 3-Clause License.
 
 R"""
-The :class:`freud.locality` module contains data structures to efficiently
+The :mod:`freud.locality` module contains data structures to efficiently
 locate points based on their proximity to other points.
 """
 import sys
@@ -89,7 +89,12 @@ cdef class _QueryArgs:
 
     @property
     def mode(self):
-        return self.thisptr.mode
+        if self.thisptr.mode == freud._locality.QueryType.ball:
+            return 'ball'
+        elif self.thisptr.mode == freud._locality.QueryType.nearest:
+            return 'nearest'
+        else:
+            raise ValueError("Unknown mode {} set!".format(self.thisptr.mode))
 
     @mode.setter
     def mode(self, value):

--- a/freud/locality.pyx
+++ b/freud/locality.pyx
@@ -300,10 +300,6 @@ cdef class NeighborQuery:
         cdef const float[:, ::1] l_query_points = query_points
         cdef _QueryArgs args = _QueryArgs(**query_args)
 
-        # Default guess value
-        if 'r_max' not in query_args:
-            args.r_max = 0
-
         iterator = self.nqptr.queryWithArgs(
             <vec3[float]*> &l_query_points[0, 0],
             query_points.shape[0],
@@ -910,32 +906,6 @@ cdef class AABBQuery(NeighborQuery):
     def __dealloc__(self):
         if type(self) is AABBQuery:
             del self.thisptr
-
-    def _queryGeneric(self, query_points, query_args):
-        # This function is temporarily included for testing and WILL be
-        # removed in future releases.
-        # Can't use this function with old-style NeighborQuery objects
-        query_points = freud.common.convert_array(
-            np.atleast_2d(query_points), shape=(None, 3))
-
-        cdef shared_ptr[freud._locality.NeighborQueryIterator] iterator
-        cdef const float[:, ::1] l_query_points = query_points
-        cdef _QueryArgs args = _QueryArgs(**query_args)
-
-        iterator = self.nqptr.queryWithArgs(
-            <vec3[float]*> &l_query_points[0, 0],
-            query_points.shape[0],
-            dereference(args.thisptr))
-
-        cdef freud._locality.NeighborList *cnlist = dereference(
-            iterator).toNeighborList()
-        cdef NeighborList nl = NeighborList()
-        nl.refer_to(cnlist)
-        # Explicitly manage a manually created nlist so that it will be
-        # deleted when the Python object is.
-        nl._managed = True
-
-        return nl
 
     def query(self, query_points, unsigned int num_neighbors=1,
               float r_guess=0, float scale=1.1, cbool exclude_ii=False):

--- a/freud/order.pyx
+++ b/freud/order.pyx
@@ -434,7 +434,7 @@ cdef class TransOrderParameter(Compute):
     def __cinit__(self, r_max, k=6.0, num_neighbors=0):
         self.thisptr = new freud._order.TransOrderParameter(k)
         self.r_max = r_max
-        self.num_neighbors = (num_neighbors if num_neighbors else int(k))
+        self.num_neighbors = (num_neighbors if num_neighbors > 0 else int(k))
 
     def __dealloc__(self):
         del self.thisptr

--- a/freud/order.pyx
+++ b/freud/order.pyx
@@ -365,7 +365,7 @@ cdef class HexOrderParameter(Compute):
         cdef freud.locality.NlistptrWrapper nlistptr = nq_nlist[1]
 
         cdef freud.locality._QueryArgs def_qargs = freud.locality._QueryArgs(
-            mode="nearest", nn=self.num_neigh, r_max=self.r_max,
+            mode="nearest", num_neigh=self.num_neigh, r_max=self.r_max,
             exclude_ii=True)
 
         with nogil:
@@ -459,7 +459,7 @@ cdef class TransOrderParameter(Compute):
         cdef freud.locality.NlistptrWrapper nlistptr = nq_nlist[1]
 
         cdef freud.locality._QueryArgs def_qargs = freud.locality._QueryArgs(
-            mode="nearest", nn=self.num_neigh, r_max=self.r_max,
+            mode="nearest", num_neigh=self.num_neigh, r_max=self.r_max,
             exclude_ii=True)
 
         with nogil:
@@ -639,7 +639,7 @@ cdef class Steinhardt(Compute):
 
         if self.num_neigh > 0:
             _qargs = freud.locality._QueryArgs(
-                mode="nearest", nn=self.num_neigh, r_max=self.r_max,
+                mode="nearest", num_neigh=self.num_neigh, r_max=self.r_max,
                 exclude_ii=True)
         else:
             _qargs = freud.locality._QueryArgs(

--- a/freud/order.pyx
+++ b/freud/order.pyx
@@ -333,13 +333,13 @@ cdef class HexOrderParameter(Compute):
             Symmetry of the order parameter.
     """  # noqa: E501
     cdef freud._order.HexOrderParameter * thisptr
-    cdef int num_neigh
+    cdef int num_neighbors
     cdef float r_max
 
     def __cinit__(self, r_max, k=int(6), num_neighbors=int(0)):
         self.thisptr = new freud._order.HexOrderParameter(k)
         self.r_max = r_max
-        self.num_neigh = (num_neighbors if num_neighbors else int(k))
+        self.num_neighbors = (num_neighbors if num_neighbors else int(k))
 
     def __dealloc__(self):
         del self.thisptr
@@ -365,7 +365,7 @@ cdef class HexOrderParameter(Compute):
         cdef freud.locality.NlistptrWrapper nlistptr = nq_nlist[1]
 
         cdef freud.locality._QueryArgs def_qargs = freud.locality._QueryArgs(
-            mode="nearest", num_neigh=self.num_neigh, r_max=self.r_max,
+            mode="nearest", num_neighbors=self.num_neighbors, r_max=self.r_max,
             exclude_ii=True)
 
         with nogil:
@@ -397,7 +397,7 @@ cdef class HexOrderParameter(Compute):
     def __repr__(self):
         return "freud.order.{cls}(r_max={r}, k={k}, num_neighbors={n})".format(
             cls=type(self).__name__, r=self.r_max, k=self.K,
-            n=self.num_neigh)
+            n=self.num_neighbors)
 
     def __str__(self):
         return repr(self)
@@ -428,13 +428,13 @@ cdef class TransOrderParameter(Compute):
             Normalization value (d_r is divided by K).
     """  # noqa: E501
     cdef freud._order.TransOrderParameter * thisptr
-    cdef num_neigh
+    cdef num_neighbors
     cdef r_max
 
     def __cinit__(self, r_max, k=6.0, num_neighbors=0):
         self.thisptr = new freud._order.TransOrderParameter(k)
         self.r_max = r_max
-        self.num_neigh = (num_neighbors if num_neighbors else int(k))
+        self.num_neighbors = (num_neighbors if num_neighbors else int(k))
 
     def __dealloc__(self):
         del self.thisptr
@@ -459,7 +459,7 @@ cdef class TransOrderParameter(Compute):
         cdef freud.locality.NlistptrWrapper nlistptr = nq_nlist[1]
 
         cdef freud.locality._QueryArgs def_qargs = freud.locality._QueryArgs(
-            mode="nearest", num_neigh=self.num_neigh, r_max=self.r_max,
+            mode="nearest", num_neighbors=self.num_neighbors, r_max=self.r_max,
             exclude_ii=True)
 
         with nogil:
@@ -491,7 +491,7 @@ cdef class TransOrderParameter(Compute):
     def __repr__(self):
         return "freud.order.{cls}(r_max={r}, k={k}, num_neighbors={n})".format(
             cls=type(self).__name__, r=self.r_max, k=self.K,
-            n=self.num_neigh)
+            n=self.num_neighbors)
 
     def __str__(self):
         return repr(self)
@@ -576,7 +576,7 @@ cdef class Steinhardt(Compute):
     cdef r_max
     cdef sph_l
     cdef r_min
-    cdef num_neigh
+    cdef num_neighbors
 
     def __cinit__(self, r_max, l, r_min=0, average=False,
                   Wl=False, num_neighbors=0, *args, **kwargs):
@@ -584,7 +584,7 @@ cdef class Steinhardt(Compute):
             self.r_max = r_max
             self.sph_l = l
             self.r_min = r_min
-            self.num_neigh = num_neighbors
+            self.num_neighbors = num_neighbors
             self.stptr = new freud._order.Steinhardt(
                 r_max, l, r_min,
                 average, Wl)
@@ -637,10 +637,10 @@ cdef class Steinhardt(Compute):
         cdef freud.locality.NeighborQuery nq = nq_nlist[0]
         cdef freud.locality.NlistptrWrapper nlistptr = nq_nlist[1]
 
-        if self.num_neigh > 0:
+        if self.num_neighbors > 0:
             _qargs = freud.locality._QueryArgs(
-                mode="nearest", num_neigh=self.num_neigh, r_max=self.r_max,
-                exclude_ii=True)
+                mode="nearest", num_neighbors=self.num_neighbors,
+                r_max=self.r_max, exclude_ii=True)
         else:
             _qargs = freud.locality._QueryArgs(
                 mode="ball", r_max=self.r_max, exclude_ii=True)
@@ -927,7 +927,7 @@ cdef class SolLiqNear(SolLiq):
 
     .. todo:: move box to compute, this is old API
     """  # noqa: E501
-    cdef num_neigh
+    cdef num_neighbors
 
     def __cinit__(self, box, r_max, Qthreshold, Sthreshold,
                   l, num_neighbors=12):
@@ -940,7 +940,7 @@ cdef class SolLiqNear(SolLiq):
             self.Qthreshold = Qthreshold
             self.Sthreshold = Sthreshold
             self.sph_l = l
-            self.num_neigh = num_neighbors
+            self.num_neighbors = num_neighbors
 
     def __dealloc__(self):
         del self.thisptr
@@ -960,7 +960,7 @@ cdef class SolLiqNear(SolLiq):
         """
         defaulted_nlist = freud.locality.make_default_nlist_nn(
             self.m_box, points, points,
-            self.num_neigh, nlist, True, self.r_max)
+            self.num_neighbors, nlist, True, self.r_max)
         cdef freud.locality.NeighborList nlist_ = defaulted_nlist[0]
         return SolLiq.compute(self, points, nlist_)
 
@@ -978,7 +978,7 @@ cdef class SolLiqNear(SolLiq):
         """
         defaulted_nlist = freud.locality.make_default_nlist_nn(
             self.m_box, points, points,
-            self.num_neigh, nlist, True, self.r_max)
+            self.num_neighbors, nlist, True, self.r_max)
         cdef freud.locality.NeighborList nlist_ = defaulted_nlist[0]
         return SolLiq.computeSolLiqVariant(self, points, nlist_)
 
@@ -996,7 +996,7 @@ cdef class SolLiqNear(SolLiq):
         """
         defaulted_nlist = freud.locality.make_default_nlist_nn(
             self.m_box, points, points,
-            self.num_neigh, nlist, True, self.r_max)
+            self.num_neighbors, nlist, True, self.r_max)
         cdef freud.locality.NeighborList nlist_ = defaulted_nlist[0]
         return SolLiq.computeSolLiqNoNorm(self, points, nlist_)
 
@@ -1010,7 +1010,7 @@ cdef class SolLiqNear(SolLiq):
                                              Qthreshold=self.Qthreshold,
                                              Sthreshold=self.Sthreshold,
                                              sph_l=self.sph_l,
-                                             n=self.num_neigh)
+                                             n=self.num_neighbors)
 
     def __str__(self):
         return repr(self)

--- a/tests/test_density_ComplexCF.py
+++ b/tests/test_density_ComplexCF.py
@@ -212,34 +212,34 @@ class TestComplexCF(unittest.TestCase):
 
         cf = freud.density.ComplexCF(rmax, dr)
         cf.compute(box, ref_points, ref_values, points, values,
-                   query_args={'mode': 'nearest', 'num_neigh': 1})
+                   query_args={'mode': 'nearest', 'num_neighbors': 1})
         npt.assert_array_equal(cf.RDF, [1, 1, 1])
         npt.assert_array_equal(cf.counts, [2, 2, 2])
 
         cf.compute(box, points, values, ref_points, ref_values,
-                   query_args={'mode': 'nearest', 'num_neigh': 1})
+                   query_args={'mode': 'nearest', 'num_neighbors': 1})
         npt.assert_array_equal(cf.RDF, [1, 0, 0])
         npt.assert_array_equal(cf.counts, [1, 0, 0])
 
         ref_values = [1+1j]
         values = [1+1j, 1+1j, 2+2j, 2+2j, 3+3j, 3+3j]
         cf.compute(box, ref_points, ref_values, points, np.conj(values),
-                   query_args={'mode': 'nearest', 'num_neigh': 1})
+                   query_args={'mode': 'nearest', 'num_neighbors': 1})
         npt.assert_array_equal(cf.RDF, [2, 4, 6])
         npt.assert_array_equal(cf.counts, [2, 2, 2])
 
         cf.compute(box, ref_points, ref_values, points, values,
-                   query_args={'mode': 'nearest', 'num_neigh': 1})
+                   query_args={'mode': 'nearest', 'num_neighbors': 1})
         npt.assert_array_equal(cf.RDF, [2j, 4j, 6j])
         npt.assert_array_equal(cf.counts, [2, 2, 2])
 
         cf.compute(box, points, values, ref_points, np.conj(ref_values),
-                   query_args={'mode': 'nearest', 'num_neigh': 1})
+                   query_args={'mode': 'nearest', 'num_neighbors': 1})
         npt.assert_array_equal(cf.RDF, [2, 0, 0])
         npt.assert_array_equal(cf.counts, [1, 0, 0])
 
         cf.compute(box, points, values, ref_points, ref_values,
-                   query_args={'mode': 'nearest', 'num_neigh': 1})
+                   query_args={'mode': 'nearest', 'num_neighbors': 1})
         npt.assert_array_equal(cf.RDF, [2j, 0, 0])
         npt.assert_array_equal(cf.counts, [1, 0, 0])
 

--- a/tests/test_density_ComplexCF.py
+++ b/tests/test_density_ComplexCF.py
@@ -212,34 +212,34 @@ class TestComplexCF(unittest.TestCase):
 
         cf = freud.density.ComplexCF(rmax, dr)
         cf.compute(box, ref_points, ref_values, points, values,
-                   query_args={'mode': 'nearest', 'nn': 1})
+                   query_args={'mode': 'nearest', 'num_neigh': 1})
         npt.assert_array_equal(cf.RDF, [1, 1, 1])
         npt.assert_array_equal(cf.counts, [2, 2, 2])
 
         cf.compute(box, points, values, ref_points, ref_values,
-                   query_args={'mode': 'nearest', 'nn': 1})
+                   query_args={'mode': 'nearest', 'num_neigh': 1})
         npt.assert_array_equal(cf.RDF, [1, 0, 0])
         npt.assert_array_equal(cf.counts, [1, 0, 0])
 
         ref_values = [1+1j]
         values = [1+1j, 1+1j, 2+2j, 2+2j, 3+3j, 3+3j]
         cf.compute(box, ref_points, ref_values, points, np.conj(values),
-                   query_args={'mode': 'nearest', 'nn': 1})
+                   query_args={'mode': 'nearest', 'num_neigh': 1})
         npt.assert_array_equal(cf.RDF, [2, 4, 6])
         npt.assert_array_equal(cf.counts, [2, 2, 2])
 
         cf.compute(box, ref_points, ref_values, points, values,
-                   query_args={'mode': 'nearest', 'nn': 1})
+                   query_args={'mode': 'nearest', 'num_neigh': 1})
         npt.assert_array_equal(cf.RDF, [2j, 4j, 6j])
         npt.assert_array_equal(cf.counts, [2, 2, 2])
 
         cf.compute(box, points, values, ref_points, np.conj(ref_values),
-                   query_args={'mode': 'nearest', 'nn': 1})
+                   query_args={'mode': 'nearest', 'num_neigh': 1})
         npt.assert_array_equal(cf.RDF, [2, 0, 0])
         npt.assert_array_equal(cf.counts, [1, 0, 0])
 
         cf.compute(box, points, values, ref_points, ref_values,
-                   query_args={'mode': 'nearest', 'nn': 1})
+                   query_args={'mode': 'nearest', 'num_neigh': 1})
         npt.assert_array_equal(cf.RDF, [2j, 0, 0])
         npt.assert_array_equal(cf.counts, [1, 0, 0])
 

--- a/tests/test_density_FloatCF.py
+++ b/tests/test_density_FloatCF.py
@@ -173,12 +173,12 @@ class TestFloatCF(unittest.TestCase):
 
         cf = freud.density.FloatCF(rmax, dr)
         cf.compute(box, ref_points, ref_values, points, values,
-                   query_args={'mode': 'nearest', 'num_neigh': 1})
+                   query_args={'mode': 'nearest', 'num_neighbors': 1})
         npt.assert_array_equal(cf.RDF, [1, 1, 1])
         npt.assert_array_equal(cf.counts, [2, 2, 2])
 
         cf.compute(box, points, values, ref_points, ref_values,
-                   query_args={'mode': 'nearest', 'num_neigh': 1})
+                   query_args={'mode': 'nearest', 'num_neighbors': 1})
         npt.assert_array_equal(cf.RDF, [1, 0, 0])
         npt.assert_array_equal(cf.counts, [1, 0, 0])
 

--- a/tests/test_density_FloatCF.py
+++ b/tests/test_density_FloatCF.py
@@ -173,12 +173,12 @@ class TestFloatCF(unittest.TestCase):
 
         cf = freud.density.FloatCF(rmax, dr)
         cf.compute(box, ref_points, ref_values, points, values,
-                   query_args={'mode': 'nearest', 'nn': 1})
+                   query_args={'mode': 'nearest', 'num_neigh': 1})
         npt.assert_array_equal(cf.RDF, [1, 1, 1])
         npt.assert_array_equal(cf.counts, [2, 2, 2])
 
         cf.compute(box, points, values, ref_points, ref_values,
-                   query_args={'mode': 'nearest', 'nn': 1})
+                   query_args={'mode': 'nearest', 'num_neigh': 1})
         npt.assert_array_equal(cf.RDF, [1, 0, 0])
         npt.assert_array_equal(cf.counts, [1, 0, 0])
 

--- a/tests/test_environment_LocalDescriptors.py
+++ b/tests/test_environment_LocalDescriptors.py
@@ -26,20 +26,20 @@ class TestLocalDescriptors(unittest.TestCase):
         with self.assertRaises(AttributeError):
             comp.num_particles
         with self.assertRaises(AttributeError):
-            comp.num_neighbors
+            comp.num_sphs
 
         comp.compute(box, Nneigh, positions)
 
         # Test access
         comp.sph
         comp.num_particles
-        comp.num_neighbors
+        comp.num_sphs
 
         self.assertEqual(comp.sph.shape[0], N*Nneigh)
 
         self.assertEqual(comp.num_particles, positions.shape[0])
 
-        self.assertEqual(comp.num_neighbors/comp.num_particles, Nneigh)
+        self.assertEqual(comp.num_sphs/comp.num_particles, Nneigh)
 
         self.assertEqual(comp.l_max, lmax)
 

--- a/tests/test_locality_NeighborQuery.py
+++ b/tests/test_locality_NeighborQuery.py
@@ -178,7 +178,7 @@ class TestNeighborQuery(object):
         points[3] = [2.0, 0.0, 0.0]
         nq = self.build_query_object(box, points, L/10)
 
-        nlist = nq._queryGeneric(points, dict(mode='nearest', nn=3))
+        nlist = nq._queryGeneric(points, dict(mode='nearest', num_neigh=3))
         result = list(zip(nlist.index_i, nlist.index_j))
         npt.assert_equal(get_point_neighbors(result, 0), {0, 1, 3})
         npt.assert_equal(get_point_neighbors(result, 1), {0, 1, 3})
@@ -187,7 +187,7 @@ class TestNeighborQuery(object):
 
         # All other points are neighbors when self-neighbors are excluded.
         nlist = nq._queryGeneric(
-            points, dict(mode='nearest', nn=3, exclude_ii=True))
+            points, dict(mode='nearest', num_neigh=3, exclude_ii=True))
         result = list(zip(nlist.index_i, nlist.index_j))
         npt.assert_equal(get_point_neighbors(result, 0), {1, 2, 3})
         npt.assert_equal(get_point_neighbors(result, 1), {0, 2, 3})

--- a/tests/test_locality_NeighborQuery.py
+++ b/tests/test_locality_NeighborQuery.py
@@ -130,6 +130,52 @@ class TestNeighborQuery(object):
         # particle 3 has 2 bonds
         npt.assert_equal(sum(nlist.index_i == 3), 3)
 
+    def test_query_generic_mode_inference(self):
+        """Check that the generic querying method correctly infers modes."""
+        L = 10  # Box Dimensions
+        r_cut = 2.01  # Cutoff radius
+        num_neighbors = 3
+        N = 10  # number of particles
+
+        box = freud.box.Box.cube(L)  # Initialize Box
+        points = np.random.rand(N, 3).astype(np.float32)
+        nq = self.build_query_object(box, points, r_cut)
+
+        # Test ball query.
+        nlist1 = nq._queryGeneric(points, dict(mode='ball', r_max=r_cut))
+        nlist_neighbors1 = sorted(list(zip(nlist1.index_i, nlist1.index_j)))
+        nlist2 = nq._queryGeneric(points, dict(r_max=r_cut))
+        nlist_neighbors2 = sorted(list(zip(nlist2.index_i, nlist2.index_j)))
+        npt.assert_equal(nlist_neighbors1, nlist_neighbors2)
+
+        # Test ball query with exclusion.
+        nlist1 = nq._queryGeneric(
+            points, dict(mode='ball', r_max=r_cut, exclude_ii=True))
+        nlist_neighbors1 = sorted(list(zip(nlist1.index_i, nlist1.index_j)))
+        nlist2 = nq._queryGeneric(
+            points, dict(r_max=r_cut, exclude_ii=True))
+        nlist_neighbors2 = sorted(list(zip(nlist2.index_i, nlist2.index_j)))
+        npt.assert_equal(nlist_neighbors1, nlist_neighbors2)
+
+        # Test number of neighbors.
+        nlist1 = nq._queryGeneric(
+            points, dict(mode='nearest', num_neighbors=num_neighbors))
+        nlist_neighbors1 = sorted(list(zip(nlist1.index_i, nlist1.index_j)))
+        nlist2 = nq._queryGeneric(points, dict(num_neighbors=num_neighbors))
+        nlist_neighbors2 = sorted(list(zip(nlist2.index_i, nlist2.index_j)))
+        npt.assert_equal(nlist_neighbors1, nlist_neighbors2)
+
+        # Test number of neighbors with exclusion.
+        nlist1 = nq._queryGeneric(
+            points, dict(mode='nearest',
+                         num_neighbors=num_neighbors,
+                         exclude_ii=True))
+        nlist_neighbors1 = sorted(list(zip(nlist1.index_i, nlist1.index_j)))
+        nlist2 = nq._queryGeneric(
+            points, dict(num_neighbors=num_neighbors, exclude_ii=True))
+        nlist_neighbors2 = sorted(list(zip(nlist2.index_i, nlist2.index_j)))
+        npt.assert_equal(nlist_neighbors1, nlist_neighbors2)
+
     def test_query(self):
         L = 10  # Box Dimensions
         N = 4  # number of particles

--- a/tests/test_locality_NeighborQuery.py
+++ b/tests/test_locality_NeighborQuery.py
@@ -178,7 +178,7 @@ class TestNeighborQuery(object):
         points[3] = [2.0, 0.0, 0.0]
         nq = self.build_query_object(box, points, L/10)
 
-        nlist = nq._queryGeneric(points, dict(mode='nearest', num_neigh=3))
+        nlist = nq._queryGeneric(points, dict(mode='nearest', num_neighbors=3))
         result = list(zip(nlist.index_i, nlist.index_j))
         npt.assert_equal(get_point_neighbors(result, 0), {0, 1, 3})
         npt.assert_equal(get_point_neighbors(result, 1), {0, 1, 3})
@@ -187,7 +187,7 @@ class TestNeighborQuery(object):
 
         # All other points are neighbors when self-neighbors are excluded.
         nlist = nq._queryGeneric(
-            points, dict(mode='nearest', num_neigh=3, exclude_ii=True))
+            points, dict(mode='nearest', num_neighbors=3, exclude_ii=True))
         result = list(zip(nlist.index_i, nlist.index_j))
         npt.assert_equal(get_point_neighbors(result, 0), {1, 2, 3})
         npt.assert_equal(get_point_neighbors(result, 1), {0, 2, 3})

--- a/tests/test_locality_NeighborQuery.py
+++ b/tests/test_locality_NeighborQuery.py
@@ -176,6 +176,23 @@ class TestNeighborQuery(object):
         nlist_neighbors2 = sorted(list(zip(nlist2.index_i, nlist2.index_j)))
         npt.assert_equal(nlist_neighbors1, nlist_neighbors2)
 
+    def test_query_generic_invalid(self):
+        """Check that mode inference fails for invalid combinations."""
+        L = 10  # Box Dimensions
+        r_cut = 2.01  # Cutoff radius
+        num_neighbors = 3
+        N = 10  # number of particles
+
+        box = freud.box.Box.cube(L)  # Initialize Box
+        points = np.random.rand(N, 3).astype(np.float32)
+        nq = self.build_query_object(box, points, r_cut)
+
+        # Test failure cases.
+        with self.assertRaises(RuntimeError):
+            nq._queryGeneric(
+                points,
+                dict(mode='ball', num_neighbors=num_neighbors, r_max=r_cut))
+
     def test_query(self):
         L = 10  # Box Dimensions
         N = 4  # number of particles

--- a/tests/test_pmft.py
+++ b/tests/test_pmft.py
@@ -664,7 +664,7 @@ class TestPMFTXY2D(unittest.TestCase):
         nbins = 3
         pmft = freud.pmft.PMFTXY2D(max_width, max_width, nbins, nbins)
         pmft.compute(box, points, angles, query_points, query_angles,
-                     query_args={'mode': 'nearest', 'num_neigh': 1})
+                     query_args={'mode': 'nearest', 'num_neighbors': 1})
         # Now every point in query_points will find the origin as a neighbor.
         npt.assert_array_equal(
             pmft.bin_counts,
@@ -673,7 +673,7 @@ class TestPMFTXY2D(unittest.TestCase):
              [0, 1, 0]])
         # Now there will be only one neighbor for the single point.
         pmft.compute(box, query_points, query_angles, points, angles,
-                     query_args={'mode': 'nearest', 'num_neigh': 1})
+                     query_args={'mode': 'nearest', 'num_neighbors': 1})
         npt.assert_array_equal(
             pmft.bin_counts,
             [[0, 0, 0],
@@ -932,7 +932,7 @@ class TestPMFTXYZ(unittest.TestCase):
         pmft = freud.pmft.PMFTXYZ(max_width, max_width, max_width,
                                   nbins, nbins, nbins)
         pmft.compute(box, points, angles, query_points,
-                     query_args={'mode': 'nearest', 'num_neigh': 1})
+                     query_args={'mode': 'nearest', 'num_neighbors': 1})
 
         # Now every point in query_points will find the origin as a neighbor.
         npt.assert_array_equal(
@@ -948,7 +948,7 @@ class TestPMFTXYZ(unittest.TestCase):
               [0, 0, 0]]])
 
         pmft.compute(box, query_points, query_angles, points,
-                     query_args={'mode': 'nearest', 'num_neigh': 1})
+                     query_args={'mode': 'nearest', 'num_neighbors': 1})
         # The only nonzero bin is in the left bin for x, but the center for
         # everything else (0 distance in y and z).
         self.assertEqual(pmft.bin_counts[1, 1, 0], 1)

--- a/tests/test_pmft.py
+++ b/tests/test_pmft.py
@@ -664,7 +664,7 @@ class TestPMFTXY2D(unittest.TestCase):
         nbins = 3
         pmft = freud.pmft.PMFTXY2D(max_width, max_width, nbins, nbins)
         pmft.compute(box, points, angles, query_points, query_angles,
-                     query_args={'mode': 'nearest', 'nn': 1})
+                     query_args={'mode': 'nearest', 'num_neigh': 1})
         # Now every point in query_points will find the origin as a neighbor.
         npt.assert_array_equal(
             pmft.bin_counts,
@@ -673,7 +673,7 @@ class TestPMFTXY2D(unittest.TestCase):
              [0, 1, 0]])
         # Now there will be only one neighbor for the single point.
         pmft.compute(box, query_points, query_angles, points, angles,
-                     query_args={'mode': 'nearest', 'nn': 1})
+                     query_args={'mode': 'nearest', 'num_neigh': 1})
         npt.assert_array_equal(
             pmft.bin_counts,
             [[0, 0, 0],
@@ -932,7 +932,7 @@ class TestPMFTXYZ(unittest.TestCase):
         pmft = freud.pmft.PMFTXYZ(max_width, max_width, max_width,
                                   nbins, nbins, nbins)
         pmft.compute(box, points, angles, query_points,
-                     query_args={'mode': 'nearest', 'nn': 1})
+                     query_args={'mode': 'nearest', 'num_neigh': 1})
 
         # Now every point in query_points will find the origin as a neighbor.
         npt.assert_array_equal(
@@ -948,7 +948,7 @@ class TestPMFTXYZ(unittest.TestCase):
               [0, 0, 0]]])
 
         pmft.compute(box, query_points, query_angles, points,
-                     query_args={'mode': 'nearest', 'nn': 1})
+                     query_args={'mode': 'nearest', 'num_neigh': 1})
         # The only nonzero bin is in the left bin for x, but the center for
         # everything else (0 distance in y and z).
         self.assertEqual(pmft.bin_counts[1, 1, 0], 1)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR cleans up some of the C++ code for the `QueryArgs` class, introducing more constants into the namespace and improving code consistency. Query argument names have been standardized further, and updated throughout freud. In particular, most references to `rmax`, `nn`, `num_neigh`, etc have been removed in favor of the standard names `r_max` and `num_neighbors`. On the Python side, more of the `QueryArgs` logic has been standardized by introducing a `PairCompute` subclass of `Compute` that encapsulates the standard code that goes at the beginning of every `compute` or `accumulate` call. In the process, I've also defined a standard method for classes to expose a set of default query arguments.

## Motivation and Context
This PR is necessary to standardize the usage of query arguments (especially default query arguments) throughout freud. It's also consistent with #179 and related changes for improving the API.

## How Has This Been Tested?
No new tests have been added yet, they will need to be added once the code is closer to a final state. The main tests we will need to add are ensuring that default query arguments work as expected, and that invalid `QueryArgs` objects are properly rejected.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds or improves functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/glotzerlab/freud/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] I have updated the documentation (if relevant).
- [x] I have added tests that cover my changes (if relevant).
- [x] All new and existing tests passed.
- [x] I have updated the [Changelog](https://github.com/glotzerlab/freud/blob/master/ChangeLog.md).
