### PR TITLE
Fix/rdf defaults

### DIFF
--- a/cpp/density/RDF.cc
+++ b/cpp/density/RDF.cc
@@ -50,7 +50,7 @@ RDF::RDF(float r_max, float dr, float r_min) : util::NdHistogram(), m_r_max(r_ma
     {
         float r = float(i) * m_dr + m_r_min;
         float nextr = float(i + 1) * m_dr + m_r_min;
-        m_r_array.get()[i] = r + m_dr/2;
+        m_r_array.get()[i] = (r + nextr)/2;
         m_vol_array2D.get()[i] = M_PI * (nextr * nextr - r * r);
         m_vol_array3D.get()[i] = 4.0f / 3.0f * M_PI * (nextr * nextr * nextr - r * r * r);
     }

--- a/cpp/density/RDF.cc
+++ b/cpp/density/RDF.cc
@@ -106,15 +106,12 @@ void RDF::reduceRDF()
     memset((void*) m_avg_counts.get(), 0, sizeof(float) * m_nbins);
     // now compute the rdf
     float ndens = float(m_n_query_points) / m_box.getVolume();
-    m_pcf_array.get()[0] = 0.0f;
-    m_N_r_array.get()[0] = 0.0f;
-    m_N_r_array.get()[1] = 0.0f;
     if (m_box.is2D())
         m_vol_array = m_vol_array2D;
     else
         m_vol_array = m_vol_array3D;
     // now compute the rdf
-    parallel_for(blocked_range<size_t>(1, m_nbins), [=](const blocked_range<size_t>& r) {
+    parallel_for(blocked_range<size_t>(0, m_nbins), [=](const blocked_range<size_t>& r) {
         for (size_t i = r.begin(); i != r.end(); i++)
         {
             for (util::ThreadStorage<unsigned int>::const_iterator local_bins = m_local_bin_counts.begin();

--- a/cpp/density/RDF.cc
+++ b/cpp/density/RDF.cc
@@ -50,7 +50,7 @@ RDF::RDF(float r_max, float dr, float r_min) : util::NdHistogram(), m_r_max(r_ma
     {
         float r = float(i) * m_dr + m_r_min;
         float nextr = float(i + 1) * m_dr + m_r_min;
-        m_r_array.get()[i] = 2.0f / 3.0f * (nextr * nextr * nextr - r * r * r) / (nextr * nextr - r * r);
+        m_r_array.get()[i] = r + m_dr/2;
         m_vol_array2D.get()[i] = M_PI * (nextr * nextr - r * r);
         m_vol_array3D.get()[i] = 4.0f / 3.0f * M_PI * (nextr * nextr * nextr - r * r * r);
     }

--- a/cpp/density/RDF.h
+++ b/cpp/density/RDF.h
@@ -55,7 +55,11 @@ public:
     //! Get a reference to the r array
     std::shared_ptr<float> getR();
 
-    //! Get a reference to the N_r array
+    //! Get a reference to the N_r array.
+    /*! Mathematically, m_N_r_array[i] is the average number of points
+     * contained within a ball of radius m_r_array[i]+dr/2 centered at a given
+     * query_point, averaged over all query_points.
+     */
     std::shared_ptr<float> getNr()
     {
         return reduceAndReturn(m_N_r_array);

--- a/freud/density.pyx
+++ b/freud/density.pyx
@@ -758,7 +758,11 @@ cdef class RDF(SpatialHistogram):
         R ((:math:`N_{bins}`) :class:`numpy.ndarray`):
             The centers of each bin.
         n_r ((:math:`N_{bins}`,) :class:`numpy.ndarray`):
-            Histogram of cumulative RDF values (*i.e.* the integrated RDF).
+            Histogram of cumulative bin_counts values. More precisely,
+            :code:`n_r[i]` is the average number of points contained within a
+            ball of radius :code:`R[i]+dr/2` centered at a given
+            :code:`query_point` averaged over all :code:`query_points` in the
+            last call to :meth:`~.compute` (or :meth:`~.accumulate`).
     """
     cdef freud._density.RDF * thisptr
     cdef dr

--- a/tests/test_density_RDF.py
+++ b/tests/test_density_RDF.py
@@ -84,8 +84,6 @@ class TestRDF(unittest.TestCase):
         for i, r_min in enumerate([0, 0.05, 0.1, 1.0, 3.0]):
             nbins = int((r_max - r_min) / dr)
             box, points = util.make_box_and_random_points(box_size, num_points)
-            points.flags['WRITEABLE'] = False
-            box = freud.box.Box.cube(box_size)
             test_set = util.make_raw_query_nlist_test_set(
                 box, points, points, "ball", r_max, 0, True)
             for ts in test_set:
@@ -104,8 +102,8 @@ class TestRDF(unittest.TestCase):
                 # a limited precision. Also, since dealing with nonzero r_min
                 # values requires extrapolation, we only test when r_min=0.
                 ndens = points.shape[0]/box.volume
-                bin_boundaries = np.linspace(r_min, r_max,
-                                             int((r_max-r_min)/dr)+1)
+                bin_boundaries = np.array([r_min + dr*i for i in range(nbins+1)
+                                           if r_min + dr*i <= r_max])
                 bin_volumes = 4/3*np.pi*np.diff(bin_boundaries**3)
                 avg_counts = rdf.RDF*ndens*bin_volumes
                 npt.assert_allclose(rdf.n_r, np.cumsum(avg_counts),

--- a/tests/test_density_RDF.py
+++ b/tests/test_density_RDF.py
@@ -81,9 +81,6 @@ class TestRDF(unittest.TestCase):
         tolerance = 0.1
         box_size = r_max*3.1
 
-        def ig_sphere(x, y, j):
-            return 4/3*np.pi*np.trapz(y[:j]*(x[:j]+dr/2)**2, x[:j])
-
         for i, r_min in enumerate([0, 0.05, 0.1, 1.0, 3.0]):
             nbins = int((r_max - r_min) / dr)
             box, points = util.make_box_and_random_points(box_size, num_points)
@@ -100,19 +97,19 @@ class TestRDF(unittest.TestCase):
                     rdf.compute(box, ts[0], nlist=ts[1])
                 self.assertTrue(rdf.box == box)
                 correct = np.ones(nbins, dtype=np.float32)
-                correct[0] = 0.0
                 npt.assert_allclose(rdf.RDF, correct, atol=tolerance)
 
                 # Numerical integration to compute the running coordination
                 # number will be highly inaccurate, so we can only test up to
                 # a limited precision. Also, since dealing with nonzero r_min
                 # values requires extrapolation, we only test when r_min=0.
-                if r_min == 0:
-                    correct_cumulative = np.array(
-                        [ig_sphere(rdf.R, rdf.RDF, j)
-                            for j in range(1, nbins+1)])
-                    npt.assert_allclose(rdf.n_r, correct_cumulative,
-                                        rtol=tolerance*5)
+                ndens = points.shape[0]/box.volume
+                bin_boundaries = np.linspace(r_min, r_max,
+                                             int((r_max-r_min)/dr)+1)
+                bin_volumes = 4/3*np.pi*np.diff(bin_boundaries**3)
+                avg_counts = rdf.RDF*ndens*bin_volumes
+                npt.assert_allclose(rdf.n_r, np.cumsum(avg_counts),
+                                    rtol=tolerance)
 
     def test_repr(self):
         rdf = freud.density.RDF(10, 0.1, r_min=0.5)
@@ -156,7 +153,7 @@ class TestRDF(unittest.TestCase):
                 query_points.append([r * np.cos(2*np.pi*k/N),
                                      r * np.sin(2*np.pi*k/N), 0])
             supposed_RDF.append(supposed_RDF[-1] + N)
-        supposed_RDF = np.array(supposed_RDF[:-1])
+        supposed_RDF = np.array(supposed_RDF[1:])
 
         test_set = util.make_raw_query_nlist_test_set(
             box, points, query_points, "ball", r_max, 0, False)

--- a/tests/test_density_RDF.py
+++ b/tests/test_density_RDF.py
@@ -15,11 +15,8 @@ class TestRDF(unittest.TestCase):
             nbins = int((r_max - r_min) / dr)
 
             # make sure the radius for each bin is generated correctly
-            r_list = np.zeros(nbins, dtype=np.float32)
-            for i in range(nbins):
-                r1 = i * dr + r_min
-                r2 = r1 + dr
-                r_list[i] = 2.0/3.0 * (r2**3.0 - r1**3.0) / (r2**2.0 - r1**2.0)
+            r_list = np.array([r_min + dr*(i+1/2) for i in range(nbins) if
+                               r_min + dr*(i+1/2) < r_max])
             rdf = freud.density.RDF(r_max, dr, r_min=r_min)
             npt.assert_allclose(rdf.R, r_list, rtol=1e-4, atol=1e-4)
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR removes some of the odd choices built into the RDF class.

## Motivation and Context
The use of off-center "bin centers" is not well motivated and not worth keeping. Neither is the automatic zeroing out of the initial bin of the RDF, or the first two cumulative bins. There is some question of the convention used for the cumulative count (whether or not the zeroth bin should be empty), but since we're taking discrete sums and not integrating it makes much more sense to have a nonempty zero bin and have the final bin actually be the total.

This PR is still a draft because there is one other change I want to investigate before finalizing. I also need to update the documentation for the cumulative counts.

## How Has This Been Tested?
Existing tests were tailored to the current output, which in hindsight is probably unexpected. I've updated tests to account for the new behaviors.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds or improves functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/glotzerlab/freud/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] I have updated the documentation (if relevant).
- [x] I have added tests that cover my changes (if relevant).
- [x] All new and existing tests passed.
- [ ] I have updated the [Changelog](https://github.com/glotzerlab/freud/blob/master/ChangeLog.md).
