### PR TITLE
Make tests work for pytest

### DIFF
--- a/tests/test_locality_NeighborQuery.py
+++ b/tests/test_locality_NeighborQuery.py
@@ -28,7 +28,7 @@ def nlist_equal(nlist1, nlist2):
     return set((i, j) for i, j in nlist1) == set((i, j) for i, j in nlist2)
 
 
-class TestNeighborQuery(object):
+class NeighborQueryTest(object):
     @classmethod
     def build_query_object(cls, box, ref_points, r_max=None):
         raise RuntimeError(
@@ -466,7 +466,7 @@ class TestNeighborQuery(object):
         self.assertEqual(len(list(q)), 3)
 
 
-class TestNeighborQueryAABB(TestNeighborQuery, unittest.TestCase):
+class TestNeighborQueryAABB(NeighborQueryTest, unittest.TestCase):
     @classmethod
     def build_query_object(cls, box, ref_points, r_max=None):
         return freud.locality.AABBQuery(box, ref_points)
@@ -494,7 +494,7 @@ class TestNeighborQueryAABB(TestNeighborQuery, unittest.TestCase):
         self.assertTrue(nlist_equal(nlist1, nlist2))
 
 
-class TestNeighborQueryLinkCell(TestNeighborQuery, unittest.TestCase):
+class TestNeighborQueryLinkCell(NeighborQueryTest, unittest.TestCase):
     @classmethod
     def build_query_object(cls, box, ref_points, r_max=None):
         if r_max is None:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Allows pytest to work with our existing test suite.

## Motivation and Context
The only current incompatibility with pytest is that it automatically assumes all classes starting with `Test` are unit tests, and I was previously using a parent class for `NeighborQuery` testing that was called `TestNeighborQuery` and inherited from by specific `LinkCell` and `AABBQuery` test classes. Renaming that class solves the issue and allows pytest to run successfully. 

## How Has This Been Tested?
Existing tests pass when run with `pytest` in the project root (after an in-place build, would also work in the test directory after installing).

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds or improves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/glotzerlab/freud/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] I have updated the documentation (if relevant).
- [x] I have added tests that cover my changes (if relevant).
- [x] All new and existing tests passed.
- [x] I have updated the [Changelog](https://github.com/glotzerlab/freud/blob/master/ChangeLog.md).
