### PR TITLE
Change clustering algorithm to use connected components

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -21,6 +21,7 @@ Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to
 * Arrays returned to Python persist even after the compute object is destroyed or resizes its arrays.
 * RDF bin centers are now strictly at the center of bins.
 * RDF no longer performs parallel accumulation of cumulative counts (provided no performance gains and was substantially more complex code).
+* Cluster now finds connected components of the neighbor graph (the cluster cutoff distance is given through query arguments).
 
 ### Fixed
 * Steinhardt uses the ThreadStorage class and properly resets memory where needed.

--- a/cpp/cluster/Cluster.cc
+++ b/cpp/cluster/Cluster.cc
@@ -44,7 +44,7 @@ void Cluster::compute(const freud::locality::NeighborQuery* nq,
     // particle index.
     vector<size_t> cluster_label(m_num_particles, -1);
     vector<size_t> cluster_label_count(m_num_particles);
-    vector<size_t> cluster_min_id(m_num_particles);
+    vector<size_t> cluster_min_id(m_num_particles, -1);
 
     // Loop over every particle.
     m_num_clusters = 0;
@@ -69,7 +69,9 @@ void Cluster::compute(const freud::locality::NeighborQuery* nq,
 
     // Resize label counts and min ids to the number of unique clusters found.
     cluster_label_count.resize(m_num_clusters);
+    cluster_label_count.shrink_to_fit();
     cluster_min_id.resize(m_num_clusters);
+    cluster_min_id.shrink_to_fit();
 
     // Get a permutation that reorders clusters, largest to smallest.
     vector<size_t> cluster_reindex = sort_indexes_inverse(cluster_label_count, cluster_min_id);

--- a/cpp/cluster/Cluster.cc
+++ b/cpp/cluster/Cluster.cc
@@ -20,20 +20,15 @@ Cluster::Cluster() {}
 
 void Cluster::compute(const freud::locality::NeighborQuery* nq,
                       const freud::locality::NeighborList* nlist,
-                      const vec3<float>* points, unsigned int Np,
                       freud::locality::QueryArgs qargs,
                       const unsigned int* keys)
 {
-    assert(points);
-    assert(Np > 0);
-
-    m_cluster_idx.prepare(Np);
-
-    m_num_particles = Np;
+    m_num_particles = nq->getNPoints();
+    m_cluster_idx.prepare(m_num_particles);
     DisjointSets dj(m_num_particles);
 
     freud::locality::loopOverNeighbors(
-        nq, points, Np, qargs, nlist,
+        nq, nq->getPoints(), m_num_particles, qargs, nlist,
         [&dj](const freud::locality::NeighborBond& neighbor_bond) {
             // Merge the two sets using the disjoint set
             if (!dj.same(neighbor_bond.ref_id, neighbor_bond.id))

--- a/cpp/cluster/Cluster.cc
+++ b/cpp/cluster/Cluster.cc
@@ -14,10 +14,7 @@
 
 using namespace std;
 
-/*! \file Cluster.cc
-    \brief Routines for clustering points.
-*/
-
+//! Finds clusters using a network of neighbors.
 namespace freud { namespace cluster {
 
 Cluster::Cluster() : m_num_particles(0), m_num_clusters(0) {}
@@ -38,7 +35,7 @@ void Cluster::compute(const freud::locality::NeighborQuery* nq,
 
     freud::locality::loopOverNeighbors(
         nq, points, Np, qargs, nlist,
-        [this, &dj](const freud::locality::NeighborBond& neighbor_bond) {
+        [&dj](const freud::locality::NeighborBond& neighbor_bond) {
             // merge the two sets using the disjoint set
             if (!dj.same(neighbor_bond.ref_id, neighbor_bond.id))
             {
@@ -115,7 +112,7 @@ void Cluster::compute(const freud::locality::NeighborQuery* nq,
 
 // Returns inverse permutation of cluster indices, sorted from largest to smallest.
 // Adapted from https://stackoverflow.com/questions/1577475/c-sorting-and-keeping-track-of-indexes
-std::vector<size_t> sort_indexes_inverse(const std::vector<size_t> &counts, const std::vector<size_t> &min_ids) {
+std::vector<size_t> Cluster::sort_indexes_inverse(const std::vector<size_t> &counts, const std::vector<size_t> &min_ids) {
 
     // Initialize original index locations
     std::vector<size_t> idx(counts.size());

--- a/cpp/cluster/Cluster.cc
+++ b/cpp/cluster/Cluster.cc
@@ -1,8 +1,10 @@
 // Copyright (c) 2010-2019 The Regents of the University of Michigan
 // This file is from the freud project, released under the BSD 3-Clause License.
 
+#include <algorithm>
 #include <cassert>
 #include <map>
+#include <numeric>
 #include <stdexcept>
 
 #include "Cluster.h"
@@ -18,17 +20,13 @@ using namespace std;
 
 namespace freud { namespace cluster {
 
-Cluster::Cluster(float r_max) : m_r_max(r_max), m_num_particles(0), m_num_clusters(0)
-{
-    if (m_r_max < 0.0f)
-        throw invalid_argument("Cluster requires that r_max must be non-negative.");
-}
+Cluster::Cluster() : m_num_particles(0), m_num_clusters(0) {}
 
 void Cluster::compute(const freud::locality::NeighborQuery* nq,
                       const freud::locality::NeighborList* nlist,
-                      const vec3<float> *points,
-                      unsigned int Np,
-                      freud::locality::QueryArgs qargs)
+                      const vec3<float>* points, unsigned int Np,
+                      freud::locality::QueryArgs qargs,
+                      const unsigned int* keys)
 {
     assert(points);
     assert(Np > 0);
@@ -41,66 +39,108 @@ void Cluster::compute(const freud::locality::NeighborQuery* nq,
     freud::locality::loopOverNeighbors(
         nq, points, Np, qargs, nlist,
         [this, &dj](const freud::locality::NeighborBond& neighbor_bond) {
-            // compute r between the two particles
-            if (neighbor_bond.distance < m_r_max)
+            // merge the two sets using the disjoint set
+            if (!dj.same(neighbor_bond.ref_id, neighbor_bond.id))
             {
-                // merge the two sets using the disjoint set
-                if (!dj.same(neighbor_bond.ref_id, neighbor_bond.id))
-                {
-                    dj.unite(neighbor_bond.ref_id, neighbor_bond.id);
-                }
+                dj.unite(neighbor_bond.ref_id, neighbor_bond.id);
             }
         });
 
-    // done looping over points. All clusters are now determined. Renumber them from zero to num_clusters-1.
-    map<uint32_t, uint32_t> label_map;
+    // Done looping over points. All clusters are now determined.
+    // Next, we renumber clusters from zero to num_clusters-1.
+    // These new cluster indices are then sorted by cluster size from largest
+    // to smallest, with equally-sized clusters sorted based on their minimum
+    // particle index.
+    map<size_t, size_t> label_map;
+    map<size_t, size_t> label_counts;
+    map<size_t, size_t> label_min_id;
 
-    // go over every point
-    uint32_t cur_set = 0;
-    for (uint32_t i = 0; i < m_num_particles; i++)
+    // Go over every point
+    size_t cur_set = 0;
+    for (size_t i = 0; i < m_num_particles; i++)
     {
-        uint32_t s = dj.find(i);
+        size_t s = dj.find(i);
 
-        // insert it into the mapping if we haven't seen this one yet
+        // Insert this cluster id into the mapping if we haven't seen it yet
         if (label_map.count(s) == 0)
         {
             label_map[s] = cur_set;
+            label_min_id[cur_set] = m_num_particles;
             cur_set++;
         }
 
-        // label this point in cluster_idx
-        m_cluster_idx[i] = label_map[s];
+        // Increment the counter for this cluster label
+        label_counts[label_map[s]]++;
+
+        // Track the smallest particle index in this cluster
+        label_min_id[label_map[s]] = std::min(label_min_id[label_map[s]], i);
     }
 
-    // cur_set is now the number of clusters
+    // cur_set is now the total number of clusters
     m_num_clusters = cur_set;
 
+    // Build vectors of counts/min_ids from the maps of label counts/min_ids
+    vector<size_t> counts(m_num_clusters);
+    vector<size_t> min_ids(m_num_clusters);
+    for (size_t i = 0; i < m_num_clusters; i++)
+    {
+        counts[i] = label_counts[i];
+        min_ids[i] = label_min_id[i];
+    }
+
+    // Get a permutation that reorders clusters, largest to smallest
+    vector<size_t> cluster_reindex = sort_indexes_inverse(counts, min_ids);
+
+    // Clear the cluster keys
+    m_cluster_keys.resize(m_num_clusters);
+    for (auto v : m_cluster_keys)
+        v.clear();
+
+    /* Loop over all particles, set their cluster ids and add them to a list of
+     * sets. Each set contains all the keys that are part of that cluster. If
+     * no keys are provided, the keys use particle ids. Get the computed list
+     * with getClusterKeys().
+    */
+    for (size_t i = 0; i < m_num_particles; i++)
+    {
+        size_t s = dj.find(i);
+        size_t cluster_idx = cluster_reindex[label_map[s]];
+        m_cluster_idx[i] = cluster_idx;
+        unsigned int key = i;
+        if (keys != NULL)
+            key = keys[i];
+        m_cluster_keys[cluster_idx].push_back(key);
+    }
 }
 
-/*! \param keys Array of keys (1 per particle)
-    Loops over all particles and adds them to a list of sets. Each set contains all the keys that are part of
-    that cluster.
+// Returns inverse permutation of cluster indices, sorted from largest to smallest.
+// Adapted from https://stackoverflow.com/questions/1577475/c-sorting-and-keeping-track-of-indexes
+std::vector<size_t> sort_indexes_inverse(const std::vector<size_t> &counts, const std::vector<size_t> &min_ids) {
 
-    Get the computed list with getClusterKeys().
+    // Initialize original index locations
+    std::vector<size_t> idx(counts.size());
+    std::iota(idx.begin(), idx.end(), 0);
 
-    \note The length of keys is assumed to be the same length as the particles in the last call to
-    computeClusters().
-*/
-void Cluster::computeClusterMembership(const unsigned int* keys)
-{
-    // clear the membership
-    m_cluster_keys.resize(m_num_clusters);
+    // Sort indexes based on comparing values in counts, min_ids
+    std::sort(idx.begin(), idx.end(), [&counts, &min_ids](size_t i1, size_t i2) {
+        if (counts[i1] != counts[i2])
+        {
+            // If the counts are unequal, return the largest cluster first
+            return counts[i1] > counts[i2];
+        }
+        else
+        {
+            // If the counts are equal, return the cluster with the smallest
+            // particle id first
+            return min_ids[i1] < min_ids[i2];
+        }
+    });
 
-    for (unsigned int i = 0; i < m_num_clusters; i++)
-        m_cluster_keys[i].clear();
-
-    // add members to the sets
-    for (unsigned int i = 0; i < m_num_particles; i++)
-    {
-        unsigned int key = keys[i];
-        unsigned int cluster = m_cluster_idx[i];
-        m_cluster_keys[cluster].push_back(key);
-    }
+    // Invert the permutation
+    std::vector<size_t> inv_idx(idx.size());
+    for (size_t i = 0; i < idx.size(); i++)
+        inv_idx[idx[i]] = i;
+    return inv_idx;
 }
 
 }; }; // end namespace freud::cluster

--- a/cpp/cluster/Cluster.h
+++ b/cpp/cluster/Cluster.h
@@ -20,29 +20,7 @@
 */
 
 namespace freud { namespace cluster {
-//! Find clusters in a set of points
-/*! Given a set of particles and their bonds, Cluster will determine all of the
-    connected components of the network formed by those bonds. That is, two
-    points are in the same cluster if and only if a path exists between them on
-    the network of bonds. Clusters are labeled from 0 to the number of
-    clusters-1 and an index array is returned where \c cluster_idx[i] is the
-    cluster index in which particle \c i is found. By the definition of a
-    cluster, points that are not bonded to any other point end up in their own
-    1-particle cluster. Identifying micelles is one primary use-case for
-    finding clusters. This operation is somewhat different, though. In a
-    cluster of points, each and every point belongs to one and only one
-    cluster. However, because a string of points belongs to a polymer, that
-    single polymer may be present in more than one cluster. To handle this
-    situation, an optional layer is presented on top of the \c cluster_idx
-    array. Given a key value per particle (i.e. the polymer id), the compute
-    function will process cluster_idx with the key values in mind and provide a
-    list of keys that are present in each cluster.
-
-    <b>2D:</b><br>
-    Cluster properly handles 2D boxes. As with everything else in freud, 2D
-    points must be passed in as 3 component vectors x,y,0. Failing to set 0 in
-    the third component will lead to undefined behavior.
-*/
+//! Finds clusters using a network of neighbors.
 class Cluster
 {
 public:
@@ -85,11 +63,13 @@ private:
     unsigned int m_num_clusters;  //!< Number of clusters found in the last call to compute()
     util::ManagedArray<unsigned int> m_cluster_idx; //!< Cluster index determined for each particle
     std::vector<std::vector<unsigned int>> m_cluster_keys; //!< List of keys in each cluster
-};
 
-// Returns inverse permutation of cluster indices, sorted from largest to smallest.
-// Adapted from https://stackoverflow.com/questions/1577475/c-sorting-and-keeping-track-of-indexes
-std::vector<size_t> sort_indexes_inverse(const std::vector<size_t> &counts, const std::vector<size_t> &min_ids);
+    // Returns inverse permutation of cluster indices, sorted from largest to
+    // smallest. Adapted from
+    // https://stackoverflow.com/questions/1577475/c-sorting-and-keeping-track-of-indexes
+    static std::vector<size_t> sort_indexes_inverse(const std::vector<size_t> &counts,
+            const std::vector<size_t> &min_ids);
+};
 
 }; }; // end namespace freud::cluster
 

--- a/cpp/cluster/Cluster.h
+++ b/cpp/cluster/Cluster.h
@@ -30,7 +30,6 @@ public:
     //! Compute the point clusters
     void compute(const freud::locality::NeighborQuery* nq,
                  const freud::locality::NeighborList* nlist,
-                 const vec3<float>* points, unsigned int Np,
                  freud::locality::QueryArgs qargs,
                  const unsigned int* keys=NULL);
 

--- a/cpp/cluster/Cluster.h
+++ b/cpp/cluster/Cluster.h
@@ -9,8 +9,8 @@
 #include <stdint.h>
 #include <vector>
 
-#include "ManagedArray.h"
 #include "Box.h"
+#include "ManagedArray.h"
 #include "NeighborList.h"
 #include "NeighborQuery.h"
 #include "VectorMath.h"
@@ -21,21 +21,22 @@
 
 namespace freud { namespace cluster {
 //! Find clusters in a set of points
-/*! Given a set of coordinates and a cutoff, Cluster will determine all of the
-    clusters of points that are made up of points that are closer than the
-    cutoff. Clusters are labeled from 0 to the number of clusters-1 and an index
-    array is returned where \c cluster_idx[i] is the cluster index in which
-    particle \c i is found. By the definition of a cluster, points that are not
-    within the cutoff of another point end up in their own 1-particle cluster.
-    Identifying micelles is one primary use-case for finding clusters. This
-    operation is somewhat different, though. In a cluster of points, each and
-    every point belongs to one and only one cluster. However, because a string
-    of points belongs to a polymer, that single polymer may be present in more
-    than one cluster. To handle this situation, an optional layer is presented
-    on top of the \c cluster_idx array. Given a key value per particle (i.e. the
-    polymer id), the computeClusterMembership function will process cluster_idx
-    with the key values in mind and provide a list of keys that are present in
-    each cluster.
+/*! Given a set of particles and their bonds, Cluster will determine all of the
+    connected components of the network formed by those bonds. That is, two
+    points are in the same cluster if and only if a path exists between them on
+    the network of bonds. Clusters are labeled from 0 to the number of
+    clusters-1 and an index array is returned where \c cluster_idx[i] is the
+    cluster index in which particle \c i is found. By the definition of a
+    cluster, points that are not bonded to any other point end up in their own
+    1-particle cluster. Identifying micelles is one primary use-case for
+    finding clusters. This operation is somewhat different, though. In a
+    cluster of points, each and every point belongs to one and only one
+    cluster. However, because a string of points belongs to a polymer, that
+    single polymer may be present in more than one cluster. To handle this
+    situation, an optional layer is presented on top of the \c cluster_idx
+    array. Given a key value per particle (i.e. the polymer id), the compute
+    function will process cluster_idx with the key values in mind and provide a
+    list of keys that are present in each cluster.
 
     <b>2D:</b><br>
     Cluster properly handles 2D boxes. As with everything else in freud, 2D
@@ -46,17 +47,14 @@ class Cluster
 {
 public:
     //! Constructor
-    Cluster(float r_max);
+    Cluster();
 
     //! Compute the point clusters
     void compute(const freud::locality::NeighborQuery* nq,
                  const freud::locality::NeighborList* nlist,
-                 const vec3<float> *points,
-                 unsigned int Np,
-                 freud::locality::QueryArgs qargs);
-
-    //! Compute clusters with key membership
-    void computeClusterMembership(const unsigned int* keys);
+                 const vec3<float>* points, unsigned int Np,
+                 freud::locality::QueryArgs qargs,
+                 const unsigned int* keys=NULL);
 
     //! Count the number of clusters found in the last call to compute()
     unsigned int getNumClusters()
@@ -70,25 +68,28 @@ public:
         return m_num_particles;
     }
 
-    //! Get a reference to the last computed cluster_idx
+    //! Get a reference to the last computed cluster ids
     const util::ManagedArray<unsigned int> &getClusterIdx()
     {
         return m_cluster_idx;
     }
 
-    //! Returns the cluster keys last determined by computeClusterKeys
-    const std::vector<std::vector<unsigned int>>& getClusterKeys()
+    //! Returns the last computed cluster keys
+    const std::vector<std::vector<unsigned int>> &getClusterKeys()
     {
         return m_cluster_keys;
     }
 
 private:
-    float m_r_max;                 //!< Maximum r at which points will be counted in the same cluster
     unsigned int m_num_particles; //!< Number of particles processed in the last call to compute()
     unsigned int m_num_clusters;  //!< Number of clusters found in the last call to compute()
     util::ManagedArray<unsigned int> m_cluster_idx; //!< Cluster index determined for each particle
     std::vector<std::vector<unsigned int>> m_cluster_keys; //!< List of keys in each cluster
 };
+
+// Returns inverse permutation of cluster indices, sorted from largest to smallest.
+// Adapted from https://stackoverflow.com/questions/1577475/c-sorting-and-keeping-track-of-indexes
+std::vector<size_t> sort_indexes_inverse(const std::vector<size_t> &counts, const std::vector<size_t> &min_ids);
 
 }; }; // end namespace freud::cluster
 

--- a/cpp/cluster/Cluster.h
+++ b/cpp/cluster/Cluster.h
@@ -21,37 +21,63 @@
 
 namespace freud { namespace cluster {
 //! Finds clusters using a network of neighbors.
+/*! Given a set of particles and their neighbors,
+ *  freud.cluster.Cluster will determine all of the connected
+ *  components of the network formed by those neighbor bonds. That is, two
+ *  points are in the same cluster if and only if a path exists between them on
+ *  the network of bonds. The class attribute cluster_idx holds an
+ *  array of cluster indices for each particle. By the definition of a cluster,
+ *  points that are not bonded to any other point end up in their own
+ *  1-particle cluster.
+ *
+ *  Identifying micelles is one use-case for finding clusters. This operation
+ *  is somewhat different, though. In a cluster of points, each and every point
+ *  belongs to one and only one cluster. However, because a string of points
+ *  belongs to a polymer, that single polymer may be present in more than one
+ *  cluster. To handle this situation, an optional layer is presented on top of
+ *  the cluster_idx array. Given a key value per particle (e.g. the polymer
+ *  id), the compute function will process clusters with the key values in mind and
+ *  provide a list of keys that are present in each cluster in the attribute
+ *  cluster_keys, as a list of lists. If keys are not provided, every
+ *  particle is assigned a key corresponding to its index, and cluster_keys
+ *  contains the particle ids present in each cluster.
+ *
+ *  <b>2D:</b><br>
+ *  Cluster properly handles 2D boxes. As with everything else in freud, 2D
+ *  points must be passed in as 3 component vectors x, y, 0. Failing to set 0 in
+ *  the third component will lead to undefined behavior.
+ */
 class Cluster
 {
 public:
     //! Constructor
     Cluster();
 
-    //! Compute the point clusters
+    //! Compute the point clusters.
     void compute(const freud::locality::NeighborQuery* nq,
                  const freud::locality::NeighborList* nlist,
                  freud::locality::QueryArgs qargs,
                  const unsigned int* keys=NULL);
 
-    //! Count the number of clusters found in the last call to compute()
+    //! Count the number of clusters found in the last call to compute().
     unsigned int getNumClusters()
     {
         return m_num_clusters;
     }
 
-    //! Return the number of particles in the current Compute
+    //! Return the number of particles in the current Compute.
     unsigned int getNumParticles()
     {
         return m_num_particles;
     }
 
-    //! Get a reference to the last computed cluster ids
+    //! Get a reference to the last computed cluster ids.
     const util::ManagedArray<unsigned int> &getClusterIdx()
     {
         return m_cluster_idx;
     }
 
-    //! Returns the last computed cluster keys
+    //! Returns the last computed cluster keys.
     const std::vector<std::vector<unsigned int>> &getClusterKeys()
     {
         return m_cluster_keys;

--- a/freud/_cluster.pxd
+++ b/freud/_cluster.pxd
@@ -12,13 +12,13 @@ cimport freud.util
 
 cdef extern from "Cluster.h" namespace "freud::cluster":
     cdef cppclass Cluster:
-        Cluster(float) except +
+        Cluster() except +
         void compute(const freud._locality.NeighborQuery*,
                      const freud._locality.NeighborList*,
-                     const vec3[float] *,
+                     const vec3[float]*,
                      unsigned int,
-                     freud._locality.QueryArgs) except +
-        void computeClusterMembership(const unsigned int*) except +
+                     freud._locality.QueryArgs,
+                     const unsigned int*) except +
         unsigned int getNumClusters()
         unsigned int getNumParticles()
         const freud.util.ManagedArray[unsigned int] &getClusterIdx()

--- a/freud/_cluster.pxd
+++ b/freud/_cluster.pxd
@@ -15,8 +15,6 @@ cdef extern from "Cluster.h" namespace "freud::cluster":
         Cluster() except +
         void compute(const freud._locality.NeighborQuery*,
                      const freud._locality.NeighborList*,
-                     const vec3[float]*,
-                     unsigned int,
                      freud._locality.QueryArgs,
                      const unsigned int*) except +
         unsigned int getNumClusters()

--- a/freud/cluster.pyx
+++ b/freud/cluster.pyx
@@ -114,8 +114,6 @@ cdef class Cluster(PairCompute):
         self.thisptr.compute(
             nq.get_ptr(),
             nlistptr.get_ptr(),
-            <vec3[float]*> &l_query_points[0, 0],
-            num_query_points,
             dereference(qargs.thisptr),
             l_keys_ptr)
         return self

--- a/freud/cluster.pyx
+++ b/freud/cluster.pyx
@@ -27,34 +27,31 @@ cimport numpy as np
 np.import_array()
 
 cdef class Cluster(PairCompute):
-    R"""Finds clusters in a set of points.
+    """Finds clusters using a network of neighbors.
 
-    Given a set of coordinates and a cutoff, :class:`freud.cluster.Cluster`
-    will determine all of the clusters of points that are made up of points
-    that are closer than the cutoff. Clusters are 0-indexed. The class contains
-    an index array, the :code:`cluster_idx` attribute, which can be used to
-    identify which cluster a particle is associated with:
-    :code:`cluster_obj.cluster_idx[i]` is the cluster index in which particle
-    :code:`i` is found. By the definition of a cluster, points that are not
-    within the cutoff of another point end up in their own 1-particle cluster.
+    Given a set of particles and their neighbors,
+    :class:`freud.cluster.Cluster` will determine all of the connected
+    components of the network formed by those neighbor bonds.  That is, two
+    points are in the same cluster if and only if a path exists between them on
+    the network of bonds. The class attribute :code:`cluster_idx` holds an
+    array of cluster indices for each particle. By the definition of a cluster,
+    points that are not bonded to any other point end up in their own
+    1-particle cluster.
 
-    Identifying micelles is one primary use-case for finding clusters. This
-    operation is somewhat different, though. In a cluster of points, each and
-    every point belongs to one and only one cluster. However, because a string
-    of points belongs to a polymer, that single polymer may be present in more
-    than one cluster. To handle this situation, an optional layer is presented
-    on top of the :code:`cluster_idx` array. Given a key value per particle
-    (i.e. the polymer id), the computeClusterMembership function will process
-    :code:`cluster_idx` with the key values in mind and provide a list of keys
-    that are present in each cluster.
+    Identifying micelles is one use-case for finding clusters. This operation
+    is somewhat different, though. In a cluster of points, each and every point
+    belongs to one and only one cluster. However, because a string of points
+    belongs to a polymer, that single polymer may be present in more than one
+    cluster. To handle this situation, an optional layer is presented on top of
+    the :code:`cluster_idx` array. Given a key value per particle (e.g. the
+    polymer id), the compute function will process clusters with the key values
+    in mind and provide a list of keys that are present in each cluster in the
+    attribute :code:`cluster_keys`, as a list of lists. If keys are not
+    provided, every particle is assigned a key corresponding to its index, and
+    :code:`cluster_keys` contains the particle ids present in each cluster.
 
     .. moduleauthor:: Joshua Anderson <joaander@umich.edu>
-
-    Args:
-        box (:class:`freud.box.Box`):
-            The simulation box.
-        r_max (float):
-            Particle distance cutoff.
+    .. moduleauthor:: Bradley Dice <bdice@bradleydice.com>
 
     .. note::
         **2D:** :class:`freud.cluster.Cluster` properly handles 2D boxes.

--- a/freud/cluster.pyx
+++ b/freud/cluster.pyx
@@ -31,7 +31,7 @@ cdef class Cluster(PairCompute):
 
     Given a set of particles and their neighbors,
     :class:`freud.cluster.Cluster` will determine all of the connected
-    components of the network formed by those neighbor bonds.  That is, two
+    components of the network formed by those neighbor bonds. That is, two
     points are in the same cluster if and only if a path exists between them on
     the network of bonds. The class attribute :code:`cluster_idx` holds an
     array of cluster indices for each particle. By the definition of a cluster,

--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -116,13 +116,12 @@ class TestCluster(unittest.TestCase):
         positions = np.array(positions).reshape((-1, 3))
 
         clust = freud.cluster.Cluster(0.5)
-        clust.compute(box, positions)
 
         # Test protected attribute access
         with self.assertRaises(AttributeError):
             clust.cluster_keys
 
-        clust.computeClusterMembership(np.array(range(Nrep*Ngrid)))
+        clust.compute(box, positions, keys=np.arange(Nrep*Ngrid))
 
         # Test if attributes are accessible now
         clust.cluster_keys


### PR DESCRIPTION
## Description
In previous versions of freud, the cluster algorithm has looped over bonds in the NeighborList/NeighborQuery and used a cutoff radius to filter those bonds. That is, two particles are in the same cluster if and only if there is a path between them in the network of bonds, where every bond distance along that walk is less than `r_cut`. This is annoying for two reasons:

1. If this behavior is desired, it's easy to just filter the network of bonds using a cutoff distance before passing it into `Cluster.compute`.
2. It is not straightforward to use a network of bonds formed by some criterion other than distance (unless you fake it by producing a NeighborList and using an arbitrarily high value of `r_cut`).

## Motivation and Context
By rewriting this, it becomes much easier to use this module for the clustering performed by the Solid-Liquid order parameter.

## How Has This Been Tested?
Existing tests pass.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds or improves functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/glotzerlab/freud/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] I have updated the documentation (if relevant).
- [x] I have added tests that cover my changes (if relevant).
- [x] All new and existing tests passed.
- [ ] I have updated the [Changelog](https://github.com/glotzerlab/freud/blob/master/ChangeLog.md).
