### PR TITLE
Enable query_args for Steinhardt

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -21,6 +21,7 @@ Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to
 * Arrays returned to Python persist even after the compute object is destroyed or resizes its arrays.
 * RDF bin centers are now strictly at the center of bins.
 * RDF no longer performs parallel accumulation of cumulative counts (provided no performance gains and was substantially more complex code).
+* Steinhardt uses query arguments.
 
 ### Fixed
 * Steinhardt uses the ThreadStorage class and properly resets memory where needed.

--- a/cpp/order/Steinhardt.cc
+++ b/cpp/order/Steinhardt.cc
@@ -200,15 +200,12 @@ void Steinhardt::computeAve(const freud::locality::NeighborList* nlist,
 
                 for(freud::locality::NeighborBond nb2 = ns_neighbors_iter->next(); !ns_neighbors_iter->end(); nb2 = ns_neighbors_iter->next())
                 {
-                    if (nb2.distance < m_r_max && nb2.distance > m_r_min)
+                    for (unsigned int k = 0; k < (2 * m_l + 1); ++k)
                     {
-                        for (unsigned int k = 0; k < (2 * m_l + 1); ++k)
-                        {
-                            // Adding all the Qlm of the neighbors
-                            m_QlmiAve.get()[(2 * m_l + 1) * i + k] += m_Qlmi.get()[(2 * m_l + 1) * nb2.ref_id + k];
-                        }
-                        neighborcount++;
+                        // Adding all the Qlm of the neighbors
+                        m_QlmiAve.get()[(2 * m_l + 1) * i + k] += m_Qlmi.get()[(2 * m_l + 1) * nb2.ref_id + k];
                     }
+                    neighborcount++;
                 } // End loop over particle neighbor's bonds
             } // End loop over particle's bonds
 

--- a/cpp/order/Steinhardt.h
+++ b/cpp/order/Steinhardt.h
@@ -57,22 +57,13 @@ class Steinhardt
 public:
     //! Steinhardt Class Constructor
     /*! Constructor for Steinhardt analysis class.
-     *  \param r_max Cutoff radius for running the local order parameter.
-     *              Values near first minima of the rdf are recommended.
      *  \param l Spherical harmonic number l.
      *           Must be a positive number.
-     *  \param r_min (optional) Lower bound for computing the local order parameter.
-     *                         Allows looking at, for instance, only the second shell,
-     *                         or some other arbitrary rdf region.
      */
-    Steinhardt(float r_max, unsigned int l, float r_min = 0, bool average = false, bool Wl = false, bool weighted = false)
-        : m_Np(0), m_r_max(r_max), m_l(l), m_r_min(r_min), m_average(average), m_Wl(Wl), m_weighted(weighted), m_Qlm_local(2 * l + 1)
+    Steinhardt(unsigned int l, bool average = false, bool Wl = false, bool weighted = false)
+        : m_Np(0), m_l(l), m_average(average), m_Wl(Wl), m_weighted(weighted), m_Qlm_local(2 * l + 1)
     {
-        // Error Checking
-        if (m_r_max < 0.0f || m_r_min < 0.0f)
-            throw std::invalid_argument("Steinhardt requires r_min and r_max must be positive.");
-        if (m_r_min >= m_r_max)
-            throw std::invalid_argument("Steinhardt requires r_min must be less than r_max.");
+        // Error checking
         if (m_l < 2)
             throw std::invalid_argument("Steinhardt requires l must be two or greater.");
     }
@@ -178,9 +169,7 @@ private:
 
     // Member variables used for compute
     unsigned int m_Np; //!< Last number of points computed
-    float m_r_max;      //!< Maximum r at which to determine neighbors
     unsigned int m_l;  //!< Spherical harmonic l value.
-    float m_r_min;      //!< Minimum r at which to determine neighbors (default 0)
 
     // Flags
     bool m_average; //!< Whether to take a second shell average (default false)

--- a/cpp/order/Steinhardt.h
+++ b/cpp/order/Steinhardt.h
@@ -63,7 +63,6 @@ public:
     Steinhardt(unsigned int l, bool average = false, bool Wl = false, bool weighted = false)
         : m_Np(0), m_l(l), m_average(average), m_Wl(Wl), m_weighted(weighted), m_Qlm_local(2 * l + 1)
     {
-        // Error checking
         if (m_l < 2)
             throw std::invalid_argument("Steinhardt requires l must be two or greater.");
     }

--- a/freud/_order.pxd
+++ b/freud/_order.pxd
@@ -70,8 +70,7 @@ cdef extern from "HexTransOrderParameter.h" namespace "freud::order":
 
 cdef extern from "Steinhardt.h" namespace "freud::order":
     cdef cppclass Steinhardt:
-        Steinhardt(float, unsigned int, float,
-                   bool, bool, bool) except +
+        Steinhardt(unsigned int, bool, bool, bool) except +
         unsigned int getNP()
         void compute(const freud._locality.NeighborList*,
                      const freud._locality.NeighborQuery*,

--- a/freud/common.pyx
+++ b/freud/common.pyx
@@ -185,12 +185,13 @@ cdef class PairCompute(Compute):
 
         cdef freud.locality._QueryArgs qargs
         if query_args is not None:
+            query_args.setdefault('exclude_ii', query_points is None)
             qargs = freud.locality._QueryArgs.from_dict(query_args)
         else:
             try:
-                qargs = freud.locality._QueryArgs.from_dict(
-                    self.default_query_args)
-                qargs.update({'exclude_ii': query_points is None})
+                query_args = self.default_query_args
+                query_args.setdefault('exclude_ii', query_points is None)
+                qargs = freud.locality._QueryArgs.from_dict(query_args)
             except ValueError:
                 # If a NeighborList was provided, then the user need not
                 # provide _QueryArgs.

--- a/freud/locality.pyx
+++ b/freud/locality.pyx
@@ -148,6 +148,19 @@ cdef class _QueryArgs:
     def scale(self, value):
         self.thisptr.scale = value
 
+    def __repr__(self):
+        return ("freud.locality.{cls}(mode={mode}, r_max={r_max}, "
+                "num_neighbors={num_neighbors}, exclude_ii={exclude_ii}, "
+                "scale={scale})").format(
+                    cls=type(self).__name__,
+                    mode=self.mode, r_max=self.r_max,
+                    num_neighbors=self.num_neighbors,
+                    exclude_ii=self.exclude_ii,
+                    scale=self.scale)
+
+    def __str__(self):
+        return repr(self)
+
 
 cdef class NeighborQueryResult:
     R"""Class encapsulating the output of queries of NeighborQuery objects.

--- a/freud/order.pyx
+++ b/freud/order.pyx
@@ -606,7 +606,6 @@ cdef class Steinhardt(PairCompute):
         b, nq, nlistptr, qargs, l_query_points, num_query_points = \
             self.preprocess_arguments(box, points, nlist=nlist,
                                       query_args=query_args)
-        print(qargs)
 
         self.stptr.compute(nlistptr.get_ptr(),
                            nq.get_ptr(),

--- a/freud/order.pyx
+++ b/freud/order.pyx
@@ -499,10 +499,10 @@ cdef class Steinhardt(PairCompute):
     original definition by the average value of :math:`\overline{Q}_{lm}(k)`
     over all the :math:`k` neighbors of particle :math:`i` as well as itself.
 
-    The norm constructor argument provides normalized versions of the
-    plain :math:`Q_l` or :math:`W_l` or normalized average if the
-    average flag is set to true, where the normalization is performed by
-    dividing by the average :math:`Q_{lm}` values over all particles.
+    The :code:`norm` attribute argument provides normalized versions of the
+    order parameter, where the normalization is performed by averaging the
+    :math:`Q_{lm}` values over all particles before computing the order
+    parameter of choice.
 
     .. moduleauthor:: Xiyu Du <xiyudu@umich.edu>
     .. moduleauthor:: Vyas Ramasubramani <vramasub@umich.edu>
@@ -512,16 +512,8 @@ cdef class Steinhardt(PairCompute):
     Args:
         l (unsigned int):
             Spherical harmonic quantum number l. Must be a positive number.
-        r_min (float):
-            Can look at only the second shell or some arbitrary RDF region.
-        r_max (float):
-            Cutoff radius for the local order parameter. Values near the first
-            minimum of the RDF are recommended.
         average (bool, optional):
             Determines whether to calculate the averaged Steinhardt order
-            parameter. (Default value = :code:`False`)
-        norm (bool, optional):
-            Determines whether to calculate the normalized Steinhardt order
             parameter. (Default value = :code:`False`)
         Wl (bool, optional):
             Determines whether to use the :math:`W_l` version of the Steinhardt
@@ -531,11 +523,6 @@ cdef class Steinhardt(PairCompute):
             spherical harmonics over neighbors. If enabled and used with a
             Voronoi neighbor list, this results in the Minkowski Structure
             Metrics :math:`Q'_l`. (Default value = :code:`False`)
-        num_neighbors (int, optional):
-            If set to a non-zero positive integer, limit the calculation of the
-            Steinhardt order parameter to :code:`num_neighbors` neighbors.
-            (Default value = :code:`0`)
-
 
     Attributes:
         num_particles (unsigned int):
@@ -549,21 +536,11 @@ cdef class Steinhardt(PairCompute):
             order parameter.
     """  # noqa: E501
     cdef freud._order.Steinhardt * stptr
-    cdef r_max
     cdef sph_l
-    cdef r_min
-    cdef num_neighbors
 
-    def __cinit__(self, r_max, l, r_min=0, average=False, Wl=False,
-                  weighted=False, num_neighbors=0):
-        if type(self) is Steinhardt:
-            self.r_max = r_max
-            self.sph_l = l
-            self.r_min = r_min
-            self.num_neighbors = num_neighbors
-            self.stptr = new freud._order.Steinhardt(
-                r_max, l, r_min,
-                average, Wl, weighted)
+    def __cinit__(self, l, average=False, Wl=False, weighted=False):
+        self.sph_l = l
+        self.stptr = new freud._order.Steinhardt(l, average, Wl, weighted)
 
     def __dealloc__(self):
         if type(self) is Steinhardt:
@@ -629,32 +606,21 @@ cdef class Steinhardt(PairCompute):
         b, nq, nlistptr, qargs, l_query_points, num_query_points = \
             self.preprocess_arguments(box, points, nlist=nlist,
                                       query_args=query_args)
+        print(qargs)
 
         self.stptr.compute(nlistptr.get_ptr(),
                            nq.get_ptr(),
                            dereference(qargs.thisptr))
         return self
 
-    @property
-    def default_query_args(self):
-        if self.num_neighbors > 0:
-            return dict(mode="nearest", num_neighbors=self.num_neighbors,
-                        r_max=self.r_max)
-        else:
-            return dict(mode="ball", r_max=self.r_max)
-
     def __repr__(self):
-        return ("freud.order.{cls}(r_max={r_max}, l={sph_l}, "
-                "r_min={r_min}, average={average}, Wl={Wl}, "
-                "weighted={weighted}, num_neighbors={num_neighbors})").format(
+        return ("freud.order.{cls}(l={sph_l}, average={average}, Wl={Wl}, "
+                "weighted={weighted})").format(
                     cls=type(self).__name__,
-                    r_max=self.r_max,
                     sph_l=self.sph_l,
-                    r_min=self.r_min,
                     average=self.average,
                     Wl=self.Wl,
-                    weighted=self.weighted,
-                    num_neighbors=self.num_neighbors)
+                    weighted=self.weighted)
 
     @Compute._computed_method()
     def plot(self, ax=None):

--- a/tests/test_environment_LocalDescriptors.py
+++ b/tests/test_environment_LocalDescriptors.py
@@ -166,7 +166,7 @@ class TestLocalDescriptors(unittest.TestCase):
 
             # Test all allowable values of l.
             for L in range(2, l_max+1):
-                steinhardt = freud.order.Steinhardt(r_max*2, L)
+                steinhardt = freud.order.Steinhardt(L)
                 steinhardt.compute(box, points, nlist=nl)
                 npt.assert_array_almost_equal(steinhardt.order, Ql[:, L])
 
@@ -223,8 +223,7 @@ class TestLocalDescriptors(unittest.TestCase):
 
             # Test all allowable values of l.
             for L in range(2, l_max+1):
-                steinhardt = freud.order.Steinhardt(
-                    r_max, L, weighted=True, num_neighbors=num_neighbors)
+                steinhardt = freud.order.Steinhardt(L, weighted=True)
                 steinhardt.compute(box, points, nlist=nl)
                 npt.assert_array_almost_equal(steinhardt.order, Ql[:, L])
 
@@ -298,7 +297,7 @@ class TestLocalDescriptors(unittest.TestCase):
 
             # Test all allowable values of l.
             for L in range(2, l_max+1):
-                steinhardt = freud.order.Steinhardt(r_max*2, L, Wl=True)
+                steinhardt = freud.order.Steinhardt(L, Wl=True)
                 steinhardt.compute(box, points, nlist=nl)
                 npt.assert_array_almost_equal(steinhardt.order, Wl[:, L])
 

--- a/tests/test_order_Steinhardt.py
+++ b/tests/test_order_Steinhardt.py
@@ -184,30 +184,6 @@ class TestSteinhardt(unittest.TestCase):
         comp.norm
         comp.order
 
-    def test_soft_cutoff(self):
-        (box, positions) = util.make_fcc(4, 4, 4)
-
-        comp = freud.order.Steinhardt(6, Wl=True)
-        comp.compute(box, positions, query_args={
-            'mode': 'nearest', 'exclude_ii': True, 'num_neighbors': 12})
-        npt.assert_allclose(np.average(comp.order), PERFECT_FCC_W6, atol=1e-5)
-        npt.assert_allclose(comp.order, comp.order[0], atol=1e-5)
-        self.assertAlmostEqual(comp.norm, PERFECT_FCC_W6, delta=1e-5)
-        comp.compute(box, positions, query_args={
-            'mode': 'nearest', 'num_neighbors': 12})
-        npt.assert_allclose(np.average(comp.order), PERFECT_FCC_W6, atol=1e-5)
-        npt.assert_allclose(comp.order, comp.order[0], atol=1e-5)
-        self.assertAlmostEqual(comp.norm, PERFECT_FCC_W6, delta=1e-5)
-        comp.compute(box, positions, query_args={
-            'exclude_ii': True, 'num_neighbors': 12})
-        npt.assert_allclose(np.average(comp.order), PERFECT_FCC_W6, atol=1e-5)
-        npt.assert_allclose(comp.order, comp.order[0], atol=1e-5)
-        self.assertAlmostEqual(comp.norm, PERFECT_FCC_W6, delta=1e-5)
-        comp.compute(box, positions, query_args={'num_neighbors': 12})
-        npt.assert_allclose(np.average(comp.order), PERFECT_FCC_W6, atol=1e-5)
-        npt.assert_allclose(comp.order, comp.order[0], atol=1e-5)
-        self.assertAlmostEqual(comp.norm, PERFECT_FCC_W6, delta=1e-5)
-
     def test_compute_twice_norm(self):
         """Test that computing norm twice works as expected."""
         L = 5

--- a/tests/test_order_Steinhardt.py
+++ b/tests/test_order_Steinhardt.py
@@ -17,8 +17,8 @@ class TestSteinhardt(unittest.TestCase):
 
         box, positions = util.make_box_and_random_points(L, N)
 
-        comp = freud.order.Steinhardt(1.5, 6)
-        comp.compute(box, positions)
+        comp = freud.order.Steinhardt(6)
+        comp.compute(box, positions, query_args={'r_max': 1.5})
 
         npt.assert_equal(comp.order.shape[0], N)
 
@@ -28,15 +28,15 @@ class TestSteinhardt(unittest.TestCase):
         test_set = util.make_raw_query_nlist_test_set(
             box, positions, positions, 'ball', r_max, 0, True)
         for ts in test_set:
-            comp = freud.order.Steinhardt(r_max, 6)
-            comp.compute(box, ts[0], nlist=ts[1])
+            comp = freud.order.Steinhardt(6)
+            comp.compute(box, ts[0], nlist=ts[1], query_args=ts[2])
             npt.assert_allclose(
                 np.average(comp.order), PERFECT_FCC_Q6, atol=1e-5)
             npt.assert_allclose(comp.order, comp.order[0], atol=1e-5)
             self.assertAlmostEqual(comp.norm, PERFECT_FCC_Q6, delta=1e-5)
 
-            comp = freud.order.Steinhardt(1.5, 6, average=True)
-            comp.compute(box, positions)
+            comp = freud.order.Steinhardt(6, average=True)
+            comp.compute(box, ts[0], nlist=ts[1], query_args=ts[2])
             npt.assert_allclose(
                 np.average(comp.order), PERFECT_FCC_Q6, atol=1e-5)
             npt.assert_allclose(comp.order, comp.order[0], atol=1e-5)
@@ -50,16 +50,15 @@ class TestSteinhardt(unittest.TestCase):
         test_set = util.make_raw_query_nlist_test_set(
             box, positions, positions, 'nearest', r_max, n, True)
         for ts in test_set:
-            comp = freud.order.Steinhardt(r_max, 6, num_neighbors=n)
-            comp.compute(box, ts[0], nlist=ts[1])
+            comp = freud.order.Steinhardt(6)
+            comp.compute(box, ts[0], nlist=ts[1], query_args=ts[2])
             npt.assert_allclose(
                 np.average(comp.order), PERFECT_FCC_Q6, atol=1e-5)
             npt.assert_allclose(comp.order, comp.order[0], atol=1e-5)
             self.assertAlmostEqual(comp.norm, PERFECT_FCC_Q6, delta=1e-5)
 
-            comp = freud.order.Steinhardt(r_max, 6, num_neighbors=n,
-                                          average=True)
-            comp.compute(box, ts[0], nlist=ts[1])
+            comp = freud.order.Steinhardt(6, average=True)
+            comp.compute(box, ts[0], nlist=ts[1], query_args=ts[2])
             npt.assert_allclose(
                 np.average(comp.order), PERFECT_FCC_Q6, atol=1e-5)
             npt.assert_allclose(comp.order, comp.order[0], atol=1e-5)
@@ -74,16 +73,15 @@ class TestSteinhardt(unittest.TestCase):
             'nearest', r_max, n, True)
         # Ensure exactly 13 values change for the perturbed system
         for ts in test_set:
-            comp = freud.order.Steinhardt(r_max, 6, num_neighbors=n)
-            comp.compute(box, ts[0], nlist=ts[1])
+            comp = freud.order.Steinhardt(6)
+            comp.compute(box, ts[0], nlist=ts[1], query_args=ts[2])
             self.assertEqual(
                 sum(~np.isclose(comp.Ql, PERFECT_FCC_Q6, rtol=1e-6)), 13)
 
             # More than 13 particles should change for
             # Ql averaged over neighbors
-            comp = freud.order.Steinhardt(r_max, 6, num_neighbors=n,
-                                          average=True)
-            comp.compute(box, ts[0], nlist=ts[1])
+            comp = freud.order.Steinhardt(6, average=True)
+            comp.compute(box, ts[0], nlist=ts[1], query_args=ts[2])
             self.assertGreater(
                 sum(~np.isclose(comp.order, PERFECT_FCC_Q6, rtol=1e-6)), 13)
 
@@ -94,15 +92,15 @@ class TestSteinhardt(unittest.TestCase):
         test_set = util.make_raw_query_nlist_test_set(
             box, positions, positions, 'ball', r_max, 0, True)
         for ts in test_set:
-            comp = freud.order.Steinhardt(r_max, 6, Wl=True)
-            comp.compute(box, ts[0], nlist=ts[1])
+            comp = freud.order.Steinhardt(6, Wl=True)
+            comp.compute(box, ts[0], nlist=ts[1], query_args=ts[2])
             npt.assert_allclose(
                 np.average(comp.order), PERFECT_FCC_W6, atol=1e-5)
             npt.assert_allclose(comp.order, comp.order[0], atol=1e-5)
             self.assertAlmostEqual(comp.norm, PERFECT_FCC_W6, delta=1e-5)
 
-            comp = freud.order.Steinhardt(1.5, 6, Wl=True, average=True)
-            comp.compute(box, positions)
+            comp = freud.order.Steinhardt(6, Wl=True, average=True)
+            comp.compute(box, ts[0], nlist=ts[1], query_args=ts[2])
             npt.assert_allclose(
                 np.average(comp.order), PERFECT_FCC_W6, atol=1e-5)
             npt.assert_allclose(comp.order, comp.order[0], atol=1e-5)
@@ -117,17 +115,16 @@ class TestSteinhardt(unittest.TestCase):
         test_set = util.make_raw_query_nlist_test_set(
             box, positions, positions, 'nearest', r_max, n, True)
         for ts in test_set:
-            comp = freud.order.Steinhardt(r_max, 6, num_neighbors=n, Wl=True)
-            comp.compute(box, ts[0], nlist=ts[1])
+            comp = freud.order.Steinhardt(6, Wl=True)
+            comp.compute(box, ts[0], nlist=ts[1], query_args=ts[2])
             npt.assert_allclose(
                 np.real(np.average(comp.order)), PERFECT_FCC_W6, atol=1e-5)
             npt.assert_allclose(comp.order, comp.order[0], atol=1e-5)
             self.assertAlmostEqual(
                 np.real(comp.norm), PERFECT_FCC_W6, delta=1e-5)
 
-            comp = freud.order.Steinhardt(r_max, 6, num_neighbors=n, Wl=True,
-                                          average=True)
-            comp.compute(box, ts[0], nlist=ts[1])
+            comp = freud.order.Steinhardt(6, Wl=True, average=True)
+            comp.compute(box, ts[0], nlist=ts[1], query_args=ts[2])
             npt.assert_allclose(
                 np.real(np.average(comp.order)), PERFECT_FCC_W6, atol=1e-5)
             npt.assert_allclose(comp.order, comp.order[0], atol=1e-5)
@@ -151,7 +148,7 @@ class TestSteinhardt(unittest.TestCase):
                 # Change the weight of the first bond for each particle
                 nlist.weights[nlist.segments] = wt
 
-                comp = freud.order.Steinhardt(r_max, 6, weighted=True)
+                comp = freud.order.Steinhardt(6, weighted=True)
                 comp.compute(box, ts[0], nlist=nlist)
 
                 # Unequal neighbor weighting in a perfect FCC structure
@@ -161,7 +158,7 @@ class TestSteinhardt(unittest.TestCase):
                 npt.assert_array_less(PERFECT_FCC_Q6, comp.norm)
 
                 # Ensure that W6 values are altered by changing the weights
-                comp = freud.order.Steinhardt(r_max, 6, Wl=True, weighted=True)
+                comp = freud.order.Steinhardt(6, Wl=True, weighted=True)
                 comp.compute(box, ts[0], nlist=nlist)
                 with self.assertRaises(AssertionError):
                     npt.assert_allclose(
@@ -174,7 +171,7 @@ class TestSteinhardt(unittest.TestCase):
             self.assertEqual(len(positions), comp.num_particles)
 
     def test_attribute_access(self):
-        comp = freud.order.Steinhardt(1.5, 6)
+        comp = freud.order.Steinhardt(6)
 
         with self.assertRaises(AttributeError):
             comp.norm
@@ -182,7 +179,7 @@ class TestSteinhardt(unittest.TestCase):
             comp.order
 
         (box, positions) = util.make_fcc(4, 4, 4)
-        comp.compute(box, positions)
+        comp.compute(box, positions, query_args={'r_max': 1.5})
 
         comp.norm
         comp.order
@@ -190,9 +187,23 @@ class TestSteinhardt(unittest.TestCase):
     def test_soft_cutoff(self):
         (box, positions) = util.make_fcc(4, 4, 4)
 
-        # Use a really small cutoff to ensure that it is used as a soft cutoff
-        comp = freud.order.Steinhardt(0.1, 6, num_neighbors=12, Wl=True)
-        comp.compute(box, positions)
+        comp = freud.order.Steinhardt(6, Wl=True)
+        comp.compute(box, positions, query_args={
+            'mode': 'nearest', 'exclude_ii': True, 'num_neighbors': 12})
+        npt.assert_allclose(np.average(comp.order), PERFECT_FCC_W6, atol=1e-5)
+        npt.assert_allclose(comp.order, comp.order[0], atol=1e-5)
+        self.assertAlmostEqual(comp.norm, PERFECT_FCC_W6, delta=1e-5)
+        comp.compute(box, positions, query_args={
+            'mode': 'nearest', 'num_neighbors': 12})
+        npt.assert_allclose(np.average(comp.order), PERFECT_FCC_W6, atol=1e-5)
+        npt.assert_allclose(comp.order, comp.order[0], atol=1e-5)
+        self.assertAlmostEqual(comp.norm, PERFECT_FCC_W6, delta=1e-5)
+        comp.compute(box, positions, query_args={
+            'exclude_ii': True, 'num_neighbors': 12})
+        npt.assert_allclose(np.average(comp.order), PERFECT_FCC_W6, atol=1e-5)
+        npt.assert_allclose(comp.order, comp.order[0], atol=1e-5)
+        self.assertAlmostEqual(comp.norm, PERFECT_FCC_W6, delta=1e-5)
+        comp.compute(box, positions, query_args={'num_neighbors': 12})
         npt.assert_allclose(np.average(comp.order), PERFECT_FCC_W6, atol=1e-5)
         npt.assert_allclose(comp.order, comp.order[0], atol=1e-5)
         self.assertAlmostEqual(comp.norm, PERFECT_FCC_W6, delta=1e-5)
@@ -203,9 +214,9 @@ class TestSteinhardt(unittest.TestCase):
         num_points = 100
         box, points = util.make_box_and_random_points(L, num_points, seed=0)
 
-        st = freud.order.Steinhardt(1.5, 6)
-        first_result = st.compute(box, points).norm
-        second_result = st.compute(box, points).norm
+        st = freud.order.Steinhardt(6)
+        first_result = st.compute(box, points, query_args={'r_max': 1.5}).norm
+        second_result = st.compute(box, points, query_args={'r_max': 1.5}).norm
 
         npt.assert_array_almost_equal(first_result, second_result)
 
@@ -230,8 +241,8 @@ class TestSteinhardt(unittest.TestCase):
             13, 13, index_i, index_j)
         nlist.distances[:] = np.sqrt(2)
 
-        q6 = freud.order.Steinhardt(1.5, 6)
-        w6 = freud.order.Steinhardt(1.5, 6, Wl=True)
+        q6 = freud.order.Steinhardt(6)
+        w6 = freud.order.Steinhardt(6, Wl=True)
 
         q6.compute(box, positions, nlist=nlist)
         q6_unrotated_order = q6.order[0]
@@ -254,11 +265,10 @@ class TestSteinhardt(unittest.TestCase):
             npt.assert_almost_equal(w6.order[0], PERFECT_FCC_W6)
 
     def test_repr(self):
-        comp = freud.order.Steinhardt(1.5, 6)
+        comp = freud.order.Steinhardt(6)
         self.assertEqual(str(comp), str(eval(repr(comp))))
         # Use non-default arguments for all parameters
-        comp = freud.order.Steinhardt(1.5, 6, 0.1, average=True, Wl=True,
-                                      weighted=True, num_neighbors=7)
+        comp = freud.order.Steinhardt(6, average=True, Wl=True, weighted=True)
         self.assertEqual(str(comp), str(eval(repr(comp))))
 
 


### PR DESCRIPTION
## Description
The Steinhardt class was using constructor arguments for `r_max`, `num_neighbors`, etc. This PR changes that to use `query_args` for all neighbor computations.

## Motivation and Context
This partially addresses #368.

## How Has This Been Tested?
Edited tests to use `query_args`.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds or improves functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have read the [**CONTRIBUTING**](https://github.com/glotzerlab/freud/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] I have updated the documentation (if relevant).
- [x] I have added tests that cover my changes (if relevant).
- [x] All new and existing tests passed.
- [x] I have updated the [Changelog](https://github.com/glotzerlab/freud/blob/master/ChangeLog.md).
