### PR TITLE
Fix/iterator terminator

### DIFF
--- a/cpp/locality/NeighborQuery.cc
+++ b/cpp/locality/NeighborQuery.cc
@@ -5,7 +5,7 @@
 
 namespace freud { namespace locality {
 
-const NeighborBond NeighborQueryIterator::ITERATOR_TERMINATOR(NeighborPerPointIterator::ITERATOR_TERMINATOR);
+const NeighborBond NeighborQueryIterator::ITERATOR_TERMINATOR(-1, -1, 0);
 
 const QueryArgs::QueryType QueryArgs::DEFAULT_MODE(QueryArgs::none);
 const unsigned int QueryArgs::DEFAULT_NUM_NEIGHBORS(0xffffffff);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Explicitly specify the const terminator in NeighborQuery.

## Motivation and Context
For some reason having one constant reference the other leads to inconsistent failures. I can't be 100% certain this was the problem, but prior to this fix if I recompiled the code multiple times and reran the tests I would experience failures roughly every other time. With this change I've been able to recompile and run the code tens of times with no failures.

To be more specific, the C++ code seemed to always work fine, the iterators were correctly identifying neighbors and returning them. However, the corresponding Python iterator seemed to have problems comparing to the sentinel properly, even though printing out the terminator typically showed the expected sentinel values (see [here](https://github.com/glotzerlab/freud/blob/master/freud/locality.pyx#L173)). @joaander any thoughts on what could cause this problem? The fact that I cannot reproduce this on my laptop, my desktop, or the linux workstations suggests that this is a very environment-specific compiler bug, but just want to get a second opinion before calling it done

## How Has This Been Tested?
Existing tests now pass consistently.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds or improves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/glotzerlab/freud/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] I have updated the documentation (if relevant).
- [x] I have added tests that cover my changes (if relevant).
- [x] All new and existing tests passed.
- [x] I have updated the [Changelog](https://github.com/glotzerlab/freud/blob/master/ChangeLog.md).
