### PR TITLE
Disable CI benchmarks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -332,9 +332,10 @@ workflows:
       - test-py36:
           requires:
             - check-style
-      - benchmarks:
-          requires:
-            - test-py36
+# Disabled benchmarks on CI - currently broken
+#     - benchmarks:
+#         requires:
+#           - test-py36
   deploy:
     jobs:
       - pypi-osx-wheels:


### PR DESCRIPTION
CI benchmarks are currently broken and take a long time to run. This PR disables them until further notice. We may re-enable these using a local Jenkins server in the future.