### PR TITLE
Fix/linkcell issue pr409

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -22,6 +22,7 @@ Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to
 ### Fixed
 * Steinhardt uses the ThreadStorage class and properly resets memory where needed.
 * Removed all neighbor exclusion logic from all classes, depends entirely on locality module now.
+* LinkCell nearest neighbor queries properly check the largest distance found before proceeding to next shell.
 
 ### Removed
 * The freud.util module.

--- a/cpp/locality/LinkCell.cc
+++ b/cpp/locality/LinkCell.cc
@@ -404,11 +404,11 @@ NeighborBond LinkCellQueryIterator::next()
             // We can terminate early if we determine when we reach a shell
             // such that we already have k neighbors closer than the
             // closest possible neighbor in the new shell.
+            std::sort(m_current_neighbors.begin(), m_current_neighbors.end());
             if ((m_current_neighbors.size() >= m_num_neighbors)
                 && (m_current_neighbors[m_num_neighbors - 1].distance
                     < (m_neigh_cell_iter.getRange() - 1) * m_linkcell->getCellWidth()))
             {
-                std::sort(m_current_neighbors.begin(), m_current_neighbors.end());
                 break;
             }
         }

--- a/tests/test_locality_NeighborQuery.py
+++ b/tests/test_locality_NeighborQuery.py
@@ -586,9 +586,7 @@ class TestAlternatingPoints(unittest.TestCase):
         lattice_size = 10
         # big box to ignore periodicity
         box = freud.box.Box.square(lattice_size*5)
-        angle = 0
-        query_points, points = util.make_alternating_lattice(
-            lattice_size, angle)
+        query_points, points = util.make_alternating_lattice(lattice_size)
         r_max = 1.6
         num_neighbors = 12
 
@@ -596,40 +594,11 @@ class TestAlternatingPoints(unittest.TestCase):
             box, points, query_points, "nearest", r_max, num_neighbors, False)
         nlist = test_set[-1][1]
         for ts in test_set:
-            print()
-            if not isinstance(ts[0], freud.locality.NeighborQuery) and \
-                    not isinstance(ts[1], freud.locality.NeighborList):
-                print('skipping', [type(t).__name__ for t in ts])
+            if not isinstance(ts[0], freud.locality.NeighborQuery):
                 continue
-            if ts[1] is not None:
-                print('checking nlist')
-                check_nlist = ts[1]
-            else:
-                print('checking query')
-                check_nlist = ts[0].query(
-                    query_points, query_args=ts[2]).toNeighborList()
-            worked = True
-            for bond in check_nlist:
-                try:
-                    assert bond.tolist() in nlist[:].tolist()
-                except AssertionError:
-                    worked = False
-                    print('bond', bond, 'is in check_nlist but not nlist')
-            if not worked:
-                print()
-            for bond in nlist:
-                try:
-                    assert bond.tolist() in check_nlist[:].tolist()
-                except AssertionError:
-                    worked = False
-                    print('bond', bond, 'is in nlist but not check_nlist')
-            if not worked:
-                print()
-            if worked:
-                print('worked for', [type(t).__name__ for t in ts])
-            else:
-                print('failed for', [type(t).__name__ for t in ts])
-                raise AssertionError
+            check_nlist = ts[0].query(
+                query_points, query_args=ts[2]).toNeighborList()
+            self.assertTrue(nlist_equal(nlist, check_nlist))
 
 
 if __name__ == '__main__':

--- a/tests/test_locality_NeighborQuery.py
+++ b/tests/test_locality_NeighborQuery.py
@@ -6,7 +6,7 @@ import itertools
 import unittest
 import sys
 
-from util import make_box_and_random_points
+import util
 
 """
 Define helper functions for getting the neighbors of a point. Note that
@@ -182,7 +182,7 @@ class TestNeighborQuery(object):
         L = 10  # Box Dimensions
         N = 400  # number of particles
 
-        box, ref_points = make_box_and_random_points(L, N, seed=0)
+        box, ref_points = util.make_box_and_random_points(L, N, seed=0)
         points = np.random.rand(N, 3) * L
 
         nq = self.build_query_object(box, ref_points, L/10)
@@ -200,8 +200,8 @@ class TestNeighborQuery(object):
         L = 10  # Box Dimensions
         N = 400  # number of particles
 
-        box, ref_points = make_box_and_random_points(L, N, seed=0)
-        _, points = make_box_and_random_points(L, N, seed=1)
+        box, ref_points = util.make_box_and_random_points(L, N, seed=0)
+        _, points = util.make_box_and_random_points(L, N, seed=1)
 
         nq = self.build_query_object(box, ref_points, L/10)
 
@@ -217,7 +217,7 @@ class TestNeighborQuery(object):
         pair there also exists a (j, i) neighbor pair for one set of points"""
         L, r_max, N = (10, 2.01, 1024)
 
-        box, points = make_box_and_random_points(L, N, seed=0)
+        box, points = util.make_box_and_random_points(L, N, seed=0)
         nq = self.build_query_object(box, points, r_max)
         result = list(nq.query(points, dict(mode='ball', r_max=r_max)))
 
@@ -233,8 +233,8 @@ class TestNeighborQuery(object):
         """
         L, r_max, N = (10, 2.01, 1024)
 
-        box, points = make_box_and_random_points(L, N, seed=0)
-        _, points2 = make_box_and_random_points(L, N//6, seed=1)
+        box, points = util.make_box_and_random_points(L, N, seed=0)
+        _, points2 = util.make_box_and_random_points(L, N//6, seed=1)
         nq = self.build_query_object(box, points, r_max)
         nq2 = self.build_query_object(box, points2, r_max)
 
@@ -249,7 +249,7 @@ class TestNeighborQuery(object):
     def test_exclude_ii(self):
         L, r_max, N = (10, 2.01, 1024)
 
-        box, points = make_box_and_random_points(L, N)
+        box, points = util.make_box_and_random_points(L, N)
         points2 = points[:N//6]
         nq = self.build_query_object(box, points, r_max)
         result = list(nq.query(points2, dict(mode='ball', r_max=r_max)))
@@ -274,7 +274,7 @@ class TestNeighborQuery(object):
         seed = 0
 
         for i in range(10):
-            _, points = make_box_and_random_points(L, N, seed=seed+i)
+            _, points = util.make_box_and_random_points(L, N, seed=seed+i)
             all_vectors = points[:, np.newaxis, :] - points[np.newaxis, :, :]
             box.wrap(all_vectors.reshape((-1, 3)))
             all_rsqs = np.sum(all_vectors**2, axis=-1)
@@ -485,7 +485,7 @@ class TestNeighborQueryAABB(TestNeighborQuery, unittest.TestCase):
         N = 500
         L = 10
         r_max = 1
-        box, points = make_box_and_random_points(L, N)
+        box, points = util.make_box_and_random_points(L, N)
         nlist1 = freud.locality.AABBQuery(box, points).query(
             points, dict(r_max=r_max, exclude_ii=True)).toNeighborList()
         abq = freud.locality.AABBQuery(box, points)
@@ -505,7 +505,7 @@ class TestNeighborQueryLinkCell(TestNeighborQuery, unittest.TestCase):
         N = 500
         L = 10
         r_max = 1
-        box, points = make_box_and_random_points(L, N)
+        box, points = util.make_box_and_random_points(L, N)
         nlist1 = freud.locality.LinkCell(box, 1.0, points).query(
             points, dict(r_max=r_max, exclude_ii=True)).toNeighborList()
         lc = freud.locality.LinkCell(box, 1.0, points)
@@ -566,7 +566,7 @@ class TestNeighborQueryLinkCell(TestNeighborQuery, unittest.TestCase):
         N = 40  # number of particles
 
         # Initialize test points randomly
-        fbox, points = make_box_and_random_points(L, N)
+        fbox, points = util.make_box_and_random_points(L, N)
         cl = freud.locality.LinkCell(fbox, r_max, points)
 
         neighbors_ij = set()
@@ -578,6 +578,58 @@ class TestNeighborQueryLinkCell(TestNeighborQuery, unittest.TestCase):
         neighbors_ji = set((j, i) for (i, j) in neighbors_ij)
         # if i is a neighbor of j, then j should be a neighbor of i
         self.assertEqual(neighbors_ij, neighbors_ji)
+
+
+class TestAlternatingPoints(unittest.TestCase):
+
+    def test_alternating_points(self):
+        lattice_size = 10
+        # big box to ignore periodicity
+        box = freud.box.Box.square(lattice_size*5)
+        angle = 0
+        query_points, points = util.make_alternating_lattice(
+            lattice_size, angle)
+        r_max = 1.6
+        num_neighbors = 12
+
+        test_set = util.make_raw_query_nlist_test_set(
+            box, points, query_points, "nearest", r_max, num_neighbors, False)
+        nlist = test_set[-1][1]
+        for ts in test_set:
+            print()
+            if not isinstance(ts[0], freud.locality.NeighborQuery) and \
+                    not isinstance(ts[1], freud.locality.NeighborList):
+                print('skipping', [type(t).__name__ for t in ts])
+                continue
+            if ts[1] is not None:
+                print('checking nlist')
+                check_nlist = ts[1]
+            else:
+                print('checking query')
+                check_nlist = ts[0].query(
+                    query_points, query_args=ts[2]).toNeighborList()
+            worked = True
+            for bond in check_nlist:
+                try:
+                    assert bond.tolist() in nlist[:].tolist()
+                except AssertionError:
+                    worked = False
+                    print('bond', bond, 'is in check_nlist but not nlist')
+            if not worked:
+                print()
+            for bond in nlist:
+                try:
+                    assert bond.tolist() in check_nlist[:].tolist()
+                except AssertionError:
+                    worked = False
+                    print('bond', bond, 'is in nlist but not check_nlist')
+            if not worked:
+                print()
+            if worked:
+                print('worked for', [type(t).__name__ for t in ts])
+            else:
+                print('failed for', [type(t).__name__ for t in ts])
+                raise AssertionError
 
 
 if __name__ == '__main__':

--- a/tests/util.py
+++ b/tests/util.py
@@ -2,20 +2,54 @@ import numpy as np
 import freud
 
 
-def make_raw_query_nlist_test_set(box, ref_points, points, mode, r_max,
+def make_raw_query_nlist_test_set(box, points, query_points, mode, r_max,
                                   num_neighbors, exclude_ii):
+    """Helper function to test multiple neighbor-finding data structures.
+
+    .. moduleauthor:: Jin Soo Ihm <jinihm@umich.edu>
+    .. moduleauthor:: Bradley Dice <bdice@bradleydice.com>
+
+    Args:
+        box (:class:`freud.box.Box`):
+            Simulation box.
+        points ((:math:`N_{points}`, 3) :class:`numpy.ndarray`):
+            Reference points used to calculate the correlation function.
+        query_points ((:math:`N_{query_points}`, 3) :class:`numpy.ndarray`, optional):
+            query_points used to calculate the correlation function.
+            Uses :code:`points` if not provided or :code:`None`.
+            (Default value = :code:`None`).
+        mode (str):
+            String indicating query mode.
+        r_max (float):
+            Maximum cutoff distance.
+        num_neighbors (int):
+            Number of nearest neighbors to include.
+        exclude_ii (bool):
+            Whether to exclude self-neighbors.
+
+    Returns:
+        tuple:
+            Contains points or :class:`freud.locality.NeighborQuery`,
+            :class:`freud.locality.NeighborList` or :code:`None`,
+            query_args :class:`dict` or :code:`None`.
+    """  # noqa: E501
     test_set = []
-    test_set.append((ref_points, None))
-    test_set.append((freud.locality.RawPoints(box, ref_points), None))
-    test_set.append((freud.locality.AABBQuery(box, ref_points), None))
-    # test_set.append((freud.locality.LinkCell(box, r_max, ref_points), None))
+    query_args = {'mode': mode, 'r_max': r_max, 'exclude_ii': exclude_ii}
+    if mode == 'nearest':
+        query_args['num_neighbors'] = num_neighbors
+
+    test_set.append((points, None, query_args))
+    test_set.append((freud.locality.RawPoints(box, points), None, query_args))
+    test_set.append((freud.locality.AABBQuery(box, points), None, query_args))
+    test_set.append(
+        (freud.locality.LinkCell(box, r_max, points), None, query_args))
     if mode == "ball":
         nlist = freud.locality.make_default_nlist(
-            box, ref_points, points, r_max, None, exclude_ii)
+            box, points, query_points, r_max, None, exclude_ii)
     if mode == "nearest":
         nlist = freud.locality.make_default_nlist_nn(
-            box, ref_points, points, num_neighbors, None, exclude_ii, r_max)
-    test_set.append((ref_points, nlist[0], nlist[1]))
+            box, points, query_points, num_neighbors, None, exclude_ii, r_max)
+    test_set.append((points, nlist[0], None, nlist[1]))
     return test_set
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Make sure LinkCell::query sorts the neighbors before deciding how many sufficiently close points have been found.

## Motivation and Context
Fixes the bug found in #409.

## How Has This Been Tested?
Added the test from #409 and it now passes.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds or improves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/glotzerlab/freud/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] I have updated the documentation (if relevant).
- [x] I have added tests that cover my changes (if relevant).
- [x] All new and existing tests passed.
- [x] I have updated the [Changelog](https://github.com/glotzerlab/freud/blob/master/ChangeLog.md).
