### PR TITLE
Disallow 2D box with 3D points

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -32,6 +32,7 @@ and this project adheres to
 * Steinhardt uses query arguments.
 * APIs for several order parameters have been standardized.
 * SolidLiquid order parameter has been completely rewritten, fixing several bugs and simplifying its C++ code.
+* NeighborQuery objects require z == 0 for all points if the box is 2D.
 
 ### Fixed
 * Steinhardt uses the ThreadStorage class and properly resets memory where needed.

--- a/cpp/locality/LinkCell.cc
+++ b/cpp/locality/LinkCell.cc
@@ -351,7 +351,7 @@ vec3<unsigned int> LinkCell::getCellCoord(const vec3<float> p) const
     return c;
 }
 
-const std::vector<unsigned int>& LinkCell::getCellNeighbors(unsigned int cell)
+const std::vector<unsigned int>& LinkCell::getCellNeighbors(unsigned int cell) const
 {
     // check if the list of neighbors has been already computed
     // return the list if it has
@@ -367,7 +367,7 @@ const std::vector<unsigned int>& LinkCell::getCellNeighbors(unsigned int cell)
     }
 }
 
-const std::vector<unsigned int>& LinkCell::computeCellNeighbors(unsigned int cur_cell)
+const std::vector<unsigned int>& LinkCell::computeCellNeighbors(unsigned int cur_cell) const
 {
     std::vector<unsigned int> neighbor_cells;
     vec3<unsigned int> l_idx = indexToCoord(cur_cell);

--- a/cpp/locality/LinkCell.cc
+++ b/cpp/locality/LinkCell.cc
@@ -210,12 +210,11 @@ void IteratorCellShell::reset(unsigned int range)
 
 // Default constructor
 LinkCell::LinkCell()
-    : NeighborQuery(), m_n_points(0), m_cell_width(0), m_celldim(0, 0, 0), m_neighbor_list()
+    : NeighborQuery(), m_n_points(0), m_cell_width(0), m_celldim(0, 0, 0)
 {}
 
 LinkCell::LinkCell(const box::Box& box, float cell_width, const vec3<float>* points, unsigned int n_points)
-    : NeighborQuery(box, points, n_points), m_n_points(0), m_cell_width(cell_width), m_celldim(0, 0, 0),
-      m_neighbor_list()
+    : NeighborQuery(box, points, n_points), m_n_points(0), m_cell_width(cell_width), m_celldim(0, 0, 0)
 {
     m_celldim = computeDimensions(box, m_cell_width);
 

--- a/cpp/locality/LinkCell.h
+++ b/cpp/locality/LinkCell.h
@@ -231,7 +231,7 @@ public:
     }
 
     //! Get a list of neighbors to a cell
-    const std::vector<unsigned int>& getCellNeighbors(unsigned int cell);
+    const std::vector<unsigned int>& getCellNeighbors(unsigned int cell) const;
 
     //! Compute the cell list
     void computeCellList(const vec3<float>* points, unsigned int n_points);
@@ -249,7 +249,7 @@ private:
     static unsigned int roundDown(unsigned int v, unsigned int m);
 
     //! Helper function to compute cell neighbors
-    const std::vector<unsigned int>& computeCellNeighbors(unsigned int cell);
+    const std::vector<unsigned int>& computeCellNeighbors(unsigned int cell) const;
 
     unsigned int m_n_points;      //!< Number of particles last placed into the cell list
     unsigned int m_Nc;            //!< Number of cells last used
@@ -259,7 +259,7 @@ private:
 
     util::ManagedArray<unsigned int> m_cell_list; //!< The cell list last computed
     typedef tbb::concurrent_hash_map<unsigned int, std::vector<unsigned int>> CellNeighbors;
-    CellNeighbors m_cell_neighbors; //!< Hash map of cell neighbors for each cell
+    mutable CellNeighbors m_cell_neighbors; //!< Hash map of cell neighbors for each cell
 };
 
 //! Parent class of LinkCell iterators that knows how to traverse general cell-linked list structures.

--- a/cpp/locality/LinkCell.h
+++ b/cpp/locality/LinkCell.h
@@ -236,11 +236,6 @@ public:
     //! Compute the cell list
     void computeCellList(const vec3<float>* points, unsigned int n_points);
 
-    NeighborList* getNeighborList()
-    {
-        return &m_neighbor_list;
-    }
-
     //! Implementation of per-particle query for LinkCell (see NeighborQuery.h for documentation).
     /*! \param query_point The point to find neighbors for.
      *  \param n_query_points The number of query points.
@@ -265,7 +260,6 @@ private:
     util::ManagedArray<unsigned int> m_cell_list; //!< The cell list last computed
     typedef tbb::concurrent_hash_map<unsigned int, std::vector<unsigned int>> CellNeighbors;
     CellNeighbors m_cell_neighbors; //!< Hash map of cell neighbors for each cell
-    NeighborList m_neighbor_list;   //!< Stored neighbor list
 };
 
 //! Parent class of LinkCell iterators that knows how to traverse general cell-linked list structures.

--- a/cpp/locality/NeighborQuery.h
+++ b/cpp/locality/NeighborQuery.h
@@ -81,7 +81,18 @@ public:
     //! Constructor
     NeighborQuery(const box::Box& box, const vec3<float>* points, unsigned int n_points)
         : m_box(box), m_points(points), m_n_points(n_points)
-    {}
+    {
+        if (m_box.is2D())
+        {
+            for (unsigned int i(0); i < n_points; i++)
+            {
+                if (m_points[i].z != 0)
+                {
+                    throw std::invalid_argument("A point with z != 0 was provided in a 2D box.");
+                }
+            }
+        }
+    }
 
     //! Empty Destructor
     virtual ~NeighborQuery() {}

--- a/cpp/order/Nematic.cc
+++ b/cpp/order/Nematic.cc
@@ -14,7 +14,7 @@ namespace freud { namespace order {
 
 // m_u is the molecular axis, normalized to a unit vector
 Nematic::Nematic(vec3<float> u)
-    : m_n(0), m_u(u / sqrt(dot(u, u)))
+    : m_n(0), m_u(u / std::sqrt(dot(u, u)))
 {}
 
 float Nematic::getNematicOrderParameter()

--- a/cpp/util/BiMap.h
+++ b/cpp/util/BiMap.h
@@ -2,6 +2,7 @@
 #define BIMAP_H
 
 #include <algorithm>
+#include <cstddef> // Needed for offsetof
 #include <set>
 #include <vector>
 #include <map>

--- a/freud/_locality.pxd
+++ b/freud/_locality.pxd
@@ -36,7 +36,7 @@ cdef extern from "NeighborQuery.h" namespace "freud::locality":
         bool exclude_ii
 
     cdef cppclass NeighborQuery:
-        NeighborQuery()
+        NeighborQuery() except +
         NeighborQuery(const freud._box.Box &, const vec3[float]*, unsigned int)
         shared_ptr[NeighborQueryIterator] query(
             const vec3[float]*, unsigned int, QueryArgs) except +
@@ -58,7 +58,7 @@ cdef extern from "NeighborQuery.h" namespace "freud::locality":
 cdef extern from "RawPoints.h" namespace "freud::locality":
 
     cdef cppclass RawPoints(NeighborQuery):
-        RawPoints()
+        RawPoints() except +
         RawPoints(const freud._box.Box, const vec3[float]*, unsigned int)
 
 cdef extern from "NeighborList.h" namespace "freud::locality":
@@ -102,13 +102,11 @@ cdef extern from "LinkCell.h" namespace "freud::locality":
         unsigned int begin()
 
     cdef cppclass LinkCell(NeighborQuery):
-        LinkCell()
-        LinkCell(const freud._box.Box &, float) except +
-        LinkCell(const freud._box.Box &, float,
-                 const vec3[float]*, unsigned int) except +
-
-        setCellWidth(float) except +
-        updateBox(const freud._box.Box &) except +
+        LinkCell() except +
+        LinkCell(const freud._box.Box &,
+                 float,
+                 const vec3[float]*,
+                 unsigned int) except +
         const vec3[unsigned int] computeDimensions(
             const freud._box.Box &,
             float) const
@@ -116,17 +114,18 @@ cdef extern from "LinkCell.h" namespace "freud::locality":
         float getCellWidth() const
         unsigned int getCell(const vec3[float] &) const
         IteratorLinkCell itercell(unsigned int) const
-        vector[unsigned int] getCellNeighbors(unsigned int) const
+        vector[unsigned int] getCellNeighbors(unsigned int)
         void computeCellList(
             const freud._box.Box &,
             const vec3[float]*,
             unsigned int) except +
-        NeighborList * getNeighborList()
 
 cdef extern from "AABBQuery.h" namespace "freud::locality":
     cdef cppclass AABBQuery(NeighborQuery):
-        AABBQuery()
-        AABBQuery(const freud._box.Box, const vec3[float]*, unsigned int)
+        AABBQuery() except +
+        AABBQuery(const freud._box.Box,
+                  const vec3[float]*,
+                  unsigned int) except +
 
 cdef extern from "Voronoi.h" namespace "freud::locality":
     cdef cppclass Voronoi:

--- a/freud/_locality.pxd
+++ b/freud/_locality.pxd
@@ -114,7 +114,7 @@ cdef extern from "LinkCell.h" namespace "freud::locality":
         float getCellWidth() const
         unsigned int getCell(const vec3[float] &) const
         IteratorLinkCell itercell(unsigned int) const
-        vector[unsigned int] getCellNeighbors(unsigned int)
+        vector[unsigned int] getCellNeighbors(unsigned int) const
         void computeCellList(
             const freud._box.Box &,
             const vec3[float]*,

--- a/freud/_locality.pxd
+++ b/freud/_locality.pxd
@@ -37,7 +37,9 @@ cdef extern from "NeighborQuery.h" namespace "freud::locality":
 
     cdef cppclass NeighborQuery:
         NeighborQuery() except +
-        NeighborQuery(const freud._box.Box &, const vec3[float]*, unsigned int)
+        NeighborQuery(const freud._box.Box &,
+                      const vec3[float]*,
+                      unsigned int) except +
         shared_ptr[NeighborQueryIterator] query(
             const vec3[float]*, unsigned int, QueryArgs) except +
         const freud._box.Box & getBox() const
@@ -59,7 +61,9 @@ cdef extern from "RawPoints.h" namespace "freud::locality":
 
     cdef cppclass RawPoints(NeighborQuery):
         RawPoints() except +
-        RawPoints(const freud._box.Box, const vec3[float]*, unsigned int)
+        RawPoints(const freud._box.Box,
+                  const vec3[float]*,
+                  unsigned int) except +
 
 cdef extern from "NeighborList.h" namespace "freud::locality":
     cdef cppclass NeighborList:

--- a/tests/test_locality_NeighborQuery.py
+++ b/tests/test_locality_NeighborQuery.py
@@ -504,6 +504,16 @@ class NeighborQueryTest(object):
         q = nq.query(positions[0], dict(num_neighbors=1000))
         self.assertEqual(len(list(q)), 3)
 
+    def test_2d_box_3d_points(self):
+        """Test that points with z != 0 fail if the box is 2D."""
+        L = 10  # Box Dimensions
+        r_max = 2.01  # Cutoff radius
+
+        box = freud.box.Box.square(L)  # Initialize Box
+        points = np.array([[0, 0, 0], [0, 1, 1]])
+        with self.assertRaises(ValueError):
+            self.build_query_object(box, points, r_max)
+
 
 class TestNeighborQueryAABB(NeighborQueryTest, unittest.TestCase):
     @classmethod

--- a/tests/test_pmft.py
+++ b/tests/test_pmft.py
@@ -634,7 +634,7 @@ class TestPMFTXY2D(unittest.TestCase):
         angles = np.zeros(points.shape[0])
         max_width = 3
         nbins = 3
-        pmft = freud.pmft.PMFTXY2D(max_width, max_width, nbins, nbins)
+        pmft = freud.pmft.PMFTXY2D(max_width, max_width, nbins)
         with self.assertRaises(ValueError):
             pmft.compute(box, points, angles,
                          query_args={'mode': 'nearest', 'num_neighbors': 1})

--- a/tests/test_pmft.py
+++ b/tests/test_pmft.py
@@ -625,6 +625,20 @@ class TestPMFTXY2D(unittest.TestCase):
              [0, 0, 0],
              [0, 0, 0]])
 
+    def test_2d_box_3d_points(self):
+        """Test that points with z != 0 fail if the box is 2D."""
+        L = 10  # Box Dimensions
+
+        box = freud.box.Box.square(L)  # Initialize Box
+        points = np.array([[0, 0, 0], [0, 1, 1]])
+        angles = np.zeros(points.shape[0])
+        max_width = 3
+        nbins = 3
+        pmft = freud.pmft.PMFTXY2D(max_width, max_width, nbins, nbins)
+        with self.assertRaises(ValueError):
+            pmft.compute(box, points, angles,
+                         query_args={'mode': 'nearest', 'num_neighbors': 1})
+
 
 class TestPMFTXYZ(unittest.TestCase):
     def test_box(self):


### PR DESCRIPTION
## Description
Disallows points with `z != 0` in NeighborQuery objects built on a 2D box.

## Motivation and Context
This reduces the likelihood of users accidentally misusing freud's 2D capabilities, or accidentally using a 2D box with a system that should be 3D.

Also resolves #468.

## How Has This Been Tested?
A test was added to ensure the error is raised.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds or improves functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have read the [**CONTRIBUTING**](https://github.com/glotzerlab/freud/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] I have updated the documentation (if relevant).
- [x] I have added tests that cover my changes (if relevant).
- [x] All new and existing tests passed.
- [x] I have updated the [Changelog](https://github.com/glotzerlab/freud/blob/master/ChangeLog.md).
