### PR TITLE
Fix: initialize m_segments_counts_updated to false.

### DIFF
--- a/cpp/locality/NeighborList.cc
+++ b/cpp/locality/NeighborList.cc
@@ -6,19 +6,21 @@
 namespace freud { namespace locality {
 
 NeighborList::NeighborList()
-    : m_num_query_points(0), m_num_points(0), m_neighbors({0, 2})
+    : m_num_query_points(0), m_num_points(0), m_neighbors({0, 2}),
+    m_distances({0}), m_weights({0}), m_segments_counts_updated(false)
 {
 }
 
 NeighborList::NeighborList(unsigned int num_bonds)
     : m_num_query_points(0), m_num_points(0), m_neighbors({num_bonds, 2}),
-    m_distances({num_bonds}), m_weights({num_bonds})
+    m_distances({num_bonds}), m_weights({num_bonds}), m_segments_counts_updated(false)
 {
 }
 
 NeighborList::NeighborList(const NeighborList& other)
     : m_num_query_points(other.m_num_query_points), m_num_points(other.m_num_points),
-    m_neighbors(other.m_neighbors), m_distances(other.m_distances), m_weights(other.m_weights)
+    m_neighbors(other.m_neighbors), m_distances(other.m_distances),
+    m_weights(other.m_weights), m_segments_counts_updated(false)
 {
 }
 
@@ -26,7 +28,8 @@ NeighborList::NeighborList(unsigned int num_bonds, const unsigned int* query_poi
                  unsigned int num_query_points, const unsigned int* point_index,
                  unsigned int num_points, const float* distances, const float* weights)
     : m_num_query_points(num_query_points), m_num_points(num_points),
-    m_neighbors({num_bonds, 2}), m_distances({num_bonds}), m_weights({num_bonds})
+    m_neighbors({num_bonds, 2}), m_distances({num_bonds}),
+    m_weights({num_bonds}), m_segments_counts_updated(false)
 {
     unsigned int last_index(0);
     unsigned int index(0);
@@ -176,6 +179,7 @@ void NeighborList::copy(const NeighborList& other)
     m_neighbors = other.m_neighbors;
     m_weights = other.m_weights;
     m_distances = other.m_distances;
+    m_segments_counts_updated = false;
 }
 
 void NeighborList::validate(unsigned int num_query_points, unsigned int num_points) const


### PR DESCRIPTION
## Description
Fixes test failures in new `NeighborList` class.

## Motivation and Context
The variable `bool m_segments_counts_updated` wasn't being initialized to `false`. I didn't realize that member variables of primitive types had to be initialized, and I thought it was being set to `false` automatically when the `NeighborList` class was constructed. See also: https://stackoverflow.com/questions/4622225/boolean-variables-arent-always-false-by-default

## How Has This Been Tested?
I ran the previously failing test locally several times and it works now.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds or improves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have read the [**CONTRIBUTING**](https://github.com/glotzerlab/freud/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] I have updated the documentation (if relevant).
- [x] I have added tests that cover my changes (if relevant).
- [x] All new and existing tests passed.
- [x] I have updated the [Changelog](https://github.com/glotzerlab/freud/blob/master/ChangeLog.md).
