### PR TITLE
Use ManagedArray in ParticleBuffer

### DIFF
--- a/cpp/box/ParticleBuffer.cc
+++ b/cpp/box/ParticleBuffer.cc
@@ -1,12 +1,8 @@
 // Copyright (c) 2010-2019 The Regents of the University of Michigan
 // This file is from the freud project, released under the BSD 3-Clause License.
 
-#include <cassert>
-#include <memory>
 #include <stdexcept>
-#include <vector>
 
-#include "ManagedArray.h"
 #include "ParticleBuffer.h"
 
 using namespace std;
@@ -28,9 +24,6 @@ void ParticleBuffer::compute(const vec3<float>* points, const unsigned int Np, c
         throw invalid_argument("Buffer y distance must be non-negative.");
     if (buff.z < 0)
         throw invalid_argument("Buffer z distance must be non-negative.");
-
-    vector<vec3<float>> buffer_parts;
-    vector<unsigned int> buffer_ids;
 
     // Get the box dimensions
     vec3<float> L(m_box.getL());
@@ -60,8 +53,8 @@ void ParticleBuffer::compute(const vec3<float>* points, const unsigned int Np, c
         images.z = 0;
     }
 
-    buffer_parts.clear();
-    buffer_ids.clear();
+    m_buffer_particles.clear();
+    m_buffer_ids.clear();
 
     // for each particle
     for (unsigned int particle = 0; particle < Np; particle++)
@@ -96,8 +89,8 @@ void ParticleBuffer::compute(const vec3<float>* points, const unsigned int Np, c
                         // have the correct number of particles instead of
                         // relying on the floating point precision of the
                         // fractional check below.
-                        buffer_parts.push_back(m_buffer_box.wrap(particle_image));
-                        buffer_ids.push_back(particle);
+                        m_buffer_particles.push_back(m_buffer_box.wrap(particle_image));
+                        m_buffer_ids.push_back(particle);
                     }
                     else
                     {
@@ -109,23 +102,13 @@ void ParticleBuffer::compute(const vec3<float>* points, const unsigned int Np, c
                         if (0 <= buff_frac.x && buff_frac.x < 1 && 0 <= buff_frac.y && buff_frac.y < 1
                             && (is2D || (0 <= buff_frac.z && buff_frac.z < 1)))
                         {
-                            buffer_parts.push_back(particle_image);
-                            buffer_ids.push_back(particle);
+                            m_buffer_particles.push_back(particle_image);
+                            m_buffer_ids.push_back(particle);
                         }
                     }
                 }
             }
         }
-    }
-
-    // Copy the vectors into ManagedArrays
-    unsigned int buffer_size(buffer_parts.size());
-    m_buffer_particles.prepare(buffer_size);
-    m_buffer_ids.prepare(buffer_size);
-    for (unsigned int i = 0; i < buffer_size; i++)
-    {
-        m_buffer_particles[i] = buffer_parts[i];
-        m_buffer_ids[i] = buffer_ids[i];
     }
 }
 

--- a/cpp/box/ParticleBuffer.cc
+++ b/cpp/box/ParticleBuffer.cc
@@ -6,6 +6,7 @@
 #include <stdexcept>
 #include <vector>
 
+#include "ManagedArray.h"
 #include "ParticleBuffer.h"
 
 using namespace std;
@@ -28,10 +29,8 @@ void ParticleBuffer::compute(const vec3<float>* points, const unsigned int Np, c
     if (buff.z < 0)
         throw invalid_argument("Buffer z distance must be non-negative.");
 
-    m_buffer_particles = std::shared_ptr<std::vector<vec3<float>>>(new std::vector<vec3<float>>());
-    m_buffer_ids = std::shared_ptr<std::vector<unsigned int>>(new std::vector<unsigned int>());
-    std::vector<vec3<float>>& buffer_parts = *m_buffer_particles;
-    std::vector<unsigned int>& buffer_ids = *m_buffer_ids;
+    vector<vec3<float>> buffer_parts;
+    vector<unsigned int> buffer_ids;
 
     // Get the box dimensions
     vec3<float> L(m_box.getL());
@@ -117,6 +116,16 @@ void ParticleBuffer::compute(const vec3<float>* points, const unsigned int Np, c
                 }
             }
         }
+    }
+
+    // Copy the vectors into ManagedArrays
+    unsigned int buffer_size(buffer_parts.size());
+    m_buffer_particles.prepare(buffer_size);
+    m_buffer_ids.prepare(buffer_size);
+    for (unsigned int i = 0; i < buffer_size; i++)
+    {
+        m_buffer_particles[i] = buffer_parts[i];
+        m_buffer_ids[i] = buffer_ids[i];
     }
 }
 

--- a/cpp/box/ParticleBuffer.h
+++ b/cpp/box/ParticleBuffer.h
@@ -39,12 +39,12 @@ public:
     void compute(const vec3<float>* points, const unsigned int Np, const vec3<float> buff,
                  const bool use_images);
 
-    std::shared_ptr<std::vector<vec3<float>>> getBufferParticles()
+    util::ManagedArray<vec3<float>> &getBufferParticles()
     {
         return m_buffer_particles;
     }
 
-    std::shared_ptr<std::vector<unsigned int>> getBufferIds()
+    util::ManagedArray<unsigned int> &getBufferIds()
     {
         return m_buffer_ids;
     }
@@ -52,8 +52,8 @@ public:
 private:
     const Box m_box;  //!< Simulation box of the original particles
     Box m_buffer_box; //!< Simulation box of the replicated particles
-    std::shared_ptr<std::vector<vec3<float>>> m_buffer_particles;
-    std::shared_ptr<std::vector<unsigned int>> m_buffer_ids;
+    util::ManagedArray<vec3<float>> m_buffer_particles;
+    util::ManagedArray<unsigned int> m_buffer_ids;
 };
 
 }; }; // end namespace freud::box

--- a/cpp/box/ParticleBuffer.h
+++ b/cpp/box/ParticleBuffer.h
@@ -8,7 +8,6 @@
 #include <vector>
 
 #include "Box.h"
-#include "Index1D.h"
 #include "VectorMath.h"
 
 /*! \file ParticleBuffer.h
@@ -39,12 +38,12 @@ public:
     void compute(const vec3<float>* points, const unsigned int Np, const vec3<float> buff,
                  const bool use_images);
 
-    util::ManagedArray<vec3<float>> &getBufferParticles()
+    std::vector<vec3<float> > getBufferParticles()
     {
         return m_buffer_particles;
     }
 
-    util::ManagedArray<unsigned int> &getBufferIds()
+    std::vector<unsigned int> getBufferIds()
     {
         return m_buffer_ids;
     }
@@ -52,8 +51,8 @@ public:
 private:
     const Box m_box;  //!< Simulation box of the original particles
     Box m_buffer_box; //!< Simulation box of the replicated particles
-    util::ManagedArray<vec3<float>> m_buffer_particles;
-    util::ManagedArray<unsigned int> m_buffer_ids;
+    std::vector<vec3<float> > m_buffer_particles;
+    std::vector<unsigned int> m_buffer_ids;
 };
 
 }; }; // end namespace freud::box

--- a/freud/_box.pxd
+++ b/freud/_box.pxd
@@ -6,6 +6,7 @@ from libcpp cimport bool as bool_t
 from freud.util cimport vec3
 from libcpp.vector cimport vector
 from libcpp.string cimport string
+cimport freud.util
 
 ctypedef unsigned int uint
 
@@ -62,5 +63,5 @@ cdef extern from "ParticleBuffer.h" namespace "freud::box":
             const unsigned int,
             const vec3[float],
             const bool_t) except +
-        shared_ptr[vector[vec3[float]]] getBufferParticles()
-        shared_ptr[vector[uint]] getBufferIds()
+        const freud.util.ManagedArray[vec3[float]] &getBufferParticles()
+        const freud.util.ManagedArray[uint] &getBufferIds()

--- a/freud/_box.pxd
+++ b/freud/_box.pxd
@@ -2,11 +2,11 @@
 # This file is from the freud project, released under the BSD 3-Clause License.
 
 from libcpp.memory cimport shared_ptr
+from libcpp.vector cimport vector
 from libcpp cimport bool as bool_t
 from freud.util cimport vec3
 from libcpp.vector cimport vector
 from libcpp.string cimport string
-cimport freud.util
 
 ctypedef unsigned int uint
 
@@ -63,5 +63,5 @@ cdef extern from "ParticleBuffer.h" namespace "freud::box":
             const unsigned int,
             const vec3[float],
             const bool_t) except +
-        const freud.util.ManagedArray[vec3[float]] &getBufferParticles()
-        const freud.util.ManagedArray[uint] &getBufferIds()
+        vector[vec3[float]] getBufferParticles()
+        vector[uint] getBufferIds()

--- a/freud/box.pyx
+++ b/freud/box.pyx
@@ -705,15 +705,12 @@ cdef class ParticleBuffer:
 
     @property
     def buffer_particles(self):
-        return freud.util.make_managed_numpy_array(
-            &self.thisptr.getBufferParticles(),
-            freud.util.arr_type_t.FLOAT, element_size=3)
+        particles = self.thisptr.getBufferParticles()
+        return np.asarray([[p.x, p.y, p.z] for p in particles])
 
     @property
     def buffer_ids(self):
-        return freud.util.make_managed_numpy_array(
-            &self.thisptr.getBufferIds(),
-            freud.util.arr_type_t.UNSIGNED_INT)
+        return np.asarray(self.thisptr.getBufferIds())
 
     @property
     def buffer_box(self):

--- a/freud/box.pyx
+++ b/freud/box.pyx
@@ -705,25 +705,15 @@ cdef class ParticleBuffer:
 
     @property
     def buffer_particles(self):
-        cdef unsigned int buffer_size = \
-            dereference(self.thisptr.getBufferParticles().get()).size()
-        if not buffer_size:
-            return np.empty(shape=(0, 3), dtype=np.float32)
-        cdef const float[:, ::1] buffer_particles = \
-            <float[:buffer_size, :3]> (<float*> dereference(
-                self.thisptr.getBufferParticles().get()).data())
-        return np.asarray(buffer_particles)
+        return freud.util.make_managed_numpy_array(
+            &self.thisptr.getBufferParticles(),
+            freud.util.arr_type_t.FLOAT, element_size=3)
 
     @property
     def buffer_ids(self):
-        cdef unsigned int buffer_size = \
-            dereference(self.thisptr.getBufferParticles().get()).size()
-        if not buffer_size:
-            return np.empty(shape=(0,), dtype=np.uint32)
-        cdef const unsigned int[::1] buffer_ids = \
-            <unsigned int[:buffer_size]> dereference(
-                self.thisptr.getBufferIds().get()).data()
-        return np.asarray(buffer_ids)
+        return freud.util.make_managed_numpy_array(
+            &self.thisptr.getBufferIds(),
+            freud.util.arr_type_t.UNSIGNED_INT)
 
     @property
     def buffer_box(self):

--- a/freud/locality.pyx
+++ b/freud/locality.pyx
@@ -986,6 +986,10 @@ cdef class _Voronoi:
         if box.is2D():
             expanded_points = expanded_points[:, :2]
 
+        expanded_points = freud.common.convert_array(
+            np.atleast_2d(expanded_points),
+            shape=(None, 2 if box.is2D() else 3))
+
         # Use qhull to get the points
         return qvoronoi(expanded_points), expanded_ids, expanded_points
 


### PR DESCRIPTION
## Description
Switched ParticleBuffer to use ManagedArrays.

## Motivation and Context
More ManagedArray conversions.

## How Has This Been Tested?
Existing tests pass.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds or improves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have read the [**CONTRIBUTING**](https://github.com/glotzerlab/freud/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] I have updated the documentation (if relevant).
- [x] I have added tests that cover my changes (if relevant).
- [x] All new and existing tests passed.
- [ ] I have updated the [Changelog](https://github.com/glotzerlab/freud/blob/master/ChangeLog.md).
