### PR TITLE
Move __str__ into Compute and remove from other classes

### DIFF
--- a/freud/cluster.pyx
+++ b/freud/cluster.pyx
@@ -153,9 +153,6 @@ cdef class Cluster(Compute):
                 "r_max={r_max})").format(cls=type(self).__name__,
                                          r_max=self.r_max)
 
-    def __str__(self):
-        return repr(self)
-
     @Compute._computed_method("compute")
     def plot(self, ax=None):
         """Plot cluster distribution.
@@ -291,6 +288,3 @@ cdef class ClusterProperties(Compute):
     def __repr__(self):
         return ("freud.cluster.{cls}()").format(
             cls=type(self).__name__)
-
-    def __str__(self):
-        return repr(self)

--- a/freud/common.pyx
+++ b/freud/common.pyx
@@ -132,6 +132,9 @@ cdef class Compute:
             func(self, *args, **kwargs)
         return wrapper
 
+    def __str__(self):
+        return repr(self)
+
 
 cdef class PairCompute(Compute):
     R"""Parent class for all compute classes in freud that depend on finding

--- a/freud/density.pyx
+++ b/freud/density.pyx
@@ -228,10 +228,6 @@ cdef class FloatCF(Compute):
         return ("freud.density.{cls}(r_max={r_max}, dr={dr})").format(
             cls=type(self).__name__, r_max=self.r_max, dr=self.dr)
 
-    def __str__(self):
-        return repr(self)
-
-    @Compute._computed_method()
     def plot(self, ax=None):
         """Plot correlation function.
 
@@ -458,10 +454,6 @@ cdef class ComplexCF(Compute):
         return ("freud.density.{cls}(r_max={r_max}, dr={dr})").format(
             cls=type(self).__name__, r_max=self.r_max, dr=self.dr)
 
-    def __str__(self):
-        return repr(self)
-
-    @Compute._computed_method()
     def plot(self, ax=None):
         """Plot complex correlation function.
 
@@ -592,9 +584,6 @@ cdef class GaussianDensity(Compute):
                                             width=self.width,
                                             r_max=self.r_max,
                                             sigma=self.sigma)
-
-    def __str__(self):
-        return repr(self)
 
     @Compute._computed_method()
     def plot(self, ax=None):
@@ -771,9 +760,6 @@ cdef class LocalDensity(Compute):
                                                volume=self.volume,
                                                diameter=self.diameter)
 
-    def __str__(self):
-        return repr(self)
-
 
 cdef class RDF(PairCompute):
     R"""Computes RDF for supplied data.
@@ -934,9 +920,6 @@ cdef class RDF(PairCompute):
                                          r_max=self.r_max,
                                          dr=self.dr,
                                          r_min=self.r_min)
-
-    def __str__(self):
-        return repr(self)
 
     @Compute._computed_method()
     def plot(self, ax=None):

--- a/freud/environment.pyx
+++ b/freud/environment.pyx
@@ -306,9 +306,6 @@ cdef class BondOrder(Compute):
                     num_neighbors=self.num_neighbors, n_bins_t=self.n_bins_t,
                     n_bins_p=self.n_bins_p)
 
-    def __str__(self):
-        return repr(self)
-
 
 cdef class LocalDescriptors(Compute):
     R"""Compute a set of descriptors (a numerical "fingerprint") of a particle's
@@ -482,9 +479,6 @@ cdef class LocalDescriptors(Compute):
                     cls=type(self).__name__, num_neighbors=self.num_neighbors,
                     l_max=self.l_max, r_max=self.r_max,
                     negative_m=self.negative_m)
-
-    def __str__(self):
-        return repr(self)
 
 
 cdef class MatchEnv(Compute):
@@ -834,9 +828,6 @@ cdef class MatchEnv(Compute):
                     cls=type(self).__name__, box=self.m_box.__repr__(),
                     r=self.r_max, k=self.num_neighbors)
 
-    def __str__(self):
-        return repr(self)
-
     @Compute._computed_method()
     def plot(self, ax=None):
         """Plot cluster distribution.
@@ -1076,8 +1067,6 @@ cdef class AngularSeparation(Compute):
         return "freud.environment.{cls}(r_max={r}, num_neighbors={n})".format(
             cls=type(self).__name__, r=self.r_max, n=self.num_neighbors)
 
-    def __str__(self):
-        return repr(self)
 
 cdef class LocalBondProjection(Compute):
     R"""Calculates the maximal projection of nearest neighbor bonds for each
@@ -1248,6 +1237,3 @@ cdef class LocalBondProjection(Compute):
                 "num_neighbors={num_neighbors})").format(
                     cls=type(self).__name__, r_max=self.r_max,
                     num_neighbors=self.num_neighbors)
-
-    def __str__(self):
-        return repr(self)

--- a/freud/interface.pyx
+++ b/freud/interface.pyx
@@ -99,6 +99,3 @@ cdef class InterfaceMeasure(Compute):
     def __repr__(self):
         return "freud.interface.{cls}(r_max={r_max})".format(
             cls=type(self).__name__, r_max=self.r_max)
-
-    def __str__(self):
-        return repr(self)

--- a/freud/msd.pyx
+++ b/freud/msd.pyx
@@ -269,9 +269,6 @@ cdef class MSD(Compute):
         return "freud.msd.{cls}(box={box}, mode={mode})".format(
             cls=type(self).__name__, box=self._box, mode=repr(self.mode))
 
-    def __str__(self):
-        return repr(self)
-
     @Compute._computed_method()
     def plot(self, ax=None):
         """Plot MSD.

--- a/freud/order.pyx
+++ b/freud/order.pyx
@@ -203,8 +203,6 @@ cdef class CubaticOrderParameter(Compute):
                                        n_replicates=self.n_replicates,
                                        seed=self.seed)
 
-    def __str__(self):
-        return repr(self)
 
 cdef class NematicOrderParameter(Compute):
     R"""Compute the nematic order parameter for a system of particles.
@@ -286,9 +284,6 @@ cdef class NematicOrderParameter(Compute):
     def __repr__(self):
         return "freud.order.{cls}(u={u})".format(cls=type(self).__name__,
                                                  u=self.u.tolist())
-
-    def __str__(self):
-        return repr(self)
 
 
 cdef class HexOrderParameter(Compute):
@@ -399,9 +394,6 @@ cdef class HexOrderParameter(Compute):
             cls=type(self).__name__, r=self.r_max, k=self.K,
             n=self.num_neighbors)
 
-    def __str__(self):
-        return repr(self)
-
 
 cdef class TransOrderParameter(Compute):
     R"""Compute the translational order parameter for each particle.
@@ -492,9 +484,6 @@ cdef class TransOrderParameter(Compute):
         return "freud.order.{cls}(r_max={r}, k={k}, num_neighbors={n})".format(
             cls=type(self).__name__, r=self.r_max, k=self.K,
             n=self.num_neighbors)
-
-    def __str__(self):
-        return repr(self)
 
 
 cdef class Steinhardt(Compute):
@@ -658,9 +647,6 @@ cdef class Steinhardt(Compute):
                                          r_max=self.r_max,
                                          sph_l=self.sph_l,
                                          r_min=self.r_min)
-
-    def __str__(self):
-        return repr(self)
 
 
 cdef class SolLiq(Compute):
@@ -874,9 +860,6 @@ cdef class SolLiq(Compute):
                                      Sthreshold=self.Sthreshold,
                                      sph_l=self.sph_l)
 
-    def __str__(self):
-        return repr(self)
-
 
 cdef class SolLiqNear(SolLiq):
     R"""A variant of the :class:`~SolLiq` class that performs its average over nearest neighbor particles as determined by an instance of :class:`freud.locality.NeighborList`. The number of included neighbors is determined by the num_neighbors parameter to the constructor.
@@ -1012,9 +995,6 @@ cdef class SolLiqNear(SolLiq):
                                              sph_l=self.sph_l,
                                              n=self.num_neighbors)
 
-    def __str__(self):
-        return repr(self)
-
 
 cdef class RotationalAutocorrelation(Compute):
     """Calculates a measure of total rotational autocorrelation based on
@@ -1112,6 +1092,3 @@ cdef class RotationalAutocorrelation(Compute):
     def __repr__(self):
         return "freud.order.{cls}(l={sph_l})".format(cls=type(self).__name__,
                                                      sph_l=self.l)
-
-    def __str__(self):
-        return repr(self)

--- a/freud/pmft.pyx
+++ b/freud/pmft.pyx
@@ -330,9 +330,6 @@ cdef class PMFTR12(_PMFT):
                                        n_t1=self.n_bins_T1,
                                        n_t2=self.n_bins_T2)
 
-    def __str__(self):
-        return repr(self)
-
 
 cdef class PMFTXYT(_PMFT):
     R"""Computes the PMFT [vanAndersKlotsa2014]_ [vanAndersAhmed2014]_ for
@@ -575,9 +572,6 @@ cdef class PMFTXYT(_PMFT):
                                                 n_y=self.n_bins_Y,
                                                 n_t=self.n_bins_T)
 
-    def __str__(self):
-        return repr(self)
-
 
 cdef class PMFTXY2D(_PMFT):
     R"""Computes the PMFT [vanAndersKlotsa2014]_ [vanAndersAhmed2014]_ in
@@ -794,9 +788,6 @@ cdef class PMFTXY2D(_PMFT):
                                      y_max=self.ymax,
                                      n_x=self.n_bins_X,
                                      n_y=self.n_bins_Y)
-
-    def __str__(self):
-        return repr(self)
 
     def _repr_png_(self):
         import freud.plot
@@ -1118,6 +1109,3 @@ cdef class PMFTXYZ(_PMFT):
                     n_y=self.n_bins_Y,
                     n_z=self.n_bins_Z,
                     shiftvec=self.shiftvec.tolist())
-
-    def __str__(self):
-        return repr(self)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Our definition of `__str__` is identically just `repr(self)`, so I moved it to the `Compute` class.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds or improves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/glotzerlab/freud/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] I have updated the documentation (if relevant).
- [x] I have added tests that cover my changes (if relevant).
- [x] All new and existing tests passed.
- [x] I have updated the [Changelog](https://github.com/glotzerlab/freud/blob/master/ChangeLog.md).
