### PR TITLE
Refactor/make default nlist

### DIFF
--- a/freud/locality.pyx
+++ b/freud/locality.pyx
@@ -606,8 +606,7 @@ def make_default_nq(box, points):
     return rp
 
 
-def make_default_nlist(box, points, query_points, r_max, nlist=None,
-                       exclude_ii=False):
+def make_default_nlist(box, points, query_points, query_args, nlist=None):
     R"""Helper function to return a neighbor list object if is given, or to
     construct one using AABBQuery if it is not.
 
@@ -618,64 +617,28 @@ def make_default_nlist(box, points, query_points, r_max, nlist=None,
             Points for the neighborlist.
         query_points ((:math:`N_{particles}`, 3) :class:`numpy.ndarray`):
             Query points to construct the neighborlist.
-        r_max (float):
-            The radius within which to find neighbors.
+        query_args (dict):
+            Query arguments to use. Note that, if it is not one of the provided
+            query arguments, exclude_ii will be set to False if query_points is
+            None and True otherwise.
         nlist (:class:`freud.locality.NeighborList`, optional):
             NeighborList to use to find bonds (Default value = :code:`None`).
-        exclude_ii (bool, optional):
-            Set this to :code:`True` if pairs of points with identical
-            indices should be excluded. (Default value = :code:`False`).
 
     Returns:
         tuple (:class:`freud.locality.NeighborList`, :class:`freud.locality.AABBQuery`):
             The NeighborList and the owning AABBQuery object.
     """  # noqa: E501
     if nlist is not None:
-        return nlist, nlist
+        return nlist
 
     cdef AABBQuery aq = AABBQuery(box, points)
+    query_args.setdefault('exclude_ii', query_points is None)
+    cdef _QueryArgs qa = _QueryArgs.from_dict(query_args)
+    qp = query_points if query_points is not None else points
     cdef NeighborList aq_nlist = aq.query(
-        query_points, dict(r_max=r_max,
-                           exclude_ii=exclude_ii)).toNeighborList()
+        qp, query_args).toNeighborList()
 
-    return aq_nlist, aq
-
-
-def make_default_nlist_nn(box, points, query_points, num_neighbors, nlist=None,
-                          exclude_ii=False, r_max_guess=2.0):
-    R"""Helper function to return a neighbor list object if is given, or to
-    construct one using NearestNeighbors if it is not.
-
-    Args:
-        box (:class:`freud.box.Box`):
-            Simulation box.
-        points ((:math:`N_{particles}`, 3) :class:`numpy.ndarray`):
-            Reference points for the neighborlist.
-        query_points ((:math:`N_{particles}`, 3) :class:`numpy.ndarray`):
-            Points to construct the neighborlist.
-        num_neighbors (int):
-            The number of nearest neighbors to consider.
-        nlist (:class:`freud.locality.NeighborList`, optional):
-            NeighborList to use to find bonds (Default value = :code:`None`).
-        exclude_ii (bool, optional):
-            Set this to :code:`True` if pairs of points with identical
-            indices should be excluded. (Default value = :code:`False`).
-        r_max_guess (float):
-            Estimate of r_max, speeds up search if chosen properly.
-
-    Returns:
-        tuple (:class:`freud.locality.NeighborList`, :class:`freud.locality:NearestNeighbors`):
-            The neighborlist and the owning NearestNeighbors object.
-    """  # noqa: E501
-    if nlist is not None:
-        return nlist, nlist
-
-    cdef AABBQuery aq = AABBQuery(box, points)
-    cdef NeighborList aq_nlist = aq.query(
-        query_points, dict(num_neighbors=num_neighbors, r_guess=r_max_guess,
-                           exclude_ii=exclude_ii)).toNeighborList()
-
-    return aq_nlist, aq
+    return aq_nlist
 
 
 cdef class RawPoints(NeighborQuery):

--- a/freud/locality.pyx
+++ b/freud/locality.pyx
@@ -619,8 +619,8 @@ def make_default_nlist(box, points, query_points, query_args, nlist=None):
             Query points to construct the neighborlist.
         query_args (dict):
             Query arguments to use. Note that, if it is not one of the provided
-            query arguments, exclude_ii will be set to False if query_points is
-            None and True otherwise.
+            query arguments, :code:`exclude_ii` will be set to :code:`False` if
+            query_points is :code:`None` and :code:`True` otherwise.
         nlist (:class:`freud.locality.NeighborList`, optional):
             NeighborList to use to find bonds (Default value = :code:`None`).
 

--- a/freud/order.pyx
+++ b/freud/order.pyx
@@ -692,9 +692,9 @@ cdef class SolLiq(Compute):
         cdef const float[:, ::1] l_points = points
         cdef unsigned int nP = l_points.shape[0]
 
-        defaulted_nlist = freud.locality.make_default_nlist(
-            self.m_box, points, points, self.r_max, nlist, True)
-        cdef freud.locality.NeighborList nlist_ = defaulted_nlist[0]
+        cdef freud.locality.NeighborList nlist_
+        nlist_ = freud.locality.make_default_nlist(
+            self.m_box, points, None, dict(r_max=self.r_max), nlist)
 
         self.thisptr.compute(nlist_.get_ptr(),
                              <vec3[float]*> &l_points[0, 0], nP)
@@ -720,9 +720,9 @@ cdef class SolLiq(Compute):
         cdef const float[:, ::1] l_points = points
         cdef unsigned int nP = l_points.shape[0]
 
-        defaulted_nlist = freud.locality.make_default_nlist(
-            self.m_box, points, points, self.r_max, nlist, True)
-        cdef freud.locality.NeighborList nlist_ = defaulted_nlist[0]
+        cdef freud.locality.NeighborList nlist_
+        nlist_ = freud.locality.make_default_nlist(
+            self.m_box, points, None, dict(r_max=self.r_max), nlist)
 
         self.thisptr.computeSolLiqVariant(
             nlist_.get_ptr(), <vec3[float]*> &l_points[0, 0], nP)
@@ -745,9 +745,9 @@ cdef class SolLiq(Compute):
         cdef const float[:, ::1] l_points = points
         cdef unsigned int nP = l_points.shape[0]
 
-        defaulted_nlist = freud.locality.make_default_nlist(
-            self.m_box, points, points, self.r_max, nlist, True)
-        cdef freud.locality.NeighborList nlist_ = defaulted_nlist[0]
+        cdef freud.locality.NeighborList nlist_
+        nlist_ = freud.locality.make_default_nlist(
+            self.m_box, points, None, dict(r_max=self.r_max), nlist)
 
         self.thisptr.computeSolLiqNoNorm(
             nlist_.get_ptr(), <vec3[float]*> &l_points[0, 0], nP)
@@ -899,10 +899,10 @@ cdef class SolLiqNear(SolLiq):
                 Neighborlist to use to find bonds.
                 (Default value = :code:`None`).
         """
-        defaulted_nlist = freud.locality.make_default_nlist_nn(
-            self.m_box, points, points,
-            self.num_neighbors, nlist, True, self.r_max)
-        cdef freud.locality.NeighborList nlist_ = defaulted_nlist[0]
+        cdef freud.locality.NeighborList nlist_
+        nlist_ = freud.locality.make_default_nlist(
+            self.m_box, points, None, dict(num_neighbors=self.num_neighbors,
+                                           r_guess=self.r_max), nlist)
         return SolLiq.compute(self, points, nlist_)
 
     @Compute._compute()
@@ -917,10 +917,10 @@ cdef class SolLiqNear(SolLiq):
                 Neighborlist to use to find bonds.
                 (Default value = :code:`None`).
         """
-        defaulted_nlist = freud.locality.make_default_nlist_nn(
-            self.m_box, points, points,
-            self.num_neighbors, nlist, True, self.r_max)
-        cdef freud.locality.NeighborList nlist_ = defaulted_nlist[0]
+        cdef freud.locality.NeighborList nlist_
+        nlist_ = freud.locality.make_default_nlist(
+            self.m_box, points, None, dict(num_neighbors=self.num_neighbors,
+                                           r_guess=self.r_max), nlist)
         return SolLiq.computeSolLiqVariant(self, points, nlist_)
 
     @Compute._compute()
@@ -935,10 +935,10 @@ cdef class SolLiqNear(SolLiq):
                 Neighborlist to use to find bonds.
                 (Default value = :code:`None`).
         """
-        defaulted_nlist = freud.locality.make_default_nlist_nn(
-            self.m_box, points, points,
-            self.num_neighbors, nlist, True, self.r_max)
-        cdef freud.locality.NeighborList nlist_ = defaulted_nlist[0]
+        cdef freud.locality.NeighborList nlist_
+        nlist_ = freud.locality.make_default_nlist(
+            self.m_box, points, None, dict(num_neighbors=self.num_neighbors,
+                                           r_guess=self.r_max), nlist)
         return SolLiq.computeSolLiqNoNorm(self, points, nlist_)
 
     def __repr__(self):

--- a/tests/test_environment_LocalBondProjection.py
+++ b/tests/test_environment_LocalBondProjection.py
@@ -125,9 +125,10 @@ class TestLocalBondProjection(unittest.TestCase):
         ang = freud.environment.LocalBondProjection(r_max, num_neighbors)
         ang.compute(box, proj_vecs, points, ors)
 
-        dnlist = freud.locality.make_default_nlist_nn(
-            box, points, points, num_neighbors, None, True, r_max)
-        bonds = [(i[0], i[1]) for i in dnlist[0]]
+        dnlist = freud.locality.make_default_nlist(
+            box, points, None,
+            dict(num_neighbors=num_neighbors, r_guess=r_max), None)
+        bonds = [(i[0], i[1]) for i in dnlist]
 
         # We will look at the bond between [1, 0, 0] as ref_point
         # and [0, 0, 0] as point

--- a/tests/util.py
+++ b/tests/util.py
@@ -49,11 +49,14 @@ def make_raw_query_nlist_test_set(box, points, query_points, mode, r_max,
         (freud.locality.LinkCell(box, r_max, points), None, query_args))
     if mode == "ball":
         nlist = freud.locality.make_default_nlist(
-            box, points, query_points, r_max, None, exclude_ii)
+            box, points, query_points,
+            dict(r_max=r_max, exclude_ii=exclude_ii), None)
     if mode == "nearest":
-        nlist = freud.locality.make_default_nlist_nn(
-            box, points, query_points, num_neighbors, None, exclude_ii, r_max)
-    test_set.append((points, nlist[0], None, nlist[1]))
+        nlist = freud.locality.make_default_nlist(
+            box, points, query_points,
+            dict(num_neighbors=num_neighbors, exclude_ii=exclude_ii,
+                 r_guess=r_max), None)
+    test_set.append((points, nlist, None))
     return test_set
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
`make_default_nlist` and `make_default_nlist_nn` are now unified into a single function that uses a dictionary of query arguments.

Resolves #434 and #320. The latter was no longer really a bug, but there were some significant ambiguities in how `exclude_ii` was being handled that made it inconsistent with the rest of the updated code base. That is now fixed.

## Motivation and Context
This change, along with #451, will simplify further refactoring on the Cython side for these classes. In particular, it should allow us to generalize the code for the specific cases where we've decided that a `NeighborList` must be provided because `NeighborQuery`-based iteration doesn't make sense (typically because the properties computed are strictly related to a specific bond).

## How Has This Been Tested?
Existing tests pass.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds or improves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [**CONTRIBUTING**](https://github.com/glotzerlab/freud/blob/master/CONTRIBUTING.md) document.
- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation (if relevant).
- [ ] I have added tests that cover my changes (if relevant).
- [ ] All new and existing tests passed.
- [ ] I have updated the [Changelog](https://github.com/glotzerlab/freud/blob/master/ChangeLog.md).
