### PR TITLE
Enable Steinhardt l=0,1

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -15,6 +15,7 @@ and this project adheres to
 * Upper bound r\_max option for number of neighbors queries.
 * C++ Histogram class to standardize n-dimensional binning and simplify writing new methods.
 * Lower bound r\_min option for all queries.
+* Steinhardt now supports l = 0, 1.
 
 ### Changed
 * All compute objects that perform neighbor computations now use NeighborQuery internally.

--- a/cpp/order/Steinhardt.h
+++ b/cpp/order/Steinhardt.h
@@ -64,8 +64,6 @@ public:
     Steinhardt(unsigned int l, bool average = false, bool Wl = false, bool weighted = false)
         : m_Np(0), m_l(l), m_num_ms(2*l+1), m_average(average), m_Wl(Wl), m_weighted(weighted), m_Qlm_local(2 * l + 1)
     {
-        if (m_l < 2)
-            throw std::invalid_argument("Steinhardt requires l must be two or greater.");
     }
 
     //! Empty destructor

--- a/freud/order.pyx
+++ b/freud/order.pyx
@@ -472,7 +472,7 @@ cdef class Steinhardt(PairCompute):
 
     Args:
         l (unsigned int):
-            Spherical harmonic quantum number l. Must be a positive number.
+            Spherical harmonic quantum number l.
         average (bool, optional):
             Determines whether to calculate the averaged Steinhardt order
             parameter. (Default value = :code:`False`)
@@ -491,8 +491,8 @@ cdef class Steinhardt(PairCompute):
             parameter for each particle (filled with NaN for particles with no
             neighbors).
         norm (float or complex):
-            Stores the system wide normalization of the :math:`Ql` or :math:`Wl`
-            order parameter.
+            Stores the system wide normalization of the :math:`Q_l` or
+            :math:`W_l` order parameter.
     """  # noqa: E501
     cdef freud._order.Steinhardt * stptr
     cdef sph_l

--- a/tests/test_order_Steinhardt.py
+++ b/tests/test_order_Steinhardt.py
@@ -22,6 +22,36 @@ class TestSteinhardt(unittest.TestCase):
 
         npt.assert_equal(comp.order.shape[0], N)
 
+    def test_l_zero(self):
+        # Points should always have Q_0 = 1.
+        N = 1000
+        L = 10
+
+        box, positions = util.make_box_and_random_points(L, N)
+
+        comp = freud.order.Steinhardt(0)
+        comp.compute(box, positions, query_args={'r_max': 1.5})
+
+        npt.assert_allclose(comp.order, 1, atol=1e-5)
+
+    def test_l_axis_aligned(self):
+        # This test has three points along the z-axis. By construction, the
+        # points on the end should have Q_l = 1 for odd l and the central
+        # point should have Q_l = 0 for odd l. All three points should
+        # have perfect order for even l.
+        box = freud.box.Box.cube(10)
+        positions = [[0, 0, -1], [0, 0, 0], [0, 0, 1]]
+
+        for odd_l in range(1, 20, 2):
+            comp = freud.order.Steinhardt(odd_l)
+            comp.compute(box, positions, query_args={'num_neighbors': 2})
+            npt.assert_allclose(comp.order, [1, 0, 1], atol=1e-5)
+
+        for even_l in range(0, 20, 2):
+            comp = freud.order.Steinhardt(even_l)
+            comp.compute(box, positions, query_args={'num_neighbors': 2})
+            npt.assert_allclose(comp.order, 1, atol=1e-5)
+
     def test_identical_environments_Ql(self):
         (box, positions) = util.make_fcc(4, 4, 4)
         r_max = 1.5


### PR DESCRIPTION
## Description
I removed the check for `l >= 2` in the constructor for Steinhardt. It isn't necessary anymore since the class has been vastly improved. This isn't especially useful but there's no reason to keep the artificial limitation.

## How Has This Been Tested?
New tests were written to ensure `Q_0 = 1` (it's constant) and check that the parity of `l` gives the expected results (1 or 0) for a system of 3 particles aligned on the z-axis.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds or improves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have read the [**CONTRIBUTING**](https://github.com/glotzerlab/freud/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] I have updated the documentation (if relevant).
- [x] I have added tests that cover my changes (if relevant).
- [x] All new and existing tests passed.
- [x] I have updated the [Changelog](https://github.com/glotzerlab/freud/blob/master/ChangeLog.md).
