### PR TITLE
Use ManagedArray for ThreadStorage

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -8,6 +8,7 @@ Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to
 * Ability to specify NeighborQuery objects as points for neighbor-based pair computes.
 * Various validation tests.
 * Added standard method for preprocessing arguments of pair computations.
+* New internal array object that allows data persistence and improves indexing in C++.
 
 ### Changed
 * All compute objects that perform neighbor computations now use NeighborQuery internally.
@@ -16,6 +17,7 @@ Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to
 * Standardized naming of various common parameters across freud such as the search distance r\_max.
 * Updated GaussianDensity constructor to accept tuples as width instead of having 2 distinct signatures.
 * Removed unused query\_orientations from PMFTXYZ and PMFTXY2D.
+* Arrays returned to Python persist even after the compute object is destroyed or resizes its arrays.
 
 ### Fixed
 * Steinhardt uses the ThreadStorage class and properly resets memory where needed.

--- a/cpp/order/Steinhardt.cc
+++ b/cpp/order/Steinhardt.cc
@@ -266,8 +266,7 @@ void Steinhardt::reduce()
     parallel_for(tbb::blocked_range<size_t>(0, 2 * m_l + 1), [=](const blocked_range<size_t>& r) {
         for (size_t i = r.begin(); i != r.end(); i++)
         {
-            for (tbb::enumerable_thread_specific<complex<float>*>::const_iterator Ql_local
-                 = m_Qlm_local.begin();
+            for (util::ThreadStorage<complex<float>>::const_iterator Ql_local = m_Qlm_local.begin();
                  Ql_local != m_Qlm_local.end(); Ql_local++)
             {
                 m_Qlm.get()[i] += (*Ql_local)[i];

--- a/cpp/util/ManagedArray.h
+++ b/cpp/util/ManagedArray.h
@@ -210,7 +210,7 @@ public:
             if (indices[i] > (*m_shape)[i])
             {
                 std::ostringstream msg;
-                msg << "Attempted to access index " << index << " in dimension " << i << ", which has size" << (*m_shape)[i] << std::endl;
+                msg << "Attempted to access index " << indices[i] << " in dimension " << i << ", which has size" << (*m_shape)[i] << std::endl;
                 throw std::invalid_argument(msg.str());
             }
         }

--- a/cpp/util/ManagedArray.h
+++ b/cpp/util/ManagedArray.h
@@ -4,6 +4,7 @@
 #include <cstring>
 #include <memory>
 #include <vector>
+#include <sstream>
 
 /*! \file ManagedArray.h
     \brief Defines the standard array class to be used throughout freud.
@@ -119,17 +120,22 @@ public:
     {
         if (index >= size())
         {
-            throw std::runtime_error("Attempted to access data out of bounds.");
+            std::ostringstream msg;
+            msg << "Attempted to access index " << index << " in an array of size " << size() << std::endl;
+            throw std::invalid_argument(msg.str());
         }
         return get()[index];
     }
+
 
     //! Read-only index into array.
     const T &operator[](unsigned int index) const
     {
         if (index >= size())
         {
-            throw std::invalid_argument("Attempted to access data out of bounds.");
+            std::ostringstream msg;
+            msg << "Attempted to access index " << index << " in an array of size " << size() << std::endl;
+            throw std::invalid_argument(msg.str());
         }
         return get()[index];
     }
@@ -203,7 +209,9 @@ public:
         {
             if (indices[i] > (*m_shape)[i])
             {
-                throw std::invalid_argument("Accessing data out of bounds.");
+                std::ostringstream msg;
+                msg << "Attempted to access index " << index << " in dimension " << i << ", which has size" << (*m_shape)[i] << std::endl;
+                throw std::invalid_argument(msg.str());
             }
         }
 

--- a/cpp/util/ThreadStorage.h
+++ b/cpp/util/ThreadStorage.h
@@ -14,7 +14,7 @@ template<typename T> class ThreadStorage
 {
 public:
     //! Default constructor
-    ThreadStorage() : m_size(0), arrays(tbb::enumerable_thread_specific<ManagedArray<T> >([]() { return ManagedArray<T>(); })) {}
+    ThreadStorage() : arrays(tbb::enumerable_thread_specific<ManagedArray<T> >([]() { return ManagedArray<T>(); })) {}
 
     //! Constructor with specific size for thread local arrays
     /*! \param size Size of the thread local arrays
@@ -26,15 +26,7 @@ public:
     /*! \param shape Vector of sizes in each dimension of the thread local arrays
      */
     ThreadStorage(std::vector<unsigned int> shape)
-        : m_shape(shape),
-          arrays(tbb::enumerable_thread_specific<ManagedArray<T> >([this]() { return ManagedArray<T>(m_shape); }))
-    {
-        m_size = 1;
-        for (unsigned int i = 0; i < m_shape.size(); ++i)
-        {
-            m_size *= m_shape[i];
-        }
-    }
+        : arrays(tbb::enumerable_thread_specific<ManagedArray<T> >([shape]() { return ManagedArray<T>(shape); })) {}
 
     //! Destructor
     ~ThreadStorage() {}
@@ -52,13 +44,7 @@ public:
      */
     void resize(std::vector<unsigned int> shape)
     {
-        m_shape = shape;
-        m_size = 1;
-        for (unsigned int i = 0; i < m_shape.size(); ++i)
-        {
-            m_size *= m_shape[i];
-        }
-        arrays = tbb::enumerable_thread_specific<ManagedArray<T> >([this]() { return ManagedArray<T>(m_shape); });
+        arrays = tbb::enumerable_thread_specific<ManagedArray<T> >([shape]() { return ManagedArray<T>(shape); });
     }
 
     //! Reset the contents of thread local arrays to be 0
@@ -100,8 +86,6 @@ public:
     }
 
 private:
-    unsigned int m_size;                       //!< size of thread local arrays
-    std::vector<unsigned int> m_shape;         //!< Shape of arrays.
     tbb::enumerable_thread_specific<ManagedArray<T> > arrays; //!< thread local arrays
 };
 

--- a/cpp/util/ThreadStorage.h
+++ b/cpp/util/ThreadStorage.h
@@ -2,6 +2,8 @@
 #define THREADSTORAGE_H
 
 #include <tbb/tbb.h>
+#include "ManagedArray.h"
+#include <vector>
 
 namespace freud { namespace util {
 
@@ -12,96 +14,95 @@ template<typename T> class ThreadStorage
 {
 public:
     //! Default constructor
-    ThreadStorage() : m_size(0), array(tbb::enumerable_thread_specific<T*>([]() { return nullptr; })) {}
+    ThreadStorage() : m_size(0), arrays(tbb::enumerable_thread_specific<ManagedArray<T> >([]() { return ManagedArray<T>(); })) {}
 
     //! Constructor with specific size for thread local arrays
     /*! \param size Size of the thread local arrays
      */
     ThreadStorage(unsigned int size)
-        : m_size(size),
-          array(tbb::enumerable_thread_specific<T*>([this]() { return makeNewEmptyArray(m_size); }))
-    {}
+        : ThreadStorage(std::vector<unsigned int> {size}) {}
+
+    //! Constructor with specific shape for thread local arrays
+    /*! \param shape Vector of sizes in each dimension of the thread local arrays
+     */
+    ThreadStorage(std::vector<unsigned int> shape)
+        : m_shape(shape),
+          arrays(tbb::enumerable_thread_specific<ManagedArray<T> >([this]() { return ManagedArray<T>(m_shape); }))
+    {
+        m_size = 1;
+        for (unsigned int i = 0; i < m_shape.size(); ++i)
+        {
+            m_size *= m_shape[i];
+        }
+    }
 
     //! Destructor
-    ~ThreadStorage()
-    {
-        deleteArray();
-    }
+    ~ThreadStorage() {}
 
     //! Update size of the thread local arrays
     /*! \param size New size of the thread local arrays
      */
     void resize(unsigned int size)
     {
-        if (size != m_size)
+        resize(std::vector<unsigned int> {size});
+    }
+
+    //! Update size of the thread local arrays
+    /*! \param size New size of the thread local arrays
+     */
+    void resize(std::vector<unsigned int> shape)
+    {
+        m_shape = shape;
+        m_size = 1;
+        for (unsigned int i = 0; i < m_shape.size(); ++i)
         {
-            m_size = size;
-            deleteArray();
-            array = tbb::enumerable_thread_specific<T*>([this]() { return makeNewEmptyArray(m_size); });
+            m_size *= m_shape[i];
         }
+        arrays = tbb::enumerable_thread_specific<ManagedArray<T> >([this]() { return ManagedArray<T>(m_shape); });
     }
 
     //! Reset the contents of thread local arrays to be 0
     void reset()
     {
-        for (auto i = array.begin(); i != array.end(); ++i)
+        for (auto array = arrays.begin(); array != arrays.end(); ++array)
         {
-            memset((void*) (*i), 0, sizeof(T) * m_size);
+            array->reset();
         }
     }
 
-    typedef typename tbb::enumerable_thread_specific<T*>::const_iterator const_iterator;
-    typedef typename tbb::enumerable_thread_specific<T*>::iterator iterator;
-    typedef typename tbb::enumerable_thread_specific<T*>::reference reference;
+    typedef typename tbb::enumerable_thread_specific<ManagedArray<T> >::const_iterator const_iterator;
+    typedef typename tbb::enumerable_thread_specific<ManagedArray<T> >::iterator iterator;
+    typedef typename tbb::enumerable_thread_specific<ManagedArray<T> >::reference reference;
 
     const_iterator begin() const
     {
-        return array.begin();
+        return arrays.begin();
     }
 
     iterator begin()
     {
-        return array.begin();
+        return arrays.begin();
     }
 
     const_iterator end() const
     {
-        return array.end();
+        return arrays.end();
     }
 
     iterator end()
     {
-        return array.end();
+        return arrays.end();
     }
 
     reference local()
     {
-        return array.local();
+        return arrays.local();
     }
 
 private:
-    //! Delete arrays
-    void deleteArray()
-    {
-        for (auto i = array.begin(); i != array.end(); ++i)
-        {
-            delete[](*i);
-            *i = nullptr;
-        }
-    }
-
-    //! Make new empty array
-    /*! \param size Size of the thread local arrays
-     */
-    T* makeNewEmptyArray(unsigned int size)
-    {
-        T* tmp = new T[size];
-        memset((void*) tmp, 0, sizeof(T) * size);
-        return tmp;
-    }
-
-    unsigned int m_size;                       //!< size of thread local array
-    tbb::enumerable_thread_specific<T*> array; //!< thread local array
+    unsigned int m_size;                       //!< size of thread local arrays
+    std::vector<unsigned int> m_shape;         //!< Shape of arrays.
+    tbb::enumerable_thread_specific<ManagedArray<T> > arrays; //!< thread local arrays
 };
 
 }; }; // end namespace freud::util


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Replace raw array with ManagedArray in ThreadStorage.

## Motivation and Context
While this isn't as important as it is for output arrays (which was what ManagedArray was create for re: #151), there are dual benefits to this change. Moving to a standard array representation _everywhere_ in freud helps us encapsulate that logic (especially to isolate any memory management to a single class), and making this change immediately allows the usage of the convenient indexing functions in ManagedArray when accessing ThreadStorage objects.

## How Has This Been Tested?
Existing tests pass.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds or improves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/glotzerlab/freud/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] I have updated the documentation (if relevant).
- [x] I have added tests that cover my changes (if relevant).
- [ ] All new and existing tests passed.
- [ ] I have updated the [Changelog](https://github.com/glotzerlab/freud/blob/master/ChangeLog.md).
