### PR TITLE
Refactor/neighbors arg

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -17,6 +17,7 @@ and this project adheres to
 * Lower bound r\_min option for all queries.
 * Steinhardt now supports l = 0, 1.
 * C++ BondHistogramCompute class encapsulates logic of histogram-based methods.
+* NeighborLists and query arguments are now accepted on equal footing by compute methods that involve neighbor finding.
 
 ### Changed
 * All compute objects that perform neighbor computations now use NeighborQuery internally.

--- a/cpp/box/ParticleBuffer.h
+++ b/cpp/box/ParticleBuffer.h
@@ -37,12 +37,12 @@ public:
     void compute(const vec3<float>* points, const unsigned int Np, const vec3<float> buff,
                  const bool use_images);
 
-    std::vector<vec3<float> > getBufferParticles()
+    std::vector<vec3<float> > getBufferParticles() const
     {
         return m_buffer_particles;
     }
 
-    std::vector<unsigned int> getBufferIds()
+    std::vector<unsigned int> getBufferIds() const
     {
         return m_buffer_ids;
     }

--- a/cpp/cluster/Cluster.h
+++ b/cpp/cluster/Cluster.h
@@ -57,25 +57,25 @@ public:
                  const unsigned int* keys=NULL);
 
     //! Count the number of clusters found in the last call to compute().
-    unsigned int getNumClusters()
+    unsigned int getNumClusters() const
     {
         return m_num_clusters;
     }
 
     //! Return the number of particles in the current Compute.
-    unsigned int getNumParticles()
+    unsigned int getNumParticles() const
     {
         return m_num_particles;
     }
 
     //! Get a reference to the last computed cluster ids.
-    const util::ManagedArray<unsigned int> &getClusterIdx()
+    const util::ManagedArray<unsigned int> &getClusterIdx() const
     {
         return m_cluster_idx;
     }
 
     //! Returns the last computed cluster keys.
-    const std::vector<std::vector<unsigned int>> &getClusterKeys()
+    const std::vector<std::vector<unsigned int>> &getClusterKeys() const
     {
         return m_cluster_keys;
     }

--- a/cpp/cluster/ClusterProperties.h
+++ b/cpp/cluster/ClusterProperties.h
@@ -42,25 +42,25 @@ public:
                            unsigned int Np);
 
     //! Count the number of clusters found in the last call to computeProperties()
-    unsigned int getNumClusters()
+    unsigned int getNumClusters() const
     {
         return m_num_clusters;
     }
 
     //! Get a reference to the last computed cluster_com
-    const util::ManagedArray<vec3<float>> &getClusterCOM()
+    const util::ManagedArray<vec3<float>> &getClusterCOM() const
     {
         return m_cluster_com;
     }
 
     //! Get a reference to the last computed cluster_G
-    const util::ManagedArray<float> &getClusterG()
+    const util::ManagedArray<float> &getClusterG() const
     {
         return m_cluster_G;
     }
 
     //! Get a reference to the last computed cluster size
-    const util::ManagedArray<unsigned int> &getClusterSize()
+    const util::ManagedArray<unsigned int> &getClusterSize() const
     {
         return m_cluster_size;
     }

--- a/cpp/density/LocalDensity.cc
+++ b/cpp/density/LocalDensity.cc
@@ -65,21 +65,4 @@ void LocalDensity::compute(const freud::locality::NeighborQuery* neighbor_query,
     m_n_points = n_points;
 }
 
-unsigned int LocalDensity::getNPoints()
-{
-    return m_n_points;
-}
-
-//! Get a reference to the last computed density
-const util::ManagedArray<float> &LocalDensity::getDensity()
-{
-    return m_density_array;
-}
-
-//! Get a reference to the last computed number of neighbors
-const util::ManagedArray<float> &LocalDensity::getNumNeighbors()
-{
-    return m_num_neighbors_array;
-}
-
 }; }; // end namespace freud::density

--- a/cpp/density/LocalDensity.h
+++ b/cpp/density/LocalDensity.h
@@ -52,13 +52,22 @@ public:
                  freud::locality::QueryArgs qargs);
 
     //! Get the number of reference particles
-    unsigned int getNPoints();
+    unsigned int getNPoints() const
+    {
+        return m_n_points;
+    }
 
     //! Get a reference to the last computed density
-    const util::ManagedArray<float> &getDensity();
+    const util::ManagedArray<float> &getDensity() const
+    {
+        return m_density_array;
+    }
 
     //! Get a reference to the last computed number of neighbors
-    const util::ManagedArray<float> &getNumNeighbors();
+    const util::ManagedArray<float> &getNumNeighbors() const
+    {
+        return m_num_neighbors_array;
+    }
 
 private:
     box::Box m_box;       //!< Simulation box where the particles belong

--- a/cpp/environment/AngularSeparation.cc
+++ b/cpp/environment/AngularSeparation.cc
@@ -63,7 +63,7 @@ void AngularSeparationNeighbor::compute(const locality::NeighborQuery *nq, const
                  const freud::locality::NeighborList* nlist, locality::QueryArgs qargs)
 {
     // This function requires a NeighborList object, so we always make one and store it locally.
-    locality::NeighborList m_nlist = locality::makeDefaultNlist(nq, nlist, query_points, n_query_points, qargs);
+    m_nlist = locality::makeDefaultNlist(nq, nlist, query_points, n_query_points, qargs);
     m_nlist.validate(n_query_points, nq->getNPoints());
 
     const size_t tot_num_neigh = m_nlist.getNumBonds();

--- a/cpp/environment/AngularSeparation.cc
+++ b/cpp/environment/AngularSeparation.cc
@@ -39,7 +39,7 @@ float computeMinSeparationAngle(const quat<float> ref_q, const quat<float> q, co
     float min_angle = computeSeparationAngle(ref_q, q);
 
     // loop through all equivalent rotations and see if they have smaller angles with ref_q
-    for (unsigned int i = 1; i < n_equiv_quats; ++i)
+    for (unsigned int i = 0; i < n_equiv_quats; ++i)
     {
         quat<float> qe = equiv_qs[i];
         quat<float> qtest = qtemp * qe;
@@ -64,7 +64,6 @@ void AngularSeparationNeighbor::compute(const locality::NeighborQuery *nq, const
 {
     // This function requires a NeighborList object, so we always make one and store it locally.
     m_nlist = locality::makeDefaultNlist(nq, nlist, query_points, n_query_points, qargs);
-    m_nlist.validate(n_query_points, nq->getNPoints());
 
     const size_t tot_num_neigh = m_nlist.getNumBonds();
     m_angles.prepare(tot_num_neigh);

--- a/cpp/environment/AngularSeparation.h
+++ b/cpp/environment/AngularSeparation.h
@@ -73,8 +73,15 @@ public:
         return m_angles;
     }
 
+    //! Return a pointer to the NeighborList used in the last call to compute.
+    locality::NeighborList *getNList()
+    {
+        return &m_nlist;
+    }
+
 protected:
     util::ManagedArray<float> m_angles;  //!< neighbor angle array computed
+    locality::NeighborList m_nlist; //!< The NeighborList used in the last call to compute.
 };
 
 }; }; // end namespace freud::environment

--- a/cpp/environment/AngularSeparation.h
+++ b/cpp/environment/AngularSeparation.h
@@ -5,6 +5,7 @@
 #define ANGULAR_SEPARATION_H
 
 #include "NeighborList.h"
+#include "NeighborQuery.h"
 #include "VectorMath.h"
 
 /*! \file AngularSeparation.h
@@ -60,10 +61,11 @@ public:
     ~AngularSeparationNeighbor() {}
 
     //! Compute the angular separation between neighbors
-    void compute(const quat<float>* orientations, unsigned int n_points,
+    void compute(const locality::NeighborQuery *nq, const quat<float>* orientations,
+                 const vec3<float>* query_points,
                  const quat<float>* query_orientations, unsigned int n_query_points,
                  const quat<float>* equiv_orientations, unsigned int n_equiv_orientations,
-                 const freud::locality::NeighborList* nlist);
+                 const freud::locality::NeighborList* nlist, locality::QueryArgs qargs);
 
     //! Returns the last computed neighbor angle array
     util::ManagedArray<float> &getAngles()

--- a/cpp/environment/AngularSeparation.h
+++ b/cpp/environment/AngularSeparation.h
@@ -41,7 +41,7 @@ public:
         return m_angles;
     }
 
-protected:
+private:
     util::ManagedArray<float> m_angles; //!< Global angle array computed
 };
 
@@ -79,7 +79,7 @@ public:
         return &m_nlist;
     }
 
-protected:
+private:
     util::ManagedArray<float> m_angles;  //!< neighbor angle array computed
     locality::NeighborList m_nlist; //!< The NeighborList used in the last call to compute.
 };

--- a/cpp/environment/AngularSeparation.h
+++ b/cpp/environment/AngularSeparation.h
@@ -36,7 +36,7 @@ public:
                  const quat<float>* equiv_orientations, unsigned int n_equiv_orientations);
 
     //! Returns the last computed global angle array
-    util::ManagedArray<float> &getAngles()
+    const util::ManagedArray<float> &getAngles() const
     {
         return m_angles;
     }
@@ -68,7 +68,7 @@ public:
                  const freud::locality::NeighborList* nlist, locality::QueryArgs qargs);
 
     //! Returns the last computed neighbor angle array
-    util::ManagedArray<float> &getAngles()
+    const util::ManagedArray<float> &getAngles() const
     {
         return m_angles;
     }

--- a/cpp/environment/AngularSeparation.h
+++ b/cpp/environment/AngularSeparation.h
@@ -8,54 +8,71 @@
 #include "VectorMath.h"
 
 /*! \file AngularSeparation.h
-    \brief Compute the angular separation for each particle.
+    \brief Compute the angular separations.
 */
 
 namespace freud { namespace environment {
 
-float computeSeparationAngle(const quat<float> ref_q, const quat<float> q);
-
-float computeMinSeparationAngle(const quat<float> ref_q, const quat<float> q, const quat<float>* equiv_qs,
-                                unsigned int Nequiv);
-
 //! Compute the angular separation for a set of points
-/*!
+/*! Given a set of global orientations, this method accepts a set of
+ * orientations that are compared against the global orientations to determine
+ * the total angular distance between them. The output is an array of shape
+ * (num_orientations, num_global_orientations) containing the pairwise
+ * separation angles between the provided orientations and global orientations.
  */
-class AngularSeparation
+class AngularSeparationGlobal
 {
 public:
     //! Constructor
-    AngularSeparation();
+    AngularSeparationGlobal() {}
 
     //! Destructor
-    ~AngularSeparation();
-
-    //! Compute the angular separation between neighbors
-    void computeNeighbor(const quat<float>* orientations, unsigned int n_points,
-                         const quat<float>* query_orientations, unsigned int n_query_points,
-                         const quat<float>* equiv_orientations, unsigned int n_equiv_orientations,
-                         const freud::locality::NeighborList* nlist);
+    ~AngularSeparationGlobal() {}
 
     //! Compute the angular separation with respect to global orientation
-    void computeGlobal(const quat<float>* global_orientations, unsigned int n_global,
-                       const quat<float>* orientations, unsigned int n_points,
-                       const quat<float>* equiv_orientations, unsigned int n_equiv_orientations);
-
-    //! Returns the last computed neighbor angle array
-    util::ManagedArray<float> &getNeighborAngles()
-    {
-        return m_neighbor_angles;
-    }
+    void compute(const quat<float>* global_orientations, unsigned int n_global,
+                 const quat<float>* orientations, unsigned int n_points,
+                 const quat<float>* equiv_orientations, unsigned int n_equiv_orientations);
 
     //! Returns the last computed global angle array
-    util::ManagedArray<float> &getGlobalAngles()
+    util::ManagedArray<float> &getAngles()
     {
-        return m_global_angles;
+        return m_angles;
     }
 
-private:
-    util::ManagedArray<float> m_neighbor_angles;  //!< neighbor angle array computed
-    util::ManagedArray<float> m_global_angles; //!< global angle array computed
+protected:
+    util::ManagedArray<float> m_angles; //!< Global angle array computed
+};
+
+
+//! Compute the difference in orientation between pairs of points.
+/*! Given two sets of oriented points and the bonds between these points, this
+ * class computes the minimum separating angle between the orientations of each
+ * pair of bonded points.
+ */
+class AngularSeparationNeighbor
+{
+public:
+    //! Constructor
+    AngularSeparationNeighbor() {}
+
+    //! Destructor
+    ~AngularSeparationNeighbor() {}
+
+    //! Compute the angular separation between neighbors
+    void compute(const quat<float>* orientations, unsigned int n_points,
+                 const quat<float>* query_orientations, unsigned int n_query_points,
+                 const quat<float>* equiv_orientations, unsigned int n_equiv_orientations,
+                 const freud::locality::NeighborList* nlist);
+
+    //! Returns the last computed neighbor angle array
+    util::ManagedArray<float> &getAngles()
+    {
+        return m_angles;
+    }
+
+protected:
+    util::ManagedArray<float> m_angles;  //!< neighbor angle array computed
 };
 
 }; }; // end namespace freud::environment

--- a/cpp/environment/BondOrder.h
+++ b/cpp/environment/BondOrder.h
@@ -52,6 +52,11 @@ public:
     //! Get a reference to the last computed bond order
     const util::ManagedArray<float> &getBondOrder();
 
+    BondOrderMode getMode() const
+    {
+        return m_mode;
+    }
+
 private:
     util::ManagedArray<float> m_bo_array;          //!< bond order array computed
     util::ManagedArray<float> m_sa_array;          //!< surface area array computed

--- a/cpp/environment/BondOrder.h
+++ b/cpp/environment/BondOrder.h
@@ -35,7 +35,7 @@ class BondOrder : public locality::BondHistogramCompute
 {
 public:
     //! Constructor
-    BondOrder(unsigned int n_bins_theta, unsigned int n_bins_phi);
+    BondOrder(unsigned int n_bins_theta, unsigned int n_bins_phi, BondOrderMode mode);
 
     //! Destructor
     ~BondOrder() {}
@@ -44,7 +44,7 @@ public:
     void accumulate(const locality::NeighborQuery* neighbor_query,
                     quat<float>* orientations, vec3<float>* query_points,
                     quat<float>* query_orientations, unsigned int n_query_points,
-                    unsigned int mode, const freud::locality::NeighborList* nlist,
+                    const freud::locality::NeighborList* nlist,
                     freud::locality::QueryArgs qargs);
 
     virtual void reduce();
@@ -55,6 +55,7 @@ public:
 private:
     util::ManagedArray<float> m_bo_array;          //!< bond order array computed
     util::ManagedArray<float> m_sa_array;          //!< surface area array computed
+    BondOrderMode m_mode;                          //!< The mode to calculate with.
 };
 
 }; }; // end namespace freud::environment

--- a/cpp/environment/LocalBondProjection.cc
+++ b/cpp/environment/LocalBondProjection.cc
@@ -61,7 +61,7 @@ void LocalBondProjection::compute(const locality::NeighborQuery *nq,
     const freud::locality::NeighborList* nlist, locality::QueryArgs qargs)
 {
     // This function requires a NeighborList object, so we always make one and store it locally.
-    locality::NeighborList m_nlist = locality::makeDefaultNlist(nq, nlist, query_points, n_query_points, qargs);
+    m_nlist = locality::makeDefaultNlist(nq, nlist, query_points, n_query_points, qargs);
     m_nlist.validate(n_query_points, nq->getNPoints());
 
     // Get the maximum total number of bonds in the neighbor list

--- a/cpp/environment/LocalBondProjection.cc
+++ b/cpp/environment/LocalBondProjection.cc
@@ -61,7 +61,6 @@ void LocalBondProjection::compute(const locality::NeighborQuery *nq,
 {
     // This function requires a NeighborList object, so we always make one and store it locally.
     m_nlist = locality::makeDefaultNlist(nq, nlist, query_points, n_query_points, qargs);
-    m_nlist.validate(n_query_points, nq->getNPoints());
 
     // Get the maximum total number of bonds in the neighbor list
     const unsigned int tot_num_neigh = m_nlist.getNumBonds();

--- a/cpp/environment/LocalBondProjection.cc
+++ b/cpp/environment/LocalBondProjection.cc
@@ -2,6 +2,7 @@
 // This file is part of the freud project, released under the BSD 3-Clause License.
 
 #include "LocalBondProjection.h"
+#include "NeighborComputeFunctional.h"
 
 /*! \file LocalBondProjection.h
     \brief Compute the projection of nearest neighbor bonds for each particle onto some
@@ -52,32 +53,34 @@ float computeMaxProjection(const vec3<float> proj_vec, const vec3<float> local_b
     return max_proj;
 }
 
-void LocalBondProjection::compute(box::Box& box,
-    const vec3<float>* proj_vecs,  unsigned int n_proj,
-    const vec3<float>* points, const quat<float>* orientations, unsigned int n_points,
+void LocalBondProjection::compute(const locality::NeighborQuery *nq,
+    const quat<float>* orientations,
     const vec3<float>* query_points, unsigned int n_query_points,
+    const vec3<float>* proj_vecs,  unsigned int n_proj,
     const quat<float>* equiv_orientations, unsigned int n_equiv_orientations,
-    const freud::locality::NeighborList* nlist)
+    const freud::locality::NeighborList* nlist, locality::QueryArgs qargs)
 {
-    nlist->validate(n_query_points, n_points);
+    // This function requires a NeighborList object, so we always make one and store it locally.
+    locality::NeighborList m_nlist = locality::makeDefaultNlist(nq, nlist, query_points, n_query_points, qargs);
+    m_nlist.validate(n_query_points, nq->getNPoints());
 
     // Get the maximum total number of bonds in the neighbor list
-    const unsigned int tot_num_neigh = nlist->getNumBonds();
+    const unsigned int tot_num_neigh = m_nlist.getNumBonds();
 
     m_local_bond_proj.prepare({tot_num_neigh, n_proj});
     m_local_bond_proj_norm.prepare({tot_num_neigh, n_proj});
 
     // compute the order parameter
     util::forLoopWrapper(0, n_query_points, [=](size_t begin, size_t end) {
-        size_t bond(nlist->find_first_index(begin));
+        size_t bond(m_nlist.find_first_index(begin));
         for (size_t i = begin; i < end; ++i)
         {
-            for (; bond < tot_num_neigh && nlist->getNeighbors()(bond, 0) == i; ++bond)
+            for (; bond < tot_num_neigh && m_nlist.getNeighbors()(bond, 0) == i; ++bond)
             {
-                const size_t j(nlist->getNeighbors()(bond, 1));
+                const size_t j(m_nlist.getNeighbors()(bond, 1));
 
                 // compute bond vector between the two particles
-                vec3<float> delta = box.wrap(query_points[i] - points[j]);
+                vec3<float> delta = nq->getBox().wrap(query_points[i] - (*nq)[j]);
                 vec3<float> local_bond(delta);
                 // rotate bond vector into the local frame of particle p
                 local_bond = rotate(conj(orientations[j]), local_bond);
@@ -96,11 +99,11 @@ void LocalBondProjection::compute(box::Box& box,
     });
 
     // save the last computed box
-    m_box = box;
+    m_box = nq->getBox();
     // save the last computed number of particles
     m_n_query_points = n_query_points;
     // save the last computed number of reference particles
-    m_n_points = n_points;
+    m_n_points = nq->getNPoints();
     // save the last computed number of equivalent quaternions
     m_n_equiv_orientations = n_equiv_orientations;
     // save the last computed number of reference projection vectors

--- a/cpp/environment/LocalBondProjection.cc
+++ b/cpp/environment/LocalBondProjection.cc
@@ -11,8 +11,7 @@
 
 namespace freud { namespace environment {
 
-LocalBondProjection::LocalBondProjection() : m_n_query_points(0), m_n_points(0), m_n_proj(0), m_n_equiv_orientations(0), m_tot_num_neigh(0)
-{}
+LocalBondProjection::LocalBondProjection() {}
 
 LocalBondProjection::~LocalBondProjection() {}
 
@@ -97,19 +96,6 @@ void LocalBondProjection::compute(const locality::NeighborQuery *nq,
             }
         }
     });
-
-    // save the last computed box
-    m_box = nq->getBox();
-    // save the last computed number of particles
-    m_n_query_points = n_query_points;
-    // save the last computed number of reference particles
-    m_n_points = nq->getNPoints();
-    // save the last computed number of equivalent quaternions
-    m_n_equiv_orientations = n_equiv_orientations;
-    // save the last computed number of reference projection vectors
-    m_n_proj = n_proj;
-    // save the last computed number of total bonds
-    m_tot_num_neigh = tot_num_neigh;
 }
 
 }; }; // end namespace freud::environment

--- a/cpp/environment/LocalBondProjection.h
+++ b/cpp/environment/LocalBondProjection.h
@@ -5,6 +5,7 @@
 #define LOCAL_BOND_PROJECTION_H
 
 #include "Box.h"
+#include "NeighborQuery.h"
 #include "NeighborList.h"
 #include "VectorMath.h"
 #include "ManagedArray.h"
@@ -31,12 +32,12 @@ public:
     ~LocalBondProjection();
 
     //! Compute the maximal local bond projection
-    void compute(box::Box& box, 
-        const vec3<float>* proj_vecs,  unsigned int n_proj,
-        const vec3<float>* points, const quat<float>* orientations, unsigned int m_n_points,
+    void compute(const locality::NeighborQuery *nq,
+        const quat<float>* orientations,
         const vec3<float>* query_points, unsigned int n_query_points,
+        const vec3<float>* proj_vecs,  unsigned int n_proj,
         const quat<float>* equiv_orientations, unsigned int n_equiv_orientations,
-        const freud::locality::NeighborList* nlist);
+        const freud::locality::NeighborList* nlist, locality::QueryArgs qargs);
 
     //! Get a reference to the last computed maximal local bond projection array
     const util::ManagedArray<float> &getProjections()

--- a/cpp/environment/LocalBondProjection.h
+++ b/cpp/environment/LocalBondProjection.h
@@ -40,13 +40,13 @@ public:
         const freud::locality::NeighborList* nlist, locality::QueryArgs qargs);
 
     //! Get a reference to the last computed maximal local bond projection array
-    const util::ManagedArray<float> &getProjections()
+    const util::ManagedArray<float> &getProjections() const
     {
         return m_local_bond_proj;
     }
 
     //! Get a reference to the last computed normalized maximal local bond projection array
-    const util::ManagedArray<float> &getNormedProjections()
+    const util::ManagedArray<float> &getNormedProjections() const
     {
         return m_local_bond_proj_norm;
     }

--- a/cpp/environment/LocalBondProjection.h
+++ b/cpp/environment/LocalBondProjection.h
@@ -71,6 +71,12 @@ public:
         return m_box;
     }
 
+    //! Return a pointer to the NeighborList used in the last call to compute.
+    locality::NeighborList *getNList()
+    {
+        return &m_nlist;
+    }
+
 private:
     box::Box m_box;               //!< Last used simulation box
     unsigned int m_n_query_points;            //!< Last number of particles computed
@@ -78,6 +84,7 @@ private:
     unsigned int m_n_proj;         //!< Last number of projection vectors used for computation
     unsigned int m_n_equiv_orientations;        //!< Last number of equivalent reference orientations used for computation
     unsigned int m_tot_num_neigh; //!< Last number of total bonds used for computation
+    locality::NeighborList m_nlist; //!< The NeighborList used in the last call to compute.
 
     util::ManagedArray<float> m_local_bond_proj;      //!< Local bond projection array computed
     util::ManagedArray<float> m_local_bond_proj_norm; //!< Normalized local bond projection array computed

--- a/cpp/environment/LocalBondProjection.h
+++ b/cpp/environment/LocalBondProjection.h
@@ -58,12 +58,6 @@ public:
     }
 
 private:
-    box::Box m_box;               //!< Last used simulation box
-    unsigned int m_n_query_points;            //!< Last number of particles computed
-    unsigned int m_n_points;          //!< Last number of reference particles used for computation
-    unsigned int m_n_proj;         //!< Last number of projection vectors used for computation
-    unsigned int m_n_equiv_orientations;        //!< Last number of equivalent reference orientations used for computation
-    unsigned int m_tot_num_neigh; //!< Last number of total bonds used for computation
     locality::NeighborList m_nlist; //!< The NeighborList used in the last call to compute.
 
     util::ManagedArray<float> m_local_bond_proj;      //!< Local bond projection array computed

--- a/cpp/environment/LocalBondProjection.h
+++ b/cpp/environment/LocalBondProjection.h
@@ -51,26 +51,6 @@ public:
         return m_local_bond_proj_norm;
     }
 
-    unsigned int getNQueryPoints()
-    {
-        return m_n_query_points;
-    }
-
-    unsigned int getNPoints()
-    {
-        return m_n_points;
-    }
-
-    unsigned int getNproj()
-    {
-        return m_n_proj;
-    }
-
-    const box::Box& getBox() const
-    {
-        return m_box;
-    }
-
     //! Return a pointer to the NeighborList used in the last call to compute.
     locality::NeighborList *getNList()
     {

--- a/cpp/environment/LocalDescriptors.cc
+++ b/cpp/environment/LocalDescriptors.cc
@@ -14,7 +14,7 @@
 namespace freud { namespace environment {
 
 LocalDescriptors::LocalDescriptors(unsigned int l_max, bool negative_m)
-    : m_l_max(l_max), m_negative_m(negative_m), m_n_points(0), m_nSphs(0)
+    : m_l_max(l_max), m_negative_m(negative_m), m_nSphs(0)
 {}
 
 void LocalDescriptors::compute(const locality::NeighborQuery *nq,
@@ -125,7 +125,6 @@ void LocalDescriptors::compute(const locality::NeighborQuery *nq,
     });
 
     // save the last computed number of particles
-    m_n_points = nq->getNPoints();
     m_nSphs = m_nlist.getNumBonds();
 }
 

--- a/cpp/environment/LocalDescriptors.cc
+++ b/cpp/environment/LocalDescriptors.cc
@@ -24,7 +24,6 @@ void LocalDescriptors::compute(const locality::NeighborQuery *nq,
 {
     // This function requires a NeighborList object, so we always make one and store it locally.
     m_nlist = locality::makeDefaultNlist(nq, nlist, query_points, n_query_points, qargs);
-    m_nlist.validate(n_query_points, nq->getNPoints());
 
     m_sphArray.prepare({m_nlist.getNumBonds(), getSphWidth()});
 

--- a/cpp/environment/LocalDescriptors.cc
+++ b/cpp/environment/LocalDescriptors.cc
@@ -22,8 +22,8 @@ void LocalDescriptors::compute(const locality::NeighborQuery *nq,
     const quat<float>* orientations, LocalDescriptorOrientation orientation,
     const freud::locality::NeighborList* nlist, locality::QueryArgs qargs)
 {
-    // This function requires a NeighborList object.
-    locality::NeighborList m_nlist = locality::makeDefaultNlist(nq, nlist, query_points, n_query_points, qargs);
+    // This function requires a NeighborList object, so we always make one and store it locally..
+    m_nlist = locality::makeDefaultNlist(nq, nlist, query_points, n_query_points, qargs);
     m_nlist.validate(n_query_points, nq->getNPoints());
 
     m_sphArray.prepare({m_nlist.getNumBonds(), getSphWidth()});

--- a/cpp/environment/LocalDescriptors.cc
+++ b/cpp/environment/LocalDescriptors.cc
@@ -13,14 +13,14 @@
 
 namespace freud { namespace environment {
 
-LocalDescriptors::LocalDescriptors(unsigned int l_max, bool negative_m)
-    : m_l_max(l_max), m_negative_m(negative_m), m_nSphs(0)
+LocalDescriptors::LocalDescriptors(unsigned int l_max, bool negative_m, LocalDescriptorOrientation orientation)
+    : m_l_max(l_max), m_negative_m(negative_m), m_nSphs(0), m_orientation(orientation)
 {}
 
 void LocalDescriptors::compute(const locality::NeighborQuery *nq,
     const vec3<float>* query_points, unsigned int n_query_points,
-    const quat<float>* orientations, LocalDescriptorOrientation orientation,
-    const freud::locality::NeighborList* nlist, locality::QueryArgs qargs)
+    const quat<float>* orientations, const freud::locality::NeighborList*
+    nlist, locality::QueryArgs qargs)
 {
     // This function requires a NeighborList object, so we always make one and store it locally.
     m_nlist = locality::makeDefaultNlist(nq, nlist, query_points, n_query_points, qargs);
@@ -37,7 +37,7 @@ void LocalDescriptors::compute(const locality::NeighborQuery *nq,
 
             vec3<float> rotation_0, rotation_1, rotation_2;
 
-            if (orientation == LocalNeighborhood)
+            if (m_orientation == LocalNeighborhood)
             {
                 util::ManagedArray<float> inertiaTensor = util::ManagedArray<float>({3, 3});
 
@@ -78,14 +78,14 @@ void LocalDescriptors::compute(const locality::NeighborQuery *nq,
                 rotation_2
                     = vec3<float>(eigenvectors(2, 0), eigenvectors(2, 1), eigenvectors(2, 2));
             }
-            else if (orientation == ParticleLocal)
+            else if (m_orientation == ParticleLocal)
             {
                 const rotmat3<float> rotmat(conj(orientations[i]));
                 rotation_0 = rotmat.row0;
                 rotation_1 = rotmat.row1;
                 rotation_2 = rotmat.row2;
             }
-            else if (orientation == Global)
+            else if (m_orientation == Global)
             {
                 rotation_0 = vec3<float>(1, 0, 0);
                 rotation_1 = vec3<float>(0, 1, 0);

--- a/cpp/environment/LocalDescriptors.cc
+++ b/cpp/environment/LocalDescriptors.cc
@@ -22,7 +22,7 @@ void LocalDescriptors::compute(const locality::NeighborQuery *nq,
     const quat<float>* orientations, LocalDescriptorOrientation orientation,
     const freud::locality::NeighborList* nlist, locality::QueryArgs qargs)
 {
-    // This function requires a NeighborList object, so we always make one and store it locally..
+    // This function requires a NeighborList object, so we always make one and store it locally.
     m_nlist = locality::makeDefaultNlist(nq, nlist, query_points, n_query_points, qargs);
     m_nlist.validate(n_query_points, nq->getNPoints());
 

--- a/cpp/environment/LocalDescriptors.h
+++ b/cpp/environment/LocalDescriptors.h
@@ -50,12 +50,6 @@ public:
         return m_l_max;
     }
 
-    //! Get the number of particles
-    unsigned int getNPoints() const
-    {
-        return m_n_points;
-    }
-
     //! Compute the local neighborhood descriptors given some
     //! positions and the number of particles
     void compute(const locality::NeighborQuery *nq,
@@ -84,7 +78,6 @@ public:
 private:
     unsigned int m_l_max;  //!< Maximum spherical harmonic l to calculate
     bool m_negative_m;    //!< true if we should compute Ylm for negative m
-    unsigned int m_n_points;  //!< Last number of points computed
     unsigned int m_nSphs; //!< Last number of bond spherical harmonics computed
     locality::NeighborList m_nlist; //!< The NeighborList used in the last call to compute.
 

--- a/cpp/environment/LocalDescriptors.h
+++ b/cpp/environment/LocalDescriptors.h
@@ -69,9 +69,16 @@ public:
         return m_sphArray;
     }
 
+    //! Return the number of spherical harmonics that will be computed for each bond.
     unsigned int getSphWidth() const
     {
         return fsph::sphCount(m_l_max) + (m_l_max > 0 && m_negative_m ? fsph::sphCount(m_l_max - 1) : 0);
+    }
+
+    //! Return a pointer to the NeighborList used in the last call to compute.
+    locality::NeighborList *getNList()
+    {
+        return &m_nlist;
     }
 
 private:
@@ -79,6 +86,7 @@ private:
     bool m_negative_m;    //!< true if we should compute Ylm for negative m
     unsigned int m_n_points;  //!< Last number of points computed
     unsigned int m_nSphs; //!< Last number of bond spherical harmonics computed
+    locality::NeighborList m_nlist; //!< The NeighborList used in the last call to compute.
 
     //! Spherical harmonics for each neighbor
     util::ManagedArray<std::complex<float>> m_sphArray;

--- a/cpp/environment/LocalDescriptors.h
+++ b/cpp/environment/LocalDescriptors.h
@@ -36,7 +36,8 @@ public:
     //!
     //! \param l_max Maximum spherical harmonic l to consider
     //! \param negative_m whether to calculate Ylm for negative m
-    LocalDescriptors(unsigned int l_max, bool negative_m);
+    LocalDescriptors(unsigned int l_max, bool negative_m,
+                     LocalDescriptorOrientation orientation);
 
     //! Get the last number of spherical harmonics computed
     unsigned int getNSphs() const
@@ -54,7 +55,7 @@ public:
     //! positions and the number of particles
     void compute(const locality::NeighborQuery *nq,
         const vec3<float>* query_points, unsigned int n_query_points,
-        const quat<float>* orientations, LocalDescriptorOrientation orientation,
+        const quat<float>* orientations,
         const freud::locality::NeighborList* nlist, locality::QueryArgs qargs);
 
     //! Get a reference to the last computed spherical harmonic array
@@ -75,11 +76,17 @@ public:
         return &m_nlist;
     }
 
+    LocalDescriptorOrientation getMode() const
+    {
+        return m_orientation;
+    }
+
 private:
     unsigned int m_l_max;  //!< Maximum spherical harmonic l to calculate
     bool m_negative_m;    //!< true if we should compute Ylm for negative m
     unsigned int m_nSphs; //!< Last number of bond spherical harmonics computed
     locality::NeighborList m_nlist; //!< The NeighborList used in the last call to compute.
+    LocalDescriptorOrientation m_orientation; //!< The NeighborList used in the last call to compute.
 
     //! Spherical harmonics for each neighbor
     util::ManagedArray<std::complex<float>> m_sphArray;

--- a/cpp/environment/LocalDescriptors.h
+++ b/cpp/environment/LocalDescriptors.h
@@ -86,7 +86,7 @@ private:
     bool m_negative_m;    //!< true if we should compute Ylm for negative m
     unsigned int m_nSphs; //!< Last number of bond spherical harmonics computed
     locality::NeighborList m_nlist; //!< The NeighborList used in the last call to compute.
-    LocalDescriptorOrientation m_orientation; //!< The NeighborList used in the last call to compute.
+    LocalDescriptorOrientation m_orientation; //!< The orientation mode to compute with.
 
     //! Spherical harmonics for each neighbor
     util::ManagedArray<std::complex<float>> m_sphArray;

--- a/cpp/environment/LocalDescriptors.h
+++ b/cpp/environment/LocalDescriptors.h
@@ -58,7 +58,7 @@ public:
         const freud::locality::NeighborList* nlist, locality::QueryArgs qargs);
 
     //! Get a reference to the last computed spherical harmonic array
-    util::ManagedArray<std::complex<float>> &getSph()
+    const util::ManagedArray<std::complex<float>> &getSph() const
     {
         return m_sphArray;
     }

--- a/cpp/environment/LocalDescriptors.h
+++ b/cpp/environment/LocalDescriptors.h
@@ -8,6 +8,7 @@
 
 #include "Box.h"
 #include "ManagedArray.h"
+#include "NeighborQuery.h"
 #include "NeighborList.h"
 #include "VectorMath.h"
 #include "fsph/src/spherical_harmonics.hpp"
@@ -57,11 +58,10 @@ public:
 
     //! Compute the local neighborhood descriptors given some
     //! positions and the number of particles
-    void compute(const box::Box& box, unsigned int num_neighbors,
-        const vec3<float>* points, unsigned int n_points,
+    void compute(const locality::NeighborQuery *nq,
         const vec3<float>* query_points, unsigned int n_query_points,
         const quat<float>* orientations, LocalDescriptorOrientation orientation,
-        const freud::locality::NeighborList* nlist);
+        const freud::locality::NeighborList* nlist, locality::QueryArgs qargs);
 
     //! Get a reference to the last computed spherical harmonic array
     util::ManagedArray<std::complex<float>> &getSph()

--- a/cpp/locality/NeighborComputeFunctional.cc
+++ b/cpp/locality/NeighborComputeFunctional.cc
@@ -1,0 +1,27 @@
+#include "NeighborComputeFunctional.h"
+
+/*! \file NeighborComputeFunctional.h
+    \brief Implements logic for generic looping over neighbors and applying a compute function.
+*/
+
+namespace freud { namespace locality {
+
+
+//! Make a default NeighborList object to use.
+/*! This function makes a NeighborList from the provided NeighborQuery object
+ * if the provided NeighborList is NULL. Otherwise, it simply returns a copy of
+ * the provided NeighborList.
+ */
+NeighborList makeDefaultNlist(const NeighborQuery *nq, const NeighborList
+        *nlist, const vec3<float>* query_points, unsigned int num_query_points,
+        locality::QueryArgs qargs)
+{
+    if (nlist == NULL)
+    {
+        auto nqiter(nq->query(query_points, num_query_points, qargs));
+        nlist = nqiter->toNeighborList();
+    }
+    return NeighborList(*nlist);
+}
+
+}; }; // end namespace freud::locality

--- a/cpp/locality/NeighborComputeFunctional.cc
+++ b/cpp/locality/NeighborComputeFunctional.cc
@@ -23,6 +23,7 @@ NeighborList makeDefaultNlist(const NeighborQuery *nq, const NeighborList
     }
     locality::NeighborList new_nlist = NeighborList(*nlist);
     new_nlist.validate(num_query_points, nq->getNPoints());
+    return new_nlist;
 }
 
 }; }; // end namespace freud::locality

--- a/cpp/locality/NeighborComputeFunctional.cc
+++ b/cpp/locality/NeighborComputeFunctional.cc
@@ -21,7 +21,8 @@ NeighborList makeDefaultNlist(const NeighborQuery *nq, const NeighborList
         auto nqiter(nq->query(query_points, num_query_points, qargs));
         nlist = nqiter->toNeighborList();
     }
-    return NeighborList(*nlist);
+    locality::NeighborList new_nlist = NeighborList(*nlist);
+    new_nlist.validate(num_query_points, nq->getNPoints());
 }
 
 }; }; // end namespace freud::locality

--- a/cpp/locality/NeighborComputeFunctional.h
+++ b/cpp/locality/NeighborComputeFunctional.h
@@ -15,6 +15,15 @@
 
 namespace freud { namespace locality {
 
+//! Make a default NeighborList object to use.
+/*! This function makes a NeighborList from the provided NeighborQuery object
+ * if the provided NeighborList is NULL. Otherwise, it simply returns a copy of
+ * the provided NeighborList.
+ */
+NeighborList makeDefaultNlist(const NeighborQuery *nq, const NeighborList
+        *nlist, const vec3<float>* query_points, unsigned int num_query_points,
+        locality::QueryArgs qargs);
+
 //! Implementation of per-point finding logic for NeighborList objects.
 /*! This class provides a concrete implementation of the per-point neighbor
  *  finding interface specified by the NeighborPerPointIterator. In particular,
@@ -182,8 +191,6 @@ void loopOverNeighbors(const NeighborQuery* neighbor_query, const vec3<float>* q
         }, parallel);
     }
 }
-
-
 
 }; }; // end namespace freud::locality
 

--- a/cpp/locality/NeighborList.cc
+++ b/cpp/locality/NeighborList.cc
@@ -19,9 +19,9 @@ NeighborList::NeighborList(unsigned int num_bonds)
 
 NeighborList::NeighborList(const NeighborList& other)
     : m_num_query_points(other.m_num_query_points), m_num_points(other.m_num_points),
-    m_neighbors(other.m_neighbors), m_distances(other.m_distances),
-    m_weights(other.m_weights), m_segments_counts_updated(false)
+      m_segments_counts_updated(false)
 {
+    copy(other);
 }
 
 NeighborList::NeighborList(unsigned int num_bonds, const unsigned int* query_point_index,
@@ -176,9 +176,9 @@ void NeighborList::resize(unsigned int num_bonds)
 void NeighborList::copy(const NeighborList& other)
 {
     setNumBonds(other.getNumBonds(), other.getNumQueryPoints(), other.getNumPoints());
-    m_neighbors = other.m_neighbors;
-    m_weights = other.m_weights;
-    m_distances = other.m_distances;
+    m_neighbors = other.m_neighbors.copy();
+    m_weights = other.m_weights.copy();
+    m_distances = other.m_distances.copy();
     m_segments_counts_updated = false;
 }
 

--- a/cpp/locality/NeighborList.h
+++ b/cpp/locality/NeighborList.h
@@ -31,7 +31,7 @@ public:
     NeighborList();
     //! Create a NeighborList that can hold up to the given number of bonds
     NeighborList(unsigned int max_bonds);
-    //! Copy constructor
+    //! Copy constructor (makes a deep copy)
     NeighborList(const NeighborList& other);
     //! Construct from arrays
     NeighborList(unsigned int num_bonds, const unsigned int* query_point_index,

--- a/cpp/order/Cubatic.h
+++ b/cpp/order/Cubatic.h
@@ -114,7 +114,7 @@ public:
         return m_cubatic_orientation;
     }
 
-protected:
+private:
 
     //! Calculate the cubatic tensor
     /*! Implements the second line of eq. 27, the calculation of M_{\omega}.
@@ -159,7 +159,6 @@ protected:
     quat<float> calcRandomQuaternion(Saru& saru, float angle_multiplier) const;
 
 
-private:
     float m_t_initial;         //!< Initial temperature for simulated annealing.
     float m_t_final;           //!< Final temperature for simulated annealing.
     float m_scale;             //!< Scaling factor to reduce temperature.

--- a/cpp/order/Cubatic.h
+++ b/cpp/order/Cubatic.h
@@ -69,47 +69,47 @@ public:
     void compute(quat<float>* orientations, unsigned int num_orientations);
 
     //! Get a reference to the last computed cubatic order parameter
-    float getCubaticOrderParameter()
+    float getCubaticOrderParameter() const
     {
         return m_cubatic_order_parameter;
     }
 
-    const util::ManagedArray<float> &getParticleOrderParameter()
+    const util::ManagedArray<float> &getParticleOrderParameter() const
     {
         return m_particle_order_parameter;
     }
 
-    const util::ManagedArray<float> &getGlobalTensor()
+    const util::ManagedArray<float> &getGlobalTensor() const
     {
         return m_global_tensor;
     }
 
-    const util::ManagedArray<float> &getCubaticTensor()
+    const util::ManagedArray<float> &getCubaticTensor() const
     {
         return m_cubatic_tensor;
     }
 
-    unsigned int getNumParticles()
+    unsigned int getNumParticles() const
     {
         return m_n;
     }
 
-    float getTInitial()
+    float getTInitial() const
     {
         return m_t_initial;
     }
 
-    float getTFinal()
+    float getTFinal() const
     {
         return m_t_final;
     }
 
-    float getScale()
+    float getScale() const
     {
         return m_scale;
     }
 
-    quat<float> getCubaticOrientation()
+    quat<float> getCubaticOrientation() const
     {
         return m_cubatic_orientation;
     }

--- a/cpp/order/Nematic.cc
+++ b/cpp/order/Nematic.cc
@@ -17,17 +17,17 @@ Nematic::Nematic(vec3<float> u)
     : m_n(0), m_u(u / std::sqrt(dot(u, u)))
 {}
 
-float Nematic::getNematicOrderParameter()
+float Nematic::getNematicOrderParameter() const
 {
     return m_nematic_order_parameter;
 }
 
-const util::ManagedArray<float> &Nematic::getParticleTensor()
+const util::ManagedArray<float> &Nematic::getParticleTensor() const
 {
     return m_particle_tensor;
 }
 
-const util::ManagedArray<float> &Nematic::getNematicTensor()
+const util::ManagedArray<float> &Nematic::getNematicTensor() const
 {
     return m_nematic_tensor;
 }

--- a/cpp/order/Nematic.cc
+++ b/cpp/order/Nematic.cc
@@ -32,17 +32,17 @@ const util::ManagedArray<float> &Nematic::getNematicTensor() const
     return m_nematic_tensor;
 }
 
-unsigned int Nematic::getNumParticles()
+unsigned int Nematic::getNumParticles() const
 {
     return m_n;
 }
 
-vec3<float> Nematic::getNematicDirector()
+vec3<float> Nematic::getNematicDirector() const
 {
     return m_nematic_director;
 }
 
-vec3<float> Nematic::getU()
+vec3<float> Nematic::getU() const
 {
     return m_u;
 }

--- a/cpp/order/Nematic.h
+++ b/cpp/order/Nematic.h
@@ -32,11 +32,11 @@ public:
     void compute(quat<float>* orientations, unsigned int n);
 
     //! Get the value of the last computed nematic order parameter
-    float getNematicOrderParameter();
+    float getNematicOrderParameter() const;
 
-    const util::ManagedArray<float> &getParticleTensor();
+    const util::ManagedArray<float> &getParticleTensor() const;
 
-    const util::ManagedArray<float> &getNematicTensor();
+    const util::ManagedArray<float> &getNematicTensor() const;
 
     unsigned int getNumParticles();
 

--- a/cpp/order/Nematic.h
+++ b/cpp/order/Nematic.h
@@ -38,11 +38,11 @@ public:
 
     const util::ManagedArray<float> &getNematicTensor() const;
 
-    unsigned int getNumParticles();
+    unsigned int getNumParticles() const;
 
-    vec3<float> getNematicDirector();
+    vec3<float> getNematicDirector() const;
 
-    vec3<float> getU();
+    vec3<float> getU() const;
 
 private:
     unsigned int m_n;                //!< Last number of points computed

--- a/cpp/order/RotationalAutocorrelation.h
+++ b/cpp/order/RotationalAutocorrelation.h
@@ -66,25 +66,25 @@ public:
     ~RotationalAutocorrelation() {}
 
     //! Get the quantum number l used in calculations.
-    unsigned int getL()
+    unsigned int getL() const
     {
         return m_l;
     }
 
     //! Get the number of orientations used in the last call to compute.
-    unsigned int getN()
+    unsigned int getN() const
     {
         return m_N;
     }
 
     //! Get a reference to the last computed rotational autocorrelation array.
-    const util::ManagedArray<std::complex<float>> &getRAArray()
+    const util::ManagedArray<std::complex<float>> &getRAArray() const
     {
         return m_RA_array;
     }
 
     //! Get a reference to the last computed value of the rotational autocorrelation.
-    float getRotationalAutocorrelation()
+    float getRotationalAutocorrelation() const
     {
         return m_Ft;
     }

--- a/cpp/order/SolidLiquid.cc
+++ b/cpp/order/SolidLiquid.cc
@@ -24,7 +24,6 @@ void SolidLiquid::compute(const freud::locality::NeighborList* nlist,
 {
     // This function requires a NeighborList object, so we always make one and store it locally.
     m_nlist = locality::makeDefaultNlist(points, nlist, points->getPoints(), points->getNPoints(), qargs);
-    m_nlist.validate(points->getNPoints(), points->getNPoints());
 
     const unsigned int num_query_points(m_nlist.getNumQueryPoints());
 

--- a/cpp/order/SolidLiquid.cc
+++ b/cpp/order/SolidLiquid.cc
@@ -4,6 +4,7 @@
 #include <stdexcept>
 
 #include "SolidLiquid.h"
+#include "NeighborComputeFunctional.h"
 
 namespace freud { namespace order {
 
@@ -21,32 +22,29 @@ SolidLiquid::SolidLiquid(unsigned int l, float Q_threshold, unsigned int S_thres
 void SolidLiquid::compute(const freud::locality::NeighborList* nlist,
         const freud::locality::NeighborQuery* points, freud::locality::QueryArgs qargs)
 {
-    // Make NeighborList from NeighborQuery if not provided
-    if (nlist == NULL)
-    {
-        auto nqiter(points->query(points->getPoints(), points->getNPoints(), qargs));
-        nlist = nqiter->toNeighborList();
-    }
+    // This function requires a NeighborList object, so we always make one and store it locally.
+    m_nlist = locality::makeDefaultNlist(points, nlist, points->getPoints(), points->getNPoints(), qargs);
+    m_nlist.validate(points->getNPoints(), points->getNPoints());
 
-    const unsigned int num_query_points(nlist->getNumQueryPoints());
+    const unsigned int num_query_points(m_nlist.getNumQueryPoints());
 
     // Compute Steinhardt using neighbor list (also gets Ql for normalization)
-    m_steinhardt.compute(nlist, points, qargs);
+    m_steinhardt.compute(&m_nlist, points, qargs);
     const auto& Qlm = m_steinhardt.getQlm();
     const auto& Ql = m_steinhardt.getQl();
 
     // Compute (normalized) dot products for each bond in the neighbor list
     const float normalizationfactor = float(4 * M_PI / m_num_ms);
-    const unsigned int num_bonds(nlist->getNumBonds());
+    const unsigned int num_bonds(m_nlist.getNumBonds());
     m_Ql_ij.prepare(num_bonds);
 
     util::forLoopWrapper(0, num_query_points, [=](size_t begin, size_t end) {
         for (unsigned int i = begin; i != end; ++i)
         {
-            unsigned int bond(nlist->find_first_index(i));
-            for (; bond < num_bonds && nlist->getNeighbors()(bond, 0) == i; ++bond)
+            unsigned int bond(m_nlist.find_first_index(i));
+            for (; bond < num_bonds && m_nlist.getNeighbors()(bond, 0) == i; ++bond)
             {
-                const unsigned int j(nlist->getNeighbors()(bond, 1));
+                const unsigned int j(m_nlist.getNeighbors()(bond, 1));
 
                 // Accumulate the dot product over m of Qlmi and Qlmj vectors
                 std::complex<float> bond_Ql_ij = 0;
@@ -72,7 +70,7 @@ void SolidLiquid::compute(const freud::locality::NeighborList* nlist,
     {
         solid_filter[bond] = (m_Ql_ij[bond] > m_Q_threshold);
     }
-    freud::locality::NeighborList solid_nlist(*nlist);
+    freud::locality::NeighborList solid_nlist(m_nlist);
     solid_nlist.filter(solid_filter.get());
 
     // Save the neighbor counts of solid-like bonds for each query point

--- a/cpp/order/SolidLiquid.h
+++ b/cpp/order/SolidLiquid.h
@@ -113,7 +113,7 @@ public:
     }
 
     //! Get a reference to the number of connections per particle
-    const util::ManagedArray<unsigned int> &getNumberOfConnections()
+    const util::ManagedArray<unsigned int> &getNumberOfConnections() const
     {
         return m_number_of_connections;
     }
@@ -127,6 +127,12 @@ public:
     locality::NeighborList *getNList()
     {
         return &m_nlist;
+    }
+
+    //! Return the Ql_ij values.
+    const util::ManagedArray<float> &getQlij() const
+    {
+        return m_Ql_ij;
     }
 
 private:

--- a/cpp/order/SolidLiquid.h
+++ b/cpp/order/SolidLiquid.h
@@ -63,22 +63,22 @@ public:
      */
     SolidLiquid(unsigned int l, float Q_threshold, unsigned int S_threshold, bool normalize_Q=true);
 
-    unsigned int getL()
+    unsigned int getL() const
     {
         return m_l;
     }
 
-    float getQThreshold()
+    float getQThreshold() const
     {
         return m_Q_threshold;
     }
 
-    unsigned int getSThreshold()
+    unsigned int getSThreshold() const
     {
         return m_S_threshold;
     }
 
-    bool getNormalizeQ()
+    bool getNormalizeQ() const
     {
         return m_normalize_Q;
     }
@@ -88,13 +88,13 @@ public:
             const freud::locality::NeighborQuery* points, freud::locality::QueryArgs qargs);
 
     //! Returns largest cluster size.
-    unsigned int getLargestClusterSize()
+    unsigned int getLargestClusterSize() const
     {
         return m_cluster.getClusterKeys()[0].size();
     }
 
     //! Returns a vector containing the size of all clusters.
-    std::vector<unsigned int> getClusterSizes()
+    std::vector<unsigned int> getClusterSizes() const
     {
         std::vector<unsigned int> sizes;
         auto keys = m_cluster.getClusterKeys();
@@ -107,7 +107,7 @@ public:
 
     //! Get a reference to the last computed set of solid-like cluster
     //  indices for each particle
-    const util::ManagedArray<unsigned int> &getClusterIdx()
+    const util::ManagedArray<unsigned int> &getClusterIdx() const
     {
         return m_cluster.getClusterIdx();
     }
@@ -118,7 +118,7 @@ public:
         return m_number_of_connections;
     }
 
-    unsigned int getNumClusters()
+    unsigned int getNumClusters() const
     {
         return m_cluster.getNumClusters();
     }

--- a/cpp/order/SolidLiquid.h
+++ b/cpp/order/SolidLiquid.h
@@ -123,12 +123,19 @@ public:
         return m_cluster.getNumClusters();
     }
 
+    //! Return a pointer to the NeighborList used in the last call to compute.
+    locality::NeighborList *getNList()
+    {
+        return &m_nlist;
+    }
+
 private:
     unsigned int m_l;                       //!< Value of l for the spherical harmonic.
     unsigned int m_num_ms;                  //!< The number of magnetic quantum numbers (2*m_l+1).
     float m_Q_threshold;                    //!< Dot product cutoff
     unsigned int m_S_threshold;             //!< Solid-like num connections cutoff
     bool m_normalize_Q;                     //!< Whether to normalize the Qlmi dot products.
+    locality::NeighborList m_nlist; //!< The NeighborList used in the last call to compute.
 
     freud::order::Steinhardt m_steinhardt;  //!< Steinhardt class used to compute Qlm
     freud::cluster::Cluster m_cluster;      //!< Cluster class used to cluster solid-like bonds

--- a/cpp/pmft/PMFTR12.h
+++ b/cpp/pmft/PMFTR12.h
@@ -29,12 +29,6 @@ public:
     //! helper function to reduce the thread specific arrays into one array
     virtual void reducePCF();
 
-    //! Get a reference to the jacobian array
-    const util::ManagedArray<float> &getInverseJacobian()
-    {
-        return m_inv_jacobian_array;
-    }
-
 private:
     util::ManagedArray<float> m_inv_jacobian_array; //!< Array of inverse jacobians for each bin
 };

--- a/cpp/pmft/PMFTXY2D.h
+++ b/cpp/pmft/PMFTXY2D.h
@@ -30,12 +30,6 @@ public:
     //! helper function to reduce the thread specific arrays into one array
     virtual void reducePCF();
 
-    //! Get the jacobian determinant (not the matrix)
-    float getJacobian()
-    {
-        return m_jacobian;
-    }
-
 private:
     float m_jacobian;   //!< Determinant of Jacobian, bin area
 };

--- a/cpp/pmft/PMFTXYT.h
+++ b/cpp/pmft/PMFTXYT.h
@@ -29,11 +29,6 @@ public:
     //! helper function to reduce the thread specific arrays into one array
     virtual void reducePCF();
 
-    float getJacobian()
-    {
-        return m_jacobian;
-    }
-
 private:
     float m_jacobian;
 };

--- a/cpp/pmft/PMFTXYZ.h
+++ b/cpp/pmft/PMFTXYZ.h
@@ -32,11 +32,6 @@ public:
     //! helper function to reduce the thread specific arrays into one array
     virtual void reducePCF();
 
-    float getJacobian()
-    {
-        return m_jacobian;
-    }
-
 private:
     float m_jacobian;
     vec3<float> m_shiftvec; //!< vector that points from [0,0,0] to the origin of the pmft

--- a/cpp/registration/brute_force.h
+++ b/cpp/registration/brute_force.h
@@ -21,12 +21,13 @@
 #include "Eigen/Eigen/Sparse"
 
 #include "BiMap.h"
+#include "VectorMath.h"
 
 namespace freud { namespace registration {
 
 typedef Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> matrix;
 
-inline matrix makeEigenMatrix(const std::vector<vec3<float>>& vecs)
+inline matrix makeEigenMatrix(const std::vector<vec3<float> >& vecs)
 {
     // build the Eigen matrix
     matrix mat;

--- a/cpp/util/Histogram.h
+++ b/cpp/util/Histogram.h
@@ -323,7 +323,7 @@ public:
     }
 
     //! Get the computed histogram.
-    const ManagedArray<T> &getBinCounts()
+    const ManagedArray<T> &getBinCounts() const
     {
         return m_bin_counts;
     }

--- a/cpp/util/ManagedArray.h
+++ b/cpp/util/ManagedArray.h
@@ -315,6 +315,19 @@ public:
         return idx;
     }
 
+    //! Return a copy of this array.
+    /*! The returned object is a deep copy in the sense that it will copy every
+     * element of the stored array. However, if the stored elements are
+     * themselves pointers (e.g. if you create a ManagedArray<int*>), then the
+     * copy will also retain pointers to that data.
+     */
+    ManagedArray copy() const
+    {
+        ManagedArray newarray(shape());
+        for (unsigned int i = 0; i < size(); ++i)
+            newarray[i] = get()[i];
+        return newarray;
+    }
 
 private:
 

--- a/doc/source/density.rst
+++ b/doc/source/density.rst
@@ -7,8 +7,7 @@ Density Module
 .. autosummary::
     :nosignatures:
 
-    freud.density.FloatCF
-    freud.density.ComplexCF
+    freud.density.CorrelationFunction
     freud.density.GaussianDensity
     freud.density.LocalDensity
     freud.density.RDF
@@ -21,10 +20,10 @@ Density Module
 Correlation Functions
 =====================
 
-.. autoclass:: freud.density.FloatCF(r_max, dr)
+.. autoclass:: freud.density.CorrelationFunction(r_max, dr)
     :members: accumulate, compute, reset, plot
 
-.. autoclass:: freud.density.ComplexCF(r_max, dr)
+.. autoclass:: freud.density.CorrelationFunction(r_max, dr)
     :members: accumulate, compute, reset, plot
 
 Gaussian Density

--- a/doc/source/environment.rst
+++ b/doc/source/environment.rst
@@ -12,7 +12,8 @@ Environment Module
     freud.environment.BondOrder
     freud.environment.LocalDescriptors
     freud.environment.MatchEnv
-    freud.environment.AngularSeparation
+    freud.environment.AngularSeparationGlobal
+    freud.environment.AngularSeparationNeighbor
     freud.environment.LocalBondProjection
 
 .. rubric:: Details
@@ -41,8 +42,11 @@ Match Environments
 Angular Separation
 ==================
 
-.. autoclass:: freud.environment.AngularSeparation(r_max, num_neighbors)
-    :members: computeGlobal, computeNeighbor
+.. autoclass:: freud.environment.AngularSeparationGlobal()
+    :members: compute
+
+.. autoclass:: freud.environment.AngularSeparationNeighbor()
+    :members: compute
 
 Local Bond Projection
 =====================

--- a/freud/_box.pxd
+++ b/freud/_box.pxd
@@ -35,13 +35,17 @@ cdef extern from "Box.h" namespace "freud::box":
         float getTiltFactorYZ() const
 
         float getVolume() const
-        void makeCoordinates(vec3[float]*, unsigned int) except +
-        void makeFraction(vec3[float]*, unsigned int) except +
-        void getImage(vec3[float]*, unsigned int, vec3[int]*) except +
+        void makeCoordinates(vec3[float]*, unsigned int) const
+        void makeFraction(vec3[float]*, unsigned int) const
+        void getImage(vec3[float]*, unsigned int, vec3[int]*) const
+        # Note that getLatticeVector is a const function, but due to Cython
+        # parsing limitations we cannot have it both be const and pass the
+        # exception back to Cython so we choose to capture the exception since
+        # constness is less important on the Cython side.
         vec3[float] getLatticeVector(unsigned int i) except +
-        void wrap(vec3[float]* vs, unsigned int Nv) except +
+        void wrap(vec3[float]* vs, unsigned int Nv) const
         void unwrap(vec3[float]*, const vec3[int]*,
-                    unsigned int) except +
+                    unsigned int) const
 
         vec3[bool_t] getPeriodic() const
         bool_t getPeriodicX() const
@@ -63,5 +67,5 @@ cdef extern from "ParticleBuffer.h" namespace "freud::box":
             const unsigned int,
             const vec3[float],
             const bool_t) except +
-        vector[vec3[float]] getBufferParticles()
-        vector[uint] getBufferIds()
+        vector[vec3[float]] getBufferParticles() const
+        vector[uint] getBufferIds() const

--- a/freud/_box.pxd
+++ b/freud/_box.pxd
@@ -42,8 +42,8 @@ cdef extern from "Box.h" namespace "freud::box":
         # parsing limitations we cannot have it both be const and pass the
         # exception back to Cython so we choose to capture the exception since
         # constness is less important on the Cython side.
-        vec3[float] getLatticeVector(unsigned int i) except +
-        void wrap(vec3[float]* vs, unsigned int Nv) const
+        vec3[float] getLatticeVector(unsigned int) except +
+        void wrap(vec3[float]*, unsigned int) const
         void unwrap(vec3[float]*, const vec3[int]*,
                     unsigned int) const
 

--- a/freud/_cluster.pxd
+++ b/freud/_cluster.pxd
@@ -14,10 +14,10 @@ cdef extern from "Cluster.h" namespace "freud::cluster":
                      const freud._locality.NeighborList*,
                      freud._locality.QueryArgs,
                      const unsigned int*) except +
-        unsigned int getNumClusters()
-        unsigned int getNumParticles()
-        const freud.util.ManagedArray[unsigned int] &getClusterIdx()
-        const vector[vector[uint]] getClusterKeys()
+        unsigned int getNumClusters() const
+        unsigned int getNumParticles() const
+        const freud.util.ManagedArray[unsigned int] &getClusterIdx() const
+        const vector[vector[uint]] getClusterKeys() const
 
 cdef extern from "ClusterProperties.h" namespace "freud::cluster":
     cdef cppclass ClusterProperties:
@@ -27,7 +27,7 @@ cdef extern from "ClusterProperties.h" namespace "freud::cluster":
             const vec3[float]*,
             const unsigned int*,
             unsigned int) except +
-        unsigned int getNumClusters()
-        const freud.util.ManagedArray[vec3[float]] &getClusterCOM()
-        const freud.util.ManagedArray[float] &getClusterG()
-        const freud.util.ManagedArray[unsigned int] &getClusterSize()
+        unsigned int getNumClusters() const
+        const freud.util.ManagedArray[vec3[float]] &getClusterCOM() const
+        const freud.util.ManagedArray[float] &getClusterG() const
+        const freud.util.ManagedArray[unsigned int] &getClusterSize() const

--- a/freud/_density.pxd
+++ b/freud/_density.pxd
@@ -33,8 +33,8 @@ cdef extern from "GaussianDensity.h" namespace "freud::density":
             const vec3[float]*,
             unsigned int) except +
         const freud.util.ManagedArray[float] &getDensity()
-        vec3[unsigned int] getWidth()
-        float getSigma()
+        vec3[unsigned int] getWidth() const
+        float getSigma() const
         float getRMax() const
 
 cdef extern from "LocalDensity.h" namespace "freud::density":
@@ -46,9 +46,9 @@ cdef extern from "LocalDensity.h" namespace "freud::density":
             const vec3[float]*,
             unsigned int, const freud._locality.NeighborList *,
             freud._locality.QueryArgs) except +
-        unsigned int getNPoints()
-        const freud.util.ManagedArray[float] &getDensity()
-        const freud.util.ManagedArray[float] &getNumNeighbors()
+        unsigned int getNPoints() const
+        const freud.util.ManagedArray[float] &getDensity() const
+        const freud.util.ManagedArray[float] &getNumNeighbors() const
         float getRMax() const
         float getDiameter() const
 

--- a/freud/_environment.pxd
+++ b/freud/_environment.pxd
@@ -119,12 +119,11 @@ cdef extern from "AngularSeparation.h" namespace "freud::environment":
 cdef extern from "LocalBondProjection.h" namespace "freud::environment":
     cdef cppclass LocalBondProjection:
         LocalBondProjection()
-        void compute(freud._box.Box &,
-                     vec3[float]*, unsigned int,
-                     vec3[float]*, quat[float]*, unsigned int,
-                     vec3[float]*, unsigned int,
-                     quat[float]*, unsigned int,
-                     const freud._locality.NeighborList*) except +
+        void compute(const freud._locality.NeighborQuery*, quat[float]*,
+                     vec3[float]*, unsigned int, vec3[float]*, unsigned int,
+                     quat[float]*, unsigned int, const
+                     freud._locality.NeighborList*,
+                     freud._locality.QueryArgs) except +
 
         const freud.util.ManagedArray[float] &getProjections()
         const freud.util.ManagedArray[float] &getNormedProjections()

--- a/freud/_environment.pxd
+++ b/freud/_environment.pxd
@@ -41,11 +41,11 @@ cdef extern from "LocalDescriptors.h" namespace "freud::environment":
         unsigned int getSphWidth() const
         unsigned int getNPoints()
         void compute(
-            const freud._box.Box &, unsigned int,
-            const vec3[float]*, unsigned int,
+            const freud._locality.NeighborQuery*,
             const vec3[float]*, unsigned int,
             const quat[float]*, LocalDescriptorOrientation,
-            const freud._locality.NeighborList*) except +
+            const freud._locality.NeighborList*,
+            freud._locality.QueryArgs) except +
         const freud.util.ManagedArray[float complex] &getSph()
 
 cdef extern from "MatchEnv.h" namespace "freud::environment":

--- a/freud/_environment.pxd
+++ b/freud/_environment.pxd
@@ -93,21 +93,24 @@ cdef extern from "MatchEnv.h" namespace "freud::environment":
         unsigned int getMaxNumNeighbors()
 
 cdef extern from "AngularSeparation.h" namespace "freud::environment":
-    cdef cppclass AngularSeparation:
-        AngularSeparation()
-        void computeNeighbor(
+    cdef cppclass AngularSeparationGlobal:
+        AngularSeparationGlobal()
+        void compute(quat[float]*,
+                     unsigned int,
+                     quat[float]*,
+                     unsigned int,
+                     quat[float]*,
+                     unsigned int) except +
+        const freud.util.ManagedArray[float] &getAngles()
+
+    cdef cppclass AngularSeparationNeighbor:
+        AngularSeparationNeighbor()
+        void compute(
             quat[float]*, unsigned int,
             quat[float]*, unsigned int,
             quat[float]*, unsigned int,
             const freud._locality.NeighborList*) except +
-        void computeGlobal(quat[float]*,
-                           unsigned int,
-                           quat[float]*,
-                           unsigned int,
-                           quat[float]*,
-                           unsigned int) except +
-        const freud.util.ManagedArray[float] &getNeighborAngles()
-        const freud.util.ManagedArray[float] &getGlobalAngles()
+        const freud.util.ManagedArray[float] &getAngles()
 
 cdef extern from "LocalBondProjection.h" namespace "freud::environment":
     cdef cppclass LocalBondProjection:

--- a/freud/_environment.pxd
+++ b/freud/_environment.pxd
@@ -131,3 +131,4 @@ cdef extern from "LocalBondProjection.h" namespace "freud::environment":
         unsigned int getNQueryPoints()
         unsigned int getNproj()
         const freud._box.Box & getBox() const
+        freud._locality.NeighborList * getNList()

--- a/freud/_environment.pxd
+++ b/freud/_environment.pxd
@@ -47,6 +47,7 @@ cdef extern from "LocalDescriptors.h" namespace "freud::environment":
             const freud._locality.NeighborList*,
             freud._locality.QueryArgs) except +
         const freud.util.ManagedArray[float complex] &getSph()
+        freud._locality.NeighborList * getNList()
 
 cdef extern from "MatchEnv.h" namespace "freud::environment":
     cdef cppclass MatchEnv:

--- a/freud/_environment.pxd
+++ b/freud/_environment.pxd
@@ -31,6 +31,7 @@ cdef extern from "BondOrder.h" namespace "freud::environment":
             const freud._locality.NeighborList*,
             freud._locality.QueryArgs)
         const freud.util.ManagedArray[float] &getBondOrder()
+        BondOrderMode getMode() const
 
 cdef extern from "LocalDescriptors.h" namespace "freud::environment":
     ctypedef enum LocalDescriptorOrientation:

--- a/freud/_environment.pxd
+++ b/freud/_environment.pxd
@@ -127,8 +127,4 @@ cdef extern from "LocalBondProjection.h" namespace "freud::environment":
 
         const freud.util.ManagedArray[float] &getProjections()
         const freud.util.ManagedArray[float] &getNormedProjections()
-        unsigned int getNPoints()
-        unsigned int getNQueryPoints()
-        unsigned int getNproj()
-        const freud._box.Box & getBox() const
         freud._locality.NeighborList * getNList()

--- a/freud/_environment.pxd
+++ b/freud/_environment.pxd
@@ -14,14 +14,19 @@ cimport freud._locality
 cimport freud.util
 
 cdef extern from "BondOrder.h" namespace "freud::environment":
+    ctypedef enum BondOrderMode:
+        bod
+        lbod
+        obcd
+        oocd
+
     cdef cppclass BondOrder(BondHistogramCompute):
-        BondOrder(unsigned int, unsigned int) except +
+        BondOrder(unsigned int, unsigned int, BondOrderMode) except +
         void accumulate(
             const freud._locality.NeighborQuery*,
             quat[float]*,
             vec3[float]*,
             quat[float]*,
-            unsigned int,
             unsigned int,
             const freud._locality.NeighborList*,
             freud._locality.QueryArgs)

--- a/freud/_environment.pxd
+++ b/freud/_environment.pxd
@@ -45,7 +45,7 @@ cdef extern from "LocalDescriptors.h" namespace "freud::environment":
             const quat[float]*, LocalDescriptorOrientation,
             const freud._locality.NeighborList*,
             freud._locality.QueryArgs) except +
-        const freud.util.ManagedArray[float complex] &getSph()
+        const freud.util.ManagedArray[float complex] &getSph() const
         freud._locality.NeighborList * getNList()
 
 cdef extern from "MatchEnv.h" namespace "freud::environment":
@@ -100,7 +100,7 @@ cdef extern from "AngularSeparation.h" namespace "freud::environment":
                      unsigned int,
                      quat[float]*,
                      unsigned int) except +
-        const freud.util.ManagedArray[float] &getAngles()
+        const freud.util.ManagedArray[float] &getAngles() const
 
     cdef cppclass AngularSeparationNeighbor:
         AngularSeparationNeighbor()
@@ -112,7 +112,7 @@ cdef extern from "AngularSeparation.h" namespace "freud::environment":
             const quat[float]*, unsigned int,
             const freud._locality.NeighborList*,
             freud._locality.QueryArgs) except +
-        const freud.util.ManagedArray[float] &getAngles()
+        const freud.util.ManagedArray[float] &getAngles() const
         freud._locality.NeighborList * getNList()
 
 cdef extern from "LocalBondProjection.h" namespace "freud::environment":
@@ -124,6 +124,6 @@ cdef extern from "LocalBondProjection.h" namespace "freud::environment":
                      freud._locality.NeighborList*,
                      freud._locality.QueryArgs) except +
 
-        const freud.util.ManagedArray[float] &getProjections()
-        const freud.util.ManagedArray[float] &getNormedProjections()
+        const freud.util.ManagedArray[float] &getProjections() const
+        const freud.util.ManagedArray[float] &getNormedProjections() const
         freud._locality.NeighborList * getNList()

--- a/freud/_environment.pxd
+++ b/freud/_environment.pxd
@@ -39,7 +39,6 @@ cdef extern from "LocalDescriptors.h" namespace "freud::environment":
         unsigned int getNSphs() const
         unsigned int getLMax() const
         unsigned int getSphWidth() const
-        unsigned int getNPoints()
         void compute(
             const freud._locality.NeighborQuery*,
             const vec3[float]*, unsigned int,

--- a/freud/_environment.pxd
+++ b/freud/_environment.pxd
@@ -114,6 +114,7 @@ cdef extern from "AngularSeparation.h" namespace "freud::environment":
             const freud._locality.NeighborList*,
             freud._locality.QueryArgs) except +
         const freud.util.ManagedArray[float] &getAngles()
+        freud._locality.NeighborList * getNList()
 
 cdef extern from "LocalBondProjection.h" namespace "freud::environment":
     cdef cppclass LocalBondProjection:

--- a/freud/_environment.pxd
+++ b/freud/_environment.pxd
@@ -35,18 +35,19 @@ cdef extern from "LocalDescriptors.h" namespace "freud::environment":
 
     cdef cppclass LocalDescriptors:
         LocalDescriptors(unsigned int,
-                         bool)
+                         bool, LocalDescriptorOrientation)
         unsigned int getNSphs() const
         unsigned int getLMax() const
         unsigned int getSphWidth() const
         void compute(
             const freud._locality.NeighborQuery*,
             const vec3[float]*, unsigned int,
-            const quat[float]*, LocalDescriptorOrientation,
+            const quat[float]*,
             const freud._locality.NeighborList*,
             freud._locality.QueryArgs) except +
         const freud.util.ManagedArray[float complex] &getSph() const
         freud._locality.NeighborList * getNList()
+        LocalDescriptorOrientation getMode() const
 
 cdef extern from "MatchEnv.h" namespace "freud::environment":
     cdef cppclass MatchEnv:

--- a/freud/_environment.pxd
+++ b/freud/_environment.pxd
@@ -106,10 +106,13 @@ cdef extern from "AngularSeparation.h" namespace "freud::environment":
     cdef cppclass AngularSeparationNeighbor:
         AngularSeparationNeighbor()
         void compute(
-            quat[float]*, unsigned int,
-            quat[float]*, unsigned int,
-            quat[float]*, unsigned int,
-            const freud._locality.NeighborList*) except +
+            const freud._locality.NeighborQuery*,
+            const quat[float]*,
+            const vec3[float] *,
+            const quat[float]*, unsigned int,
+            const quat[float]*, unsigned int,
+            const freud._locality.NeighborList*,
+            freud._locality.QueryArgs) except +
         const freud.util.ManagedArray[float] &getAngles()
 
 cdef extern from "LocalBondProjection.h" namespace "freud::environment":

--- a/freud/_order.pxd
+++ b/freud/_order.pxd
@@ -96,6 +96,7 @@ cdef extern from "SolidLiquid.h" namespace "freud::order":
         const freud.util.ManagedArray[unsigned int] &getClusterIdx()
         const freud.util.ManagedArray[unsigned int] &getNumberOfConnections()
         unsigned int getNumClusters()
+        freud._locality.NeighborList * getNList()
 
 
 cdef extern from "RotationalAutocorrelation.h" namespace "freud::order":

--- a/freud/_order.pxd
+++ b/freud/_order.pxd
@@ -21,15 +21,15 @@ cdef extern from "Cubatic.h" namespace "freud::order":
         void reset()
         void compute(quat[float]*,
                      unsigned int) except +
-        unsigned int getNumParticles()
-        float getCubaticOrderParameter()
-        const freud.util.ManagedArray[float] &getParticleOrderParameter()
-        const freud.util.ManagedArray[float] &getGlobalTensor()
-        const freud.util.ManagedArray[float] &getCubaticTensor()
-        float getTInitial()
-        float getTFinal()
-        float getScale()
-        quat[float] getCubaticOrientation()
+        unsigned int getNumParticles() const
+        float getCubaticOrderParameter() const
+        const freud.util.ManagedArray[float] &getParticleOrderParameter() const
+        const freud.util.ManagedArray[float] &getGlobalTensor() const
+        const freud.util.ManagedArray[float] &getCubaticTensor() const
+        float getTInitial() const
+        float getTFinal() const
+        float getScale() const
+        quat[float] getCubaticOrientation() const
 
 
 cdef extern from "Nematic.h" namespace "freud::order":
@@ -38,12 +38,12 @@ cdef extern from "Nematic.h" namespace "freud::order":
         void reset()
         void compute(quat[float]*,
                      unsigned int) except +
-        unsigned int getNumParticles()
-        float getNematicOrderParameter()
-        const freud.util.ManagedArray[float] &getParticleTensor()
-        const freud.util.ManagedArray[float] &getNematicTensor()
-        vec3[float] getNematicDirector()
-        vec3[float] getU()
+        unsigned int getNumParticles() const
+        float getNematicOrderParameter() const
+        const freud.util.ManagedArray[float] &getParticleTensor() const
+        const freud.util.ManagedArray[float] &getNematicTensor() const
+        vec3[float] getNematicDirector() const
+        vec3[float] getU() const
 
 
 cdef extern from "HexaticTranslational.h" namespace "freud::order":
@@ -62,50 +62,51 @@ cdef extern from "HexaticTranslational.h" namespace "freud::order":
         void compute(const freud._locality.NeighborList*,
                      const freud._locality.NeighborQuery*,
                      freud._locality.QueryArgs) except +
-        const freud.util.ManagedArray[float complex] &getOrder()
-        float getK()
+        const freud.util.ManagedArray[float complex] &getOrder() const
+        float getK() const
 
 
 cdef extern from "Steinhardt.h" namespace "freud::order":
     cdef cppclass Steinhardt:
         Steinhardt(unsigned int, bool, bool, bool) except +
-        unsigned int getNP()
+        unsigned int getNP() const
         void compute(const freud._locality.NeighborList*,
                      const freud._locality.NeighborQuery*,
                      freud._locality.QueryArgs) except +
-        const freud.util.ManagedArray[float] &getQl()
-        const freud.util.ManagedArray[float] &getOrder()
-        float getNorm()
-        bool isAverage()
-        bool isWl()
-        bool isWeighted()
+        const freud.util.ManagedArray[float] &getQl() const
+        const freud.util.ManagedArray[float] &getOrder() const
+        float getNorm() const
+        bool isAverage() const
+        bool isWl() const
+        bool isWeighted() const
 
 
 cdef extern from "SolidLiquid.h" namespace "freud::order":
     cdef cppclass SolidLiquid:
         SolidLiquid(unsigned int, float, unsigned int, bool) except +
-        unsigned int getL()
-        float getQThreshold()
-        unsigned int getSThreshold()
-        bool getNormalizeQ()
+        unsigned int getL() const
+        float getQThreshold() const
+        unsigned int getSThreshold() const
+        bool getNormalizeQ() const
         void compute(const freud._locality.NeighborList*,
                      const freud._locality.NeighborQuery*,
                      freud._locality.QueryArgs) nogil except +
-        unsigned int getLargestClusterSize()
-        vector[unsigned int] getClusterSizes()
-        const freud.util.ManagedArray[unsigned int] &getClusterIdx()
-        const freud.util.ManagedArray[unsigned int] &getNumberOfConnections()
-        unsigned int getNumClusters()
+        unsigned int getLargestClusterSize() const
+        vector[unsigned int] getClusterSizes() const
+        const freud.util.ManagedArray[unsigned int] &getClusterIdx() const
+        const freud.util.ManagedArray[unsigned int] &getNumberOfConnections() \
+            const
+        unsigned int getNumClusters() const
         freud._locality.NeighborList * getNList()
-        const freud.util.ManagedArray[float] &getQlij()
+        const freud.util.ManagedArray[float] &getQlij() const
 
 
 cdef extern from "RotationalAutocorrelation.h" namespace "freud::order":
     cdef cppclass RotationalAutocorrelation:
         RotationalAutocorrelation()
         RotationalAutocorrelation(unsigned int)
-        unsigned int getL()
-        unsigned int getN()
-        const freud.util.ManagedArray[float complex] &getRAArray()
-        float getRotationalAutocorrelation()
+        unsigned int getL() const
+        unsigned int getN() const
+        const freud.util.ManagedArray[float complex] &getRAArray() const
+        float getRotationalAutocorrelation() const
         void compute(quat[float]*, quat[float]*, unsigned int) except +

--- a/freud/_order.pxd
+++ b/freud/_order.pxd
@@ -97,6 +97,7 @@ cdef extern from "SolidLiquid.h" namespace "freud::order":
         const freud.util.ManagedArray[unsigned int] &getNumberOfConnections()
         unsigned int getNumClusters()
         freud._locality.NeighborList * getNList()
+        const freud.util.ManagedArray[float] &getQlij()
 
 
 cdef extern from "RotationalAutocorrelation.h" namespace "freud::order":

--- a/freud/_util.pxd
+++ b/freud/_util.pxd
@@ -26,8 +26,8 @@ cdef extern from "ManagedArray.h" namespace "freud::util":
         ManagedArray()
         ManagedArray(const ManagedArray[T] &)
         T *get()
-        unsigned int size()
-        vector[unsigned int] shape()
+        unsigned int size() const
+        vector[unsigned int] shape() const
 
 
 cdef extern from "numpy/arrayobject.h":

--- a/freud/cluster.pyx
+++ b/freud/cluster.pyx
@@ -99,7 +99,7 @@ cdef class Cluster(PairCompute):
             unsigned int num_query_points
 
         b, nq, nlistptr, qargs, l_query_points, num_query_points = \
-            self.preprocess_arguments_new(box, points, neighbors=neighbors)
+            self.preprocess_arguments(box, points, neighbors=neighbors)
 
         cdef unsigned int* l_keys_ptr = NULL
         cdef unsigned int[::1] l_keys

--- a/freud/cluster.pyx
+++ b/freud/cluster.pyx
@@ -77,7 +77,7 @@ cdef class Cluster(PairCompute):
         del self.thisptr
 
     @Compute._compute()
-    def compute(self, box, points, keys=None, nlist=None, query_args=None):
+    def compute(self, box, points, keys=None, neighbors=None):
         R"""Compute the clusters for the given set of points.
 
         Args:
@@ -99,8 +99,7 @@ cdef class Cluster(PairCompute):
             unsigned int num_query_points
 
         b, nq, nlistptr, qargs, l_query_points, num_query_points = \
-            self.preprocess_arguments(box, points, nlist=nlist,
-                                      query_args=query_args)
+            self.preprocess_arguments_new(box, points, neighbors=neighbors)
 
         cdef unsigned int* l_keys_ptr = NULL
         cdef unsigned int[::1] l_keys

--- a/freud/density.pyx
+++ b/freud/density.pyx
@@ -115,7 +115,7 @@ cdef class CorrelationFunction(SpatialHistogram1D):
             unsigned int num_query_points
 
         b, nq, nlistptr, qargs, l_query_points, num_query_points = \
-            self.preprocess_arguments_new(box, points, query_points, neighbors)
+            self.preprocess_arguments(box, points, query_points, neighbors)
 
         # Save if any inputs have been complex so far.
         self.is_complex = self.is_complex or np.any(np.iscomplex(values)) or \
@@ -432,7 +432,7 @@ cdef class LocalDensity(PairCompute):
             unsigned int num_query_points
 
         b, nq, nlistptr, qargs, l_query_points, num_query_points = \
-            self.preprocess_arguments_new(box, points, query_points, neighbors)
+            self.preprocess_arguments(box, points, query_points, neighbors)
         self.thisptr.compute(
             nq.get_ptr(),
             <vec3[float]*> &l_query_points[0, 0],
@@ -544,7 +544,7 @@ cdef class RDF(SpatialHistogram1D):
             const float[:, ::1] l_query_points
             unsigned int num_query_points
         b, nq, nlistptr, qargs, l_query_points, num_query_points = \
-            self.preprocess_arguments_new(box, points, query_points, neighbors)
+            self.preprocess_arguments(box, points, query_points, neighbors)
 
         self.thisptr.accumulate(
             nq.get_ptr(),

--- a/freud/density.pyx
+++ b/freud/density.pyx
@@ -83,7 +83,7 @@ cdef class CorrelationFunction(SpatialHistogram1D):
 
     @Compute._compute()
     def accumulate(self, box, points, values, query_points=None,
-                   query_values=None, nlist=None, query_args=None):
+                   query_values=None, neighbors=None):
         R"""Calculates the correlation function and adds to the current
         histogram.
 
@@ -115,8 +115,7 @@ cdef class CorrelationFunction(SpatialHistogram1D):
             unsigned int num_query_points
 
         b, nq, nlistptr, qargs, l_query_points, num_query_points = \
-            self.preprocess_arguments(box, points, query_points, nlist,
-                                      query_args)
+            self.preprocess_arguments_new(box, points, query_points, neighbors)
 
         # Save if any inputs have been complex so far.
         self.is_complex = self.is_complex or np.any(np.iscomplex(values)) or \
@@ -158,7 +157,7 @@ cdef class CorrelationFunction(SpatialHistogram1D):
 
     @Compute._compute()
     def compute(self, box, points, values, query_points=None,
-                query_values=None, nlist=None, query_args=None):
+                query_values=None, neighbors=None):
         R"""Calculates the correlation function for the given points. Will
         overwrite the current histogram.
 
@@ -182,8 +181,8 @@ cdef class CorrelationFunction(SpatialHistogram1D):
                 :code:`None`).
         """  # noqa E501
         self.reset()
-        self.accumulate(box, points, values, query_points, query_values, nlist,
-                        query_args)
+        self.accumulate(box, points, values, query_points, query_values,
+                        neighbors)
         return self
 
     def __repr__(self):
@@ -407,8 +406,7 @@ cdef class LocalDensity(PairCompute):
         return freud.box.BoxFromCPP(self.thisptr.getBox())
 
     @Compute._compute()
-    def compute(self, box, points, query_points=None, nlist=None,
-                query_args=None):
+    def compute(self, box, points, query_points=None, neighbors=None):
         R"""Calculates the local density for the specified points. Does not
         accumulate (will overwrite current data).
 
@@ -434,8 +432,7 @@ cdef class LocalDensity(PairCompute):
             unsigned int num_query_points
 
         b, nq, nlistptr, qargs, l_query_points, num_query_points = \
-            self.preprocess_arguments(box, points, query_points, nlist,
-                                      query_args)
+            self.preprocess_arguments_new(box, points, query_points, neighbors)
         self.thisptr.compute(
             nq.get_ptr(),
             <vec3[float]*> &l_query_points[0, 0],
@@ -524,8 +521,7 @@ cdef class RDF(SpatialHistogram1D):
             del self.thisptr
 
     @Compute._compute()
-    def accumulate(self, box, points, query_points=None, nlist=None,
-                   query_args=None):
+    def accumulate(self, box, points, query_points=None, neighbors=None):
         R"""Calculates the RDF and adds to the current RDF histogram.
 
         Args:
@@ -548,8 +544,7 @@ cdef class RDF(SpatialHistogram1D):
             const float[:, ::1] l_query_points
             unsigned int num_query_points
         b, nq, nlistptr, qargs, l_query_points, num_query_points = \
-            self.preprocess_arguments(box, points, query_points, nlist,
-                                      query_args)
+            self.preprocess_arguments_new(box, points, query_points, neighbors)
 
         self.thisptr.accumulate(
             nq.get_ptr(),
@@ -559,8 +554,7 @@ cdef class RDF(SpatialHistogram1D):
         return self
 
     @Compute._compute()
-    def compute(self, box, points, query_points=None, nlist=None,
-                query_args=None):
+    def compute(self, box, points, query_points=None, neighbors=None):
         R"""Calculates the RDF for the specified points. Will overwrite the current
         histogram.
 
@@ -577,7 +571,7 @@ cdef class RDF(SpatialHistogram1D):
                 :code:`None`).
         """  # noqa E501
         self.reset()
-        self.accumulate(box, points, query_points, nlist, query_args)
+        self.accumulate(box, points, query_points, neighbors)
         return self
 
     @Compute._computed_property()

--- a/freud/environment.pyx
+++ b/freud/environment.pyx
@@ -1013,7 +1013,7 @@ cdef class LocalBondProjection(PairCompute):
 
     @Compute._computed_property()
     def nlist(self):
-        return self.nlist_
+        return freud.locality.nlist_from_cnlist(self.thisptr.getNList())
 
     @Compute._compute()
     def compute(self, box, proj_vecs, points,

--- a/freud/environment.pyx
+++ b/freud/environment.pyx
@@ -788,21 +788,12 @@ cdef class AngularSeparationNeighbor(PairCompute):
             are stored in the order of the neighborlist object.
     """  # noqa: E501
     cdef freud._environment.AngularSeparationNeighbor * thisptr
-    cdef unsigned int num_neighbors
-    cdef float r_max
-    cdef freud.locality.NeighborList nlist_
 
-    def __cinit__(self, float r_max, unsigned int num_neighbors):
+    def __cinit__(self):
         self.thisptr = new freud._environment.AngularSeparationNeighbor()
-        self.r_max = r_max
-        self.num_neighbors = num_neighbors
 
     def __dealloc__(self):
         del self.thisptr
-
-    @property
-    def nlist(self):
-        return self.nlist_
 
     @Compute._compute()
     def compute(self, box, points, orientations, query_points=None,
@@ -884,8 +875,12 @@ cdef class AngularSeparationNeighbor(PairCompute):
             freud.util.arr_type_t.FLOAT)
 
     def __repr__(self):
-        return "freud.environment.{cls}(r_max={r}, num_neighbors={n})".format(
-            cls=type(self).__name__, r=self.r_max, n=self.num_neighbors)
+        return "freud.environment.{cls}()".format(
+            cls=type(self).__name__)
+
+    @Compute._computed_property()
+    def nlist(self):
+        return freud.locality.nlist_from_cnlist(self.thisptr.getNList())
 
 
 cdef class AngularSeparationGlobal(Compute):
@@ -912,14 +907,9 @@ cdef class AngularSeparationGlobal(Compute):
             are stored in the order of the neighborlist object.
     """  # noqa: E501
     cdef freud._environment.AngularSeparationGlobal * thisptr
-    cdef unsigned int num_neighbors
-    cdef float r_max
-    cdef freud.locality.NeighborList nlist_
 
-    def __cinit__(self, float r_max, unsigned int num_neighbors):
+    def __cinit__(self):
         self.thisptr = new freud._environment.AngularSeparationGlobal()
-        self.r_max = r_max
-        self.num_neighbors = num_neighbors
 
     def __dealloc__(self):
         del self.thisptr
@@ -975,8 +965,8 @@ cdef class AngularSeparationGlobal(Compute):
             freud.util.arr_type_t.FLOAT)
 
     def __repr__(self):
-        return "freud.environment.{cls}(r_max={r}, num_neighbors={n})".format(
-            cls=type(self).__name__, r=self.r_max, n=self.num_neighbors)
+        return "freud.environment.{cls}()".format(
+            cls=type(self).__name__)
 
 
 cdef class LocalBondProjection(Compute):

--- a/freud/environment.pyx
+++ b/freud/environment.pyx
@@ -246,9 +246,17 @@ cdef class BondOrder(SpatialHistogram):
         return self
 
     def __repr__(self):
-        return ("freud.environment.{cls}( bins=({bins}))".format(
+        return ("freud.environment.{cls}(bins=({bins}), mode='{mode}')".format(
             cls=type(self).__name__,
-            bins=', '.join([str(b) for b in self.nbins])))
+            bins=', '.join([str(b) for b in self.nbins]),
+            mode=self.mode))
+
+    @property
+    def mode(self):
+        mode = self.thisptr.getMode()
+        for key, value in self.known_modes.items():
+            if value == mode:
+                return key
 
 
 cdef class LocalDescriptors(PairCompute):

--- a/freud/environment.pyx
+++ b/freud/environment.pyx
@@ -385,6 +385,10 @@ cdef class LocalDescriptors(PairCompute):
         return self
 
     @Compute._computed_property()
+    def nlist(self):
+        return freud.locality.nlist_from_cnlist(self.thisptr.getNList())
+
+    @Compute._computed_property()
     def sph(self):
         return freud.util.make_managed_numpy_array(
             &self.thisptr.getSph(),

--- a/freud/environment.pyx
+++ b/freud/environment.pyx
@@ -278,8 +278,6 @@ cdef class LocalDescriptors(PairCompute):
     Attributes:
         sph (:math:`\left(N_{bonds}, \text{SphWidth} \right)` :class:`numpy.ndarray`):
             A reference to the last computed spherical harmonic array.
-        num_particles (unsigned int):
-            The number of points passed to the last call to :meth:`~.compute`.
         num_sphs (unsigned int):
             The last number of spherical harmonics computed. This is equal to
             the number of bonds in the last computation, which is at most the
@@ -386,10 +384,6 @@ cdef class LocalDescriptors(PairCompute):
         return freud.util.make_managed_numpy_array(
             &self.thisptr.getSph(),
             freud.util.arr_type_t.COMPLEX_FLOAT)
-
-    @Compute._computed_property()
-    def num_particles(self):
-        return self.thisptr.getNPoints()
 
     @Compute._computed_property()
     def num_sphs(self):

--- a/freud/environment.pyx
+++ b/freud/environment.pyx
@@ -985,16 +985,9 @@ cdef class LocalBondProjection(PairCompute):
             The projection of each bond between reference particles and their
             neighbors onto each of the projection vectors.
         normed_projections ((:math:`\left(N_{reference}, N_{neighbors}, N_{projection\_vecs} \right)` :class:`numpy.ndarray`)
-            The normalized projection of each bond between reference particles
-            and their neighbors onto each of the projection vectors.
-        num_reference_particles (int):
-            The number of reference points used in the last calculation.
-        num_particles (int):
-            The number of points used in the last calculation.
-        num_proj_vectors (int):
-            The number of projection vectors used in the last calculation.
-        box (:class:`freud.box.Box`):
-            The box used in the last calculation.
+            The projection of each bond between reference particles and their
+            neighbors onto each of the projection vectors, normalized by the
+            length of the bond.
         nlist (:class:`freud.locality.NeighborList`):
             The neighbor list generated in the last calculation.
     """  # noqa: E501
@@ -1098,22 +1091,6 @@ cdef class LocalBondProjection(PairCompute):
         return freud.util.make_managed_numpy_array(
             &self.thisptr.getNormedProjections(),
             freud.util.arr_type_t.FLOAT)
-
-    @Compute._computed_property()
-    def num_points(self):
-        return self.thisptr.getNPoints()
-
-    @Compute._computed_property()
-    def num_query_points(self):
-        return self.thisptr.getNQueryPoints()
-
-    @Compute._computed_property()
-    def num_proj_vectors(self):
-        return self.thisptr.getNproj()
-
-    @Compute._computed_property()
-    def box(self):
-        return freud.box.BoxFromCPP(<freud._box.Box> self.thisptr.getBox())
 
     def __repr__(self):
         return ("freud.environment.{cls}(r_max={r_max}, "

--- a/freud/environment.pyx
+++ b/freud/environment.pyx
@@ -167,7 +167,7 @@ cdef class BondOrder(SpatialHistogram):
             unsigned int num_query_points
 
         b, nq, nlistptr, qargs, l_query_points, num_query_points = \
-            self.preprocess_arguments_new(box, points, query_points, neighbors)
+            self.preprocess_arguments(box, points, query_points, neighbors)
         if query_orientations is None:
             query_orientations = orientations
 
@@ -345,7 +345,7 @@ cdef class LocalDescriptors(PairCompute):
             unsigned int num_query_points
 
         b, nq, nlistptr, qargs, l_query_points, num_query_points = \
-            self.preprocess_arguments_new(box, points, query_points, neighbors)
+            self.preprocess_arguments(box, points, query_points, neighbors)
 
         # The l_orientations_ptr is only used for 'particle_local' mode.
         cdef const float[:, ::1] l_orientations
@@ -811,7 +811,7 @@ cdef class AngularSeparationNeighbor(PairCompute):
             unsigned int num_query_points
 
         b, nq, nlistptr, qargs, l_query_points, num_query_points = \
-            self.preprocess_arguments_new(box, points, query_points, neighbors)
+            self.preprocess_arguments(box, points, query_points, neighbors)
 
         orientations = freud.common.convert_array(
             orientations, shape=(points.shape[0], 4))
@@ -1004,7 +1004,7 @@ cdef class LocalBondProjection(PairCompute):
             unsigned int num_query_points
 
         b, nq, nlistptr, qargs, l_query_points, num_query_points = \
-            self.preprocess_arguments_new(box, points, query_points, neighbors)
+            self.preprocess_arguments(box, points, query_points, neighbors)
 
         orientations = freud.common.convert_array(
             orientations, shape=(None, 4))

--- a/freud/environment.pyx
+++ b/freud/environment.pyx
@@ -319,7 +319,7 @@ cdef class LocalDescriptors(Compute):
     @Compute._compute()
     def compute(self, box, unsigned int num_neighbors, points,
                 query_points=None,
-                orientations=None, mode='neighborhood', neighbors=None):
+                orientations=None, mode='neighborhood', nlist=None):
         R"""Calculates the local descriptors of bonds from a set of source
         points to a set of destination points.
 

--- a/freud/locality.pxd
+++ b/freud/locality.pxd
@@ -10,6 +10,7 @@ from freud.common cimport Compute
 cimport freud._locality
 cimport freud.box
 
+cdef NeighborList nlist_from_cnlist(freud._locality.NeighborList *c_nlist)
 
 cdef class NeighborQueryResult:
     cdef NeighborQuery nq

--- a/freud/locality.pxd
+++ b/freud/locality.pxd
@@ -49,9 +49,7 @@ cdef class NeighborQuery:
 cdef class NeighborList:
     cdef freud._locality.NeighborList * thisptr
     cdef char _managed
-    cdef base
 
-    cdef refer_to(self, freud._locality.NeighborList * other)
     cdef freud._locality.NeighborList * get_ptr(self)
     cdef void copy_c(self, NeighborList other)
 

--- a/freud/locality.pyx
+++ b/freud/locality.pyx
@@ -232,8 +232,7 @@ cdef class NeighborQueryResult:
 
         cdef freud._locality.NeighborList *cnlist = dereference(
             iterator).toNeighborList()
-        cdef NeighborList nl = NeighborList()
-        nl.refer_to(cnlist)
+        cdef NeighborList nl = nlist_from_cnlist(cnlist)
         # Explicitly manage a manually created nlist so that it will be
         # deleted when the Python object is.
         nl._managed = True
@@ -430,15 +429,6 @@ cdef class NeighborList:
             &l_point_indices[0], l_num_points, &l_distances[0], &l_weights[0])
 
         return result
-
-    cdef refer_to(self, freud._locality.NeighborList * other):
-        R"""Makes this cython wrapper object point to a different C++ object,
-        deleting the one we are already holding if necessary. We do not
-        own the memory of the other C++ object."""
-        if self._managed:
-            del self.thisptr
-        self._managed = False
-        self.thisptr = other
 
     def __cinit__(self):
         self._managed = True
@@ -1026,10 +1016,7 @@ cdef class _Voronoi:
             <int*> &expanded_ids[0], <vec3[double]*> &expanded_points[0, 0],
             <int*> &ridge_vertex_indices[0])
 
-        cdef freud._locality.NeighborList * nlist
-        nlist = self.thisptr.getNeighborList()
-        self._nlist.refer_to(nlist)
-        self._nlist.base = self
+        self._nlist = nlist_from_cnlist(self.thisptr.getNeighborList())
 
         # Construct a list of polytope vertices
         self._polytopes = list()

--- a/freud/locality.pyx
+++ b/freud/locality.pyx
@@ -1221,10 +1221,11 @@ cdef class PairCompute(Compute):
             nlist (:class:`freud.locality.NeighborList`, optional):
                 NeighborList to use to find bonds (Default value =
                 :code:`None`).
-            query_args (dict): A dictionary of query arguments (Default value =
-                :code:`None`).
-        dimensions (int): Number of dimensions the box should be. If not None,
-            used to verify the box dimensions (Default value = :code:`None`).
+            query_args (dict):
+                A dictionary of query arguments (Default value = :code:`None`).
+            dimensions (int):
+                Number of dimensions the box should be. If not None, used to
+                verify the box dimensions (Default value = :code:`None`).
         """  # noqa E501
         cdef freud.box.Box b = freud.common.convert_box(box, dimensions)
         cdef NeighborQuery nq = make_default_nq(box, points)

--- a/freud/locality.pyx
+++ b/freud/locality.pyx
@@ -560,6 +560,15 @@ cdef class NeighborList:
         return self
 
 
+cdef NeighborList nlist_from_cnlist(freud._locality.NeighborList *c_nlist):
+    cdef NeighborList result
+    result = NeighborList()
+    del result.thisptr
+    result._managed = False
+    result.thisptr = c_nlist
+    return result
+
+
 cdef class NlistptrWrapper:
     R"""Wrapper class to hold :code:`freud._locality.NeighborList *`.
 

--- a/freud/locality.pyx
+++ b/freud/locality.pyx
@@ -586,6 +586,13 @@ cdef class NlistptrWrapper:
 def make_default_nq(box, points):
     R"""Helper function to return a NeighborQuery object.
 
+    Currently the resolution for NeighborQuery objects is such that if Python
+    users pass in a numpy array of points and a box, we always make a RawPoints
+    object. On the C++ side, the RawPoints object internally constructs an
+    AABBQuery object to find neighbors if needed. On the Python side, making
+    the RawPoints object is just so that compute functions on the C++ side
+    don't require overloads to work.
+
     Args:
         box (:class:`freud.box.Box`):
             Simulation box.

--- a/freud/locality.pyx
+++ b/freud/locality.pyx
@@ -556,7 +556,7 @@ cdef NeighborList nlist_from_cnlist(freud._locality.NeighborList *c_nlist):
 
     This functions generally serves two purposes. Any special locality
     NeighborList generators, like :class:`~.Voronoi`, should use this as a way
-    to point to the C++ Neighborlist they generate internally. Additionally,
+    to point to the C++ NeighborList they generate internally. Additionally,
     any compute method that requires a :class:`~.NeighborList` (i.e. cannot do
     with just a :class:`~.NeighborQuery`) should also expose the internally
     computed :class:`~.NeighborList` using this method.

--- a/freud/locality.pyx
+++ b/freud/locality.pyx
@@ -1149,8 +1149,8 @@ cdef class PairCompute(Compute):
     well as dealing with boxes and query arguments.
     """
 
-    def preprocess_arguments_new(self, box, points, query_points=None,
-                                 neighbors=None, dimensions=None):
+    def preprocess_arguments(self, box, points, query_points=None,
+                             neighbors=None, dimensions=None):
         """Process standard compute arguments into freud's internal types by
         calling all the required internal functions.
 

--- a/freud/order.pyx
+++ b/freud/order.pyx
@@ -716,6 +716,10 @@ cdef class SolidLiquid(PairCompute):
         return self.thisptr.getLargestClusterSize()
 
     @Compute._computed_property()
+    def nlist(self):
+        return freud.locality.nlist_from_cnlist(self.thisptr.getNList())
+
+    @Compute._computed_property()
     def num_connections(self):
         return freud.util.make_managed_numpy_array(
             &self.thisptr.getNumberOfConnections(),

--- a/freud/order.pyx
+++ b/freud/order.pyx
@@ -324,7 +324,7 @@ cdef class Hexatic(PairCompute):
             unsigned int num_query_points
 
         b, nq, nlistptr, qargs, l_query_points, num_query_points = \
-            self.preprocess_arguments_new(box, points, neighbors=neighbors)
+            self.preprocess_arguments(box, points, neighbors=neighbors)
         self.thisptr.compute(nlistptr.get_ptr(),
                              nq.get_ptr(), dereference(qargs.thisptr))
         return self
@@ -393,7 +393,7 @@ cdef class Translational(PairCompute):
             unsigned int num_query_points
 
         b, nq, nlistptr, qargs, l_query_points, num_query_points = \
-            self.preprocess_arguments_new(box, points, neighbors=neighbors)
+            self.preprocess_arguments(box, points, neighbors=neighbors)
 
         self.thisptr.compute(nlistptr.get_ptr(),
                              nq.get_ptr(), dereference(qargs.thisptr))
@@ -538,7 +538,7 @@ cdef class Steinhardt(PairCompute):
             unsigned int num_query_points
 
         b, nq, nlistptr, qargs, l_query_points, num_query_points = \
-            self.preprocess_arguments_new(box, points, neighbors=neighbors)
+            self.preprocess_arguments(box, points, neighbors=neighbors)
 
         self.thisptr.compute(nlistptr.get_ptr(),
                              nq.get_ptr(),
@@ -679,7 +679,7 @@ cdef class SolidLiquid(PairCompute):
             unsigned int num_query_points
 
         b, nq, nlistptr, qargs, l_query_points, num_query_points = \
-            self.preprocess_arguments_new(box, points, neighbors=neighbors)
+            self.preprocess_arguments(box, points, neighbors=neighbors)
 
         self.thisptr.compute(nlistptr.get_ptr(),
                              nq.get_ptr(),

--- a/freud/order.pyx
+++ b/freud/order.pyx
@@ -658,7 +658,7 @@ cdef class SolidLiquid(PairCompute):
         del self.thisptr
 
     @Compute._compute()
-    def compute(self, box, points, nlist=None, query_args=None):
+    def compute(self, box, points, neighbors=None):
         R"""Compute the order parameter.
 
         Args:
@@ -679,8 +679,7 @@ cdef class SolidLiquid(PairCompute):
             unsigned int num_query_points
 
         b, nq, nlistptr, qargs, l_query_points, num_query_points = \
-            self.preprocess_arguments(box, points, nlist=nlist,
-                                      query_args=query_args)
+            self.preprocess_arguments_new(box, points, neighbors=neighbors)
 
         self.thisptr.compute(nlistptr.get_ptr(),
                              nq.get_ptr(),

--- a/freud/order.pyx
+++ b/freud/order.pyx
@@ -708,6 +708,12 @@ cdef class SolidLiquid(PairCompute):
             freud.util.arr_type_t.UNSIGNED_INT)
 
     @Compute._computed_property()
+    def Ql_ij(self):
+        return freud.util.make_managed_numpy_array(
+            &self.thisptr.getQlij(),
+            freud.util.arr_type_t.FLOAT)
+
+    @Compute._computed_property()
     def cluster_sizes(self):
         return np.asarray(self.thisptr.getClusterSizes())
 

--- a/freud/order.pyx
+++ b/freud/order.pyx
@@ -370,7 +370,7 @@ cdef class Translational(PairCompute):
         del self.thisptr
 
     @Compute._compute()
-    def compute(self, box, points, nlist=None, query_args=None):
+    def compute(self, box, points, neighbors=None):
         R"""Calculates the local descriptors.
 
         Args:
@@ -393,8 +393,7 @@ cdef class Translational(PairCompute):
             unsigned int num_query_points
 
         b, nq, nlistptr, qargs, l_query_points, num_query_points = \
-            self.preprocess_arguments(box, points, nlist=nlist,
-                                      query_args=query_args)
+            self.preprocess_arguments_new(box, points, neighbors=neighbors)
 
         self.thisptr.compute(nlistptr.get_ptr(),
                              nq.get_ptr(), dereference(qargs.thisptr))

--- a/freud/order.pyx
+++ b/freud/order.pyx
@@ -517,7 +517,7 @@ cdef class Steinhardt(PairCompute):
             freud.util.arr_type_t.FLOAT)
 
     @Compute._compute()
-    def compute(self, box, points, nlist=None, query_args=None):
+    def compute(self, box, points, neighbors=None):
         R"""Compute the order parameter.
 
         Args:
@@ -538,8 +538,7 @@ cdef class Steinhardt(PairCompute):
             unsigned int num_query_points
 
         b, nq, nlistptr, qargs, l_query_points, num_query_points = \
-            self.preprocess_arguments(box, points, nlist=nlist,
-                                      query_args=query_args)
+            self.preprocess_arguments_new(box, points, neighbors=neighbors)
 
         self.thisptr.compute(nlistptr.get_ptr(),
                              nq.get_ptr(),

--- a/freud/order.pyx
+++ b/freud/order.pyx
@@ -300,7 +300,7 @@ cdef class Hexatic(PairCompute):
         del self.thisptr
 
     @Compute._compute()
-    def compute(self, box, points, nlist=None, query_args=None):
+    def compute(self, box, points, neighbors=None):
         R"""Calculates the correlation function and adds to the current
         histogram.
 
@@ -324,8 +324,7 @@ cdef class Hexatic(PairCompute):
             unsigned int num_query_points
 
         b, nq, nlistptr, qargs, l_query_points, num_query_points = \
-            self.preprocess_arguments(box, points, nlist=nlist,
-                                      query_args=query_args)
+            self.preprocess_arguments_new(box, points, neighbors=neighbors)
         self.thisptr.compute(nlistptr.get_ptr(),
                              nq.get_ptr(), dereference(qargs.thisptr))
         return self

--- a/freud/plot.py
+++ b/freud/plot.py
@@ -11,8 +11,6 @@ except ImportError:
 def ax_to_bytes(ax):
     """Helper function to convert figure to png file.
 
-    .. moduleauthor:: Jin Soo Ihm <jinihm@umich.edu>
-
     Args:
         ax (:class:`matplotlib.axes.Axes`): axes object to plot.
 
@@ -32,8 +30,6 @@ def ax_to_bytes(ax):
 
 def bar_plot(x, height, title=None, xlabel=None, ylabel=None, ax=None):
     """Helper function to draw a bar graph.
-
-    .. moduleauthor:: Jin Soo Ihm <jinihm@umich.edu>
 
     Args:
         x (list): x values of the bar graph.
@@ -67,8 +63,6 @@ def bar_plot(x, height, title=None, xlabel=None, ylabel=None, ax=None):
 def clusters_plot(keys, freqs, num_clusters_to_plot=10, ax=None):
     """Helper function to plot most frequent clusters in a bar graph.
 
-    .. moduleauthor:: Jin Soo Ihm <jinihm@umich.edu>
-
     Args:
         keys (list): Cluster keys.
         freqs (list): Number of particles in each clusters.
@@ -94,8 +88,6 @@ def clusters_plot(keys, freqs, num_clusters_to_plot=10, ax=None):
 
 def line_plot(x, y, title=None, xlabel=None, ylabel=None, ax=None):
     """Helper function to draw a line graph.
-
-    .. moduleauthor:: Jin Soo Ihm <jinihm@umich.edu>
 
     Args:
         x (list): x values of the line graph.
@@ -127,8 +119,6 @@ def line_plot(x, y, title=None, xlabel=None, ylabel=None, ax=None):
 def histogram_plot(values, title=None, xlabel=None, ylabel=None, ax=None):
     """Helper function to draw a histogram graph.
 
-    .. moduleauthor:: Jin Soo Ihm <jinihm@umich.edu>
-
     Args:
         values (list): values of the histogram.
         title (str): Title of the graph. (Default value = :code:`None`).
@@ -157,8 +147,6 @@ def histogram_plot(values, title=None, xlabel=None, ylabel=None, ax=None):
 
 def pmft_plot(pmft, ax=None):
     """Helper function to draw 2D PMFT diagram.
-
-    .. moduleauthor:: Jin Soo Ihm <jinihm@umich.edu>
 
     Args:
         pmft (:class:`freud.pmft.PMFTXY2D`):

--- a/freud/pmft.pyx
+++ b/freud/pmft.pyx
@@ -135,7 +135,7 @@ cdef class PMFTR12(_PMFT):
 
     @Compute._compute()
     def accumulate(self, box, points, orientations, query_points=None,
-                   query_orientations=None, nlist=None, query_args=None):
+                   query_orientations=None, neighbors=None):
         R"""Calculates the positional correlation function and adds to the
         current histogram.
 
@@ -166,8 +166,8 @@ cdef class PMFTR12(_PMFT):
             unsigned int num_query_points
 
         b, nq, nlistptr, qargs, l_query_points, num_query_points = \
-            self.preprocess_arguments(box, points, query_points, nlist,
-                                      query_args, dimensions=2)
+            self.preprocess_arguments_new(box, points, query_points, neighbors,
+                                          dimensions=2)
 
         orientations = freud.common.convert_array(
             np.atleast_1d(orientations.squeeze()),
@@ -191,7 +191,7 @@ cdef class PMFTR12(_PMFT):
 
     @Compute._compute()
     def compute(self, box, points, orientations, query_points=None,
-                query_orientations=None, nlist=None, query_args=None):
+                query_orientations=None, neighbors=None):
         R"""Calculates the positional correlation function for the given points.
         Will overwrite the current histogram.
 
@@ -215,7 +215,7 @@ cdef class PMFTR12(_PMFT):
         """  # noqa: E501
         self.reset()
         self.accumulate(box, points, orientations,
-                        query_points, query_orientations, nlist, query_args)
+                        query_points, query_orientations, neighbors)
         return self
 
     def __repr__(self):
@@ -283,7 +283,7 @@ cdef class PMFTXYT(_PMFT):
 
     @Compute._compute()
     def accumulate(self, box, points, orientations, query_points=None,
-                   query_orientations=None, nlist=None, query_args=None):
+                   query_orientations=None, neighbors=None):
         R"""Calculates the positional correlation function and adds to the
         current histogram.
 
@@ -314,8 +314,8 @@ cdef class PMFTXYT(_PMFT):
             unsigned int num_query_points
 
         b, nq, nlistptr, qargs, l_query_points, num_query_points = \
-            self.preprocess_arguments(box, points, query_points, nlist,
-                                      query_args, dimensions=2)
+            self.preprocess_arguments_new(box, points, query_points, neighbors,
+                                          dimensions=2)
 
         orientations = freud.common.convert_array(
             np.atleast_1d(orientations.squeeze()),
@@ -339,7 +339,7 @@ cdef class PMFTXYT(_PMFT):
 
     @Compute._compute()
     def compute(self, box, points, orientations, query_points=None,
-                query_orientations=None, nlist=None, query_args=None):
+                query_orientations=None, neighbors=None):
         R"""Calculates the positional correlation function for the given points.
         Will overwrite the current histogram.
 
@@ -363,7 +363,7 @@ cdef class PMFTXYT(_PMFT):
         """  # noqa: E501
         self.reset()
         self.accumulate(box, points, orientations,
-                        query_points, query_orientations, nlist, query_args)
+                        query_points, query_orientations, neighbors)
         return self
 
     def __repr__(self):
@@ -430,7 +430,7 @@ cdef class PMFTXY2D(_PMFT):
 
     @Compute._compute()
     def accumulate(self, box, points, orientations, query_points=None,
-                   nlist=None, query_args=None):
+                   neighbors=None):
         R"""Calculates the positional correlation function and adds to the
         current histogram.
 
@@ -457,8 +457,8 @@ cdef class PMFTXY2D(_PMFT):
             unsigned int num_query_points
 
         b, nq, nlistptr, qargs, l_query_points, num_query_points = \
-            self.preprocess_arguments(box, points, query_points, nlist,
-                                      query_args, dimensions=2)
+            self.preprocess_arguments_new(box, points, query_points, neighbors,
+                                          dimensions=2)
 
         orientations = freud.common.convert_array(
             np.atleast_1d(orientations.squeeze()),
@@ -474,7 +474,7 @@ cdef class PMFTXY2D(_PMFT):
 
     @Compute._compute()
     def compute(self, box, points, orientations, query_points=None,
-                nlist=None, query_args=None):
+                neighbors=None):
         R"""Calculates the positional correlation function for the given points.
         Will overwrite the current histogram.
 
@@ -494,7 +494,7 @@ cdef class PMFTXY2D(_PMFT):
         """  # noqa: E501
         self.reset()
         self.accumulate(box, points, orientations,
-                        query_points, nlist, query_args)
+                        query_points, neighbors)
         return self
 
     @Compute._computed_property()
@@ -610,7 +610,7 @@ cdef class PMFTXYZ(_PMFT):
 
     @Compute._compute()
     def accumulate(self, box, points, orientations, query_points=None,
-                   face_orientations=None, nlist=None, query_args=None):
+                   face_orientations=None, neighbors=None):
         R"""Calculates the positional correlation function and adds to the
         current histogram.
 
@@ -644,8 +644,8 @@ cdef class PMFTXYZ(_PMFT):
             unsigned int num_query_points
 
         b, nq, nlistptr, qargs, l_query_points, num_query_points = \
-            self.preprocess_arguments(box, points, query_points, nlist,
-                                      query_args, dimensions=3)
+            self.preprocess_arguments_new(box, points, query_points, neighbors,
+                                          dimensions=3)
         l_query_points = l_query_points - self.shiftvec.reshape(1, 3)
 
         orientations = freud.common.convert_array(
@@ -707,8 +707,7 @@ cdef class PMFTXYZ(_PMFT):
 
     @Compute._compute()
     def compute(self, box, points, orientations, query_points=None,
-                face_orientations=None, nlist=None,
-                query_args=None):
+                face_orientations=None, neighbors=None):
         R"""Calculates the positional correlation function for the given points.
         Will overwrite the current histogram.
 
@@ -734,9 +733,8 @@ cdef class PMFTXYZ(_PMFT):
                 :code:`None`).
         """  # noqa: E501
         self.reset()
-        self.accumulate(box, points, orientations,
-                        query_points, face_orientations,
-                        nlist, query_args)
+        self.accumulate(box, points, orientations, query_points,
+                        face_orientations, neighbors)
         return self
 
     def __repr__(self):

--- a/freud/pmft.pyx
+++ b/freud/pmft.pyx
@@ -166,8 +166,8 @@ cdef class PMFTR12(_PMFT):
             unsigned int num_query_points
 
         b, nq, nlistptr, qargs, l_query_points, num_query_points = \
-            self.preprocess_arguments_new(box, points, query_points, neighbors,
-                                          dimensions=2)
+            self.preprocess_arguments(
+                box, points, query_points, neighbors, dimensions=2)
 
         orientations = freud.common.convert_array(
             np.atleast_1d(orientations.squeeze()),
@@ -314,8 +314,8 @@ cdef class PMFTXYT(_PMFT):
             unsigned int num_query_points
 
         b, nq, nlistptr, qargs, l_query_points, num_query_points = \
-            self.preprocess_arguments_new(box, points, query_points, neighbors,
-                                          dimensions=2)
+            self.preprocess_arguments(
+                box, points, query_points, neighbors, dimensions=2)
 
         orientations = freud.common.convert_array(
             np.atleast_1d(orientations.squeeze()),
@@ -457,8 +457,8 @@ cdef class PMFTXY2D(_PMFT):
             unsigned int num_query_points
 
         b, nq, nlistptr, qargs, l_query_points, num_query_points = \
-            self.preprocess_arguments_new(box, points, query_points, neighbors,
-                                          dimensions=2)
+            self.preprocess_arguments(
+                box, points, query_points, neighbors, dimensions=2)
 
         orientations = freud.common.convert_array(
             np.atleast_1d(orientations.squeeze()),
@@ -644,8 +644,8 @@ cdef class PMFTXYZ(_PMFT):
             unsigned int num_query_points
 
         b, nq, nlistptr, qargs, l_query_points, num_query_points = \
-            self.preprocess_arguments_new(box, points, query_points, neighbors,
-                                          dimensions=3)
+            self.preprocess_arguments(
+                box, points, query_points, neighbors, dimensions=3)
         l_query_points = l_query_points - self.shiftvec.reshape(1, 3)
 
         orientations = freud.common.convert_array(

--- a/setup.py
+++ b/setup.py
@@ -357,6 +357,7 @@ sources_in_all = [
 extra_module_sources = dict(
     environment=[
         os.path.join("cpp", "util", "diagonalize.cc"),
+        os.path.join("cpp", "locality", "NeighborComputeFunctional.cc"),
     ],
     order=[
         os.path.join("cpp", "util", "diagonalize.cc"),

--- a/setup.py
+++ b/setup.py
@@ -349,6 +349,7 @@ sources_in_all = [
     os.path.join("cpp", "locality", "NeighborQuery.cc"),
     os.path.join("cpp", "locality", "AABBQuery.cc"),
     os.path.join("cpp", "locality", "NeighborList.cc"),
+    os.path.join("cpp", "locality", "NeighborComputeFunctional.cc"),
 ]
 
 # Any source files required only for specific modules.
@@ -357,7 +358,6 @@ sources_in_all = [
 extra_module_sources = dict(
     environment=[
         os.path.join("cpp", "util", "diagonalize.cc"),
-        os.path.join("cpp", "locality", "NeighborComputeFunctional.cc"),
     ],
     order=[
         os.path.join("cpp", "util", "diagonalize.cc"),

--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -34,10 +34,10 @@ class TestCluster(unittest.TestCase):
         clust.compute(box, positions)
         idx = np.copy(clust.cluster_idx)
 
-        test_set = util.make_raw_query_nlist_test_set(
+        test_set = util.make_raw_query_nlist_test_set_new(
             box, positions, positions, "ball", 0.5, 0, True)
         for ts in test_set:
-            clust.compute(box, ts[0], nlist=ts[1])
+            clust.compute(box, ts[0], neighbors=ts[1])
             self.assertTrue(np.all(clust.cluster_idx == idx))
 
         # Test if attributes are accessible now

--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -34,7 +34,7 @@ class TestCluster(unittest.TestCase):
         clust.compute(box, positions)
         idx = np.copy(clust.cluster_idx)
 
-        test_set = util.make_raw_query_nlist_test_set_new(
+        test_set = util.make_raw_query_nlist_test_set(
             box, positions, positions, "ball", 0.5, 0, True)
         for ts in test_set:
             clust.compute(box, ts[0], neighbors=ts[1])

--- a/tests/test_density_CorrelationFunction.py
+++ b/tests/test_density_CorrelationFunction.py
@@ -77,7 +77,7 @@ class TestCorrelationFunction(unittest.TestCase):
         correct = np.zeros(bins, dtype=np.complex64)
         absolute_tolerance = 0.1
         # first bin is bad
-        test_set = util.make_raw_query_nlist_test_set_new(
+        test_set = util.make_raw_query_nlist_test_set(
             box, points, points, 'ball', r_max, 0, True)
         for ts in test_set:
             ocf = freud.density.CorrelationFunction(bins, r_max)
@@ -112,7 +112,7 @@ class TestCorrelationFunction(unittest.TestCase):
         correct = np.zeros(bins, dtype=np.float64)
         absolute_tolerance = 0.1
         # first bin is bad
-        test_set = util.make_raw_query_nlist_test_set_new(
+        test_set = util.make_raw_query_nlist_test_set(
             box, points, points, 'ball', r_max, 0, True)
         for ts in test_set:
             ocf = freud.density.CorrelationFunction(bins, r_max)
@@ -365,7 +365,7 @@ class TestCorrelationFunction(unittest.TestCase):
         # the result should be minimal.
         points = [[dr/4, 0, 0], [-dr/4, 0, 0], [0, dr/4, 0], [0, -dr/4, 0]]
 
-        test_set = util.make_raw_query_nlist_test_set_new(
+        test_set = util.make_raw_query_nlist_test_set(
             box, points, query_points, "ball", r_max, 0, False)
         for ts in test_set:
             ocf = freud.density.CorrelationFunction(bins, r_max)
@@ -413,7 +413,7 @@ class TestCorrelationFunction(unittest.TestCase):
         # the result should be minimal.
         points = [[dr/4, 0, 0], [-dr/4, 0, 0], [0, dr/4, 0], [0, -dr/4, 0]]
 
-        test_set = util.make_raw_query_nlist_test_set_new(
+        test_set = util.make_raw_query_nlist_test_set(
             box, points, query_points, "ball", r_max, 0, False)
         for ts in test_set:
             ocf = freud.density.CorrelationFunction(bins, r_max)

--- a/tests/test_density_CorrelationFunction.py
+++ b/tests/test_density_CorrelationFunction.py
@@ -77,29 +77,27 @@ class TestCorrelationFunction(unittest.TestCase):
         correct = np.zeros(bins, dtype=np.complex64)
         absolute_tolerance = 0.1
         # first bin is bad
-        test_set = util.make_raw_query_nlist_test_set(
+        test_set = util.make_raw_query_nlist_test_set_new(
             box, points, points, 'ball', r_max, 0, True)
         for ts in test_set:
             ocf = freud.density.CorrelationFunction(bins, r_max)
             ocf.accumulate(box, ts[0], comp, points, np.conj(comp),
-                           query_args={"r_max": r_max, "exclude_ii": True},
-                           nlist=ts[1])
+                           neighbors=ts[1])
             npt.assert_allclose(ocf.correlation, correct,
                                 atol=absolute_tolerance)
             ocf.compute(box, ts[0], comp, points, np.conj(comp),
-                        query_args={"r_max": r_max, "exclude_ii": True},
-                        nlist=ts[1])
+                        neighbors=ts[1])
             npt.assert_allclose(ocf.correlation, correct,
                                 atol=absolute_tolerance)
             self.assertEqual(box, ocf.box)
 
             ocf.reset()
             ocf.accumulate(
-                box, ts[0], comp, query_values=np.conj(comp), nlist=ts[1])
+                box, ts[0], comp, query_values=np.conj(comp), neighbors=ts[1])
             npt.assert_allclose(ocf.correlation, correct,
                                 atol=absolute_tolerance)
             ocf.compute(
-                box, ts[0], comp, query_values=np.conj(comp), nlist=ts[1])
+                box, ts[0], comp, query_values=np.conj(comp), neighbors=ts[1])
             npt.assert_allclose(ocf.correlation, correct,
                                 atol=absolute_tolerance)
 
@@ -114,27 +112,25 @@ class TestCorrelationFunction(unittest.TestCase):
         correct = np.zeros(bins, dtype=np.float64)
         absolute_tolerance = 0.1
         # first bin is bad
-        test_set = util.make_raw_query_nlist_test_set(
+        test_set = util.make_raw_query_nlist_test_set_new(
             box, points, points, 'ball', r_max, 0, True)
         for ts in test_set:
             ocf = freud.density.CorrelationFunction(bins, r_max)
-            ocf.accumulate(box, ts[0], ang, nlist=ts[1])
+            ocf.accumulate(box, ts[0], ang, neighbors=ts[1])
             npt.assert_allclose(ocf.correlation, correct,
                                 atol=absolute_tolerance)
-            ocf.compute(box, ts[0], ang, nlist=ts[1])
-            npt.assert_allclose(ocf.correlation, correct,
-                                atol=absolute_tolerance)
-            ocf.reset()
-            ocf.accumulate(box, ts[0], ang, points, ang,
-                           query_args={'r_max': r_max, 'exclude_ii': True},
-                           nlist=ts[1])
+            ocf.compute(box, ts[0], ang, neighbors=ts[1])
             npt.assert_allclose(ocf.correlation, correct,
                                 atol=absolute_tolerance)
             ocf.reset()
-            ocf.accumulate(box, ts[0], ang, query_values=ang, nlist=ts[1])
+            ocf.accumulate(box, ts[0], ang, points, ang, neighbors=ts[1])
             npt.assert_allclose(ocf.correlation, correct,
                                 atol=absolute_tolerance)
-            ocf.compute(box, ts[0], ang, nlist=ts[1])
+            ocf.reset()
+            ocf.accumulate(box, ts[0], ang, query_values=ang, neighbors=ts[1])
+            npt.assert_allclose(ocf.correlation, correct,
+                                atol=absolute_tolerance)
+            ocf.compute(box, ts[0], ang, neighbors=ts[1])
             npt.assert_allclose(ocf.correlation, correct,
                                 atol=absolute_tolerance)
             self.assertEqual(freud.box.Box.square(box_size), ocf.box)
@@ -152,7 +148,7 @@ class TestCorrelationFunction(unittest.TestCase):
         ocf = freud.density.CorrelationFunction(bins, r_max)
         ocf.accumulate(freud.box.Box.square(box_size), points, comp,
                        points, np.conj(comp),
-                       query_args={"r_max": r_max, "exclude_ii": True})
+                       neighbors={"r_max": r_max, "exclude_ii": True})
 
         correct = np.ones(int(r_max/dr), dtype=np.float32) + \
             1j * np.zeros(int(r_max/dr), dtype=np.float32)
@@ -195,7 +191,7 @@ class TestCorrelationFunction(unittest.TestCase):
         ocf = freud.density.CorrelationFunction(bins, r_max)
         ocf.compute(freud.box.Box.square(box_size), points, comp,
                     points, np.conj(comp),
-                    query_args={"r_max": r_max, "exclude_ii": True})
+                    neighbors={"r_max": r_max, "exclude_ii": True})
         self.assertEqual(np.sum(ocf.bin_counts), correct)
 
     @unittest.skip('Skipping slow summation test.')
@@ -248,7 +244,7 @@ class TestCorrelationFunction(unittest.TestCase):
 
         ocf.accumulate(freud.box.Box.square(box_size), points, comp,
                        points, np.conj(comp),
-                       query_args={"r_max": r_max, "exclude_ii": True})
+                       neighbors={"r_max": r_max, "exclude_ii": True})
         ocf._repr_png_()
 
     def test_query_nn_complex(self):
@@ -271,34 +267,34 @@ class TestCorrelationFunction(unittest.TestCase):
 
         cf = freud.density.CorrelationFunction(bins, r_max)
         cf.compute(box, ref_points, ref_values, points, values,
-                   query_args={'mode': 'nearest', 'num_neighbors': 1})
+                   neighbors={'mode': 'nearest', 'num_neighbors': 1})
         npt.assert_array_equal(cf.correlation, [1, 1, 1])
         npt.assert_array_equal(cf.bin_counts, [2, 2, 2])
 
         cf.compute(box, points, values, ref_points, ref_values,
-                   query_args={'mode': 'nearest', 'num_neighbors': 1})
+                   neighbors={'mode': 'nearest', 'num_neighbors': 1})
         npt.assert_array_equal(cf.correlation, [1, 0, 0])
         npt.assert_array_equal(cf.bin_counts, [1, 0, 0])
 
         ref_values = [1+1j]
         values = [1+1j, 1+1j, 2+2j, 2+2j, 3+3j, 3+3j]
         cf.compute(box, ref_points, ref_values, points, np.conj(values),
-                   query_args={'mode': 'nearest', 'num_neighbors': 1})
+                   neighbors={'mode': 'nearest', 'num_neighbors': 1})
         npt.assert_array_equal(cf.correlation, [2, 4, 6])
         npt.assert_array_equal(cf.bin_counts, [2, 2, 2])
 
         cf.compute(box, ref_points, ref_values, points, values,
-                   query_args={'mode': 'nearest', 'num_neighbors': 1})
+                   neighbors={'mode': 'nearest', 'num_neighbors': 1})
         npt.assert_array_equal(cf.correlation, [2j, 4j, 6j])
         npt.assert_array_equal(cf.bin_counts, [2, 2, 2])
 
         cf.compute(box, points, values, ref_points, np.conj(ref_values),
-                   query_args={'mode': 'nearest', 'num_neighbors': 1})
+                   neighbors={'mode': 'nearest', 'num_neighbors': 1})
         npt.assert_array_equal(cf.correlation, [2, 0, 0])
         npt.assert_array_equal(cf.bin_counts, [1, 0, 0])
 
         cf.compute(box, points, values, ref_points, ref_values,
-                   query_args={'mode': 'nearest', 'num_neighbors': 1})
+                   neighbors={'mode': 'nearest', 'num_neighbors': 1})
         npt.assert_array_equal(cf.correlation, [2j, 0, 0])
         npt.assert_array_equal(cf.bin_counts, [1, 0, 0])
 
@@ -322,12 +318,12 @@ class TestCorrelationFunction(unittest.TestCase):
 
         cf = freud.density.CorrelationFunction(bins, r_max)
         cf.compute(box, ref_points, ref_values, points, values,
-                   query_args={'mode': 'nearest', 'num_neighbors': 1})
+                   neighbors={'mode': 'nearest', 'num_neighbors': 1})
         npt.assert_array_equal(cf.correlation, [1, 1, 1])
         npt.assert_array_equal(cf.bin_counts, [2, 2, 2])
 
         cf.compute(box, points, values, ref_points, ref_values,
-                   query_args={'mode': 'nearest', 'num_neighbors': 1})
+                   neighbors={'mode': 'nearest', 'num_neighbors': 1})
         npt.assert_array_equal(cf.correlation, [1, 0, 0])
         npt.assert_array_equal(cf.bin_counts, [1, 0, 0])
 
@@ -369,7 +365,7 @@ class TestCorrelationFunction(unittest.TestCase):
         # the result should be minimal.
         points = [[dr/4, 0, 0], [-dr/4, 0, 0], [0, dr/4, 0], [0, -dr/4, 0]]
 
-        test_set = util.make_raw_query_nlist_test_set(
+        test_set = util.make_raw_query_nlist_test_set_new(
             box, points, query_points, "ball", r_max, 0, False)
         for ts in test_set:
             ocf = freud.density.CorrelationFunction(bins, r_max)
@@ -379,7 +375,7 @@ class TestCorrelationFunction(unittest.TestCase):
 
                 ocf.compute(
                     box, ts[0], values,
-                    query_points, query_values, nlist=ts[1])
+                    query_points, query_values, neighbors=ts[1])
                 correct = supposed_correlation
 
                 npt.assert_allclose(ocf.correlation, correct, atol=1e-6)
@@ -417,7 +413,7 @@ class TestCorrelationFunction(unittest.TestCase):
         # the result should be minimal.
         points = [[dr/4, 0, 0], [-dr/4, 0, 0], [0, dr/4, 0], [0, -dr/4, 0]]
 
-        test_set = util.make_raw_query_nlist_test_set(
+        test_set = util.make_raw_query_nlist_test_set_new(
             box, points, query_points, "ball", r_max, 0, False)
         for ts in test_set:
             ocf = freud.density.CorrelationFunction(bins, r_max)
@@ -427,7 +423,7 @@ class TestCorrelationFunction(unittest.TestCase):
 
                 ocf.compute(
                     box, ts[0], values,
-                    query_points, query_values, nlist=ts[1])
+                    query_points, query_values, neighbors=ts[1])
                 correct = supposed_correlation * rv
 
                 npt.assert_allclose(ocf.correlation, correct, atol=1e-6)

--- a/tests/test_density_LocalDensity.py
+++ b/tests/test_density_LocalDensity.py
@@ -51,10 +51,10 @@ class TestLD(unittest.TestCase):
         """Test that LocalDensity computes the correct density at each point"""
 
         r_max = self.r_max + 0.5*self.diameter
-        test_set = util.make_raw_query_nlist_test_set(
+        test_set = util.make_raw_query_nlist_test_set_new(
             self.box, self.pos, self.pos, "ball", r_max, 0, True)
         for ts in test_set:
-            self.ld.compute(self.box, ts[0], nlist=ts[1])
+            self.ld.compute(self.box, ts[0], neighbors=ts[1])
 
             # Test access
             self.ld.density

--- a/tests/test_density_LocalDensity.py
+++ b/tests/test_density_LocalDensity.py
@@ -51,7 +51,7 @@ class TestLD(unittest.TestCase):
         """Test that LocalDensity computes the correct density at each point"""
 
         r_max = self.r_max + 0.5*self.diameter
-        test_set = util.make_raw_query_nlist_test_set_new(
+        test_set = util.make_raw_query_nlist_test_set(
             self.box, self.pos, self.pos, "ball", r_max, 0, True)
         for ts in test_set:
             self.ld.compute(self.box, ts[0], neighbors=ts[1])

--- a/tests/test_density_RDF.py
+++ b/tests/test_density_RDF.py
@@ -82,15 +82,15 @@ class TestRDF(unittest.TestCase):
 
         for i, r_min in enumerate([0, 0.05, 0.1, 1.0, 3.0]):
             box, points = util.make_box_and_random_points(box_size, num_points)
-            test_set = util.make_raw_query_nlist_test_set(
+            test_set = util.make_raw_query_nlist_test_set_new(
                 box, points, points, "ball", r_max, 0, True)
             for ts in test_set:
                 rdf = freud.density.RDF(bins, r_max, r_min)
 
                 if i < 3:
-                    rdf.accumulate(box, ts[0], nlist=ts[1])
+                    rdf.accumulate(box, ts[0], neighbors=ts[1])
                 else:
-                    rdf.compute(box, ts[0], nlist=ts[1])
+                    rdf.compute(box, ts[0], neighbors=ts[1])
                 self.assertTrue(rdf.box == box)
                 correct = np.ones(bins, dtype=np.float32)
                 npt.assert_allclose(rdf.RDF, correct, atol=tolerance)
@@ -153,11 +153,11 @@ class TestRDF(unittest.TestCase):
             supposed_RDF.append(supposed_RDF[-1] + N)
         supposed_RDF = np.array(supposed_RDF[1:])
 
-        test_set = util.make_raw_query_nlist_test_set(
+        test_set = util.make_raw_query_nlist_test_set_new(
             box, points, query_points, "ball", r_max, 0, False)
         for ts in test_set:
             rdf = freud.density.RDF(bins, r_max)
-            rdf.compute(box, ts[0], query_points, nlist=ts[1])
+            rdf.compute(box, ts[0], query_points, neighbors=ts[1])
 
             npt.assert_allclose(rdf.n_r, supposed_RDF, atol=1e-6)
 

--- a/tests/test_density_RDF.py
+++ b/tests/test_density_RDF.py
@@ -82,7 +82,7 @@ class TestRDF(unittest.TestCase):
 
         for i, r_min in enumerate([0, 0.05, 0.1, 1.0, 3.0]):
             box, points = util.make_box_and_random_points(box_size, num_points)
-            test_set = util.make_raw_query_nlist_test_set_new(
+            test_set = util.make_raw_query_nlist_test_set(
                 box, points, points, "ball", r_max, 0, True)
             for ts in test_set:
                 rdf = freud.density.RDF(bins, r_max, r_min)
@@ -153,7 +153,7 @@ class TestRDF(unittest.TestCase):
             supposed_RDF.append(supposed_RDF[-1] + N)
         supposed_RDF = np.array(supposed_RDF[1:])
 
-        test_set = util.make_raw_query_nlist_test_set_new(
+        test_set = util.make_raw_query_nlist_test_set(
             box, points, query_points, "ball", r_max, 0, False)
         for ts in test_set:
             rdf = freud.density.RDF(bins, r_max)

--- a/tests/test_environment_AngularSeparation.py
+++ b/tests/test_environment_AngularSeparation.py
@@ -39,7 +39,7 @@ class TestAngularSeparation(unittest.TestCase):
     def test_compute_neighbors(self):
         boxlen = 4
         num_neighbors = 1
-        r_max = 2
+        r_guess = 2
 
         box = freud.box.Box.square(boxlen)
 
@@ -56,10 +56,12 @@ class TestAngularSeparation(unittest.TestCase):
         equivalent_orientations = np.asarray([[1, 0, 0, 0], [-1, 0, 0, 0]],
                                              dtype=np.float32)
 
-        ang = freud.environment.AngularSeparationNeighbor(r_max,
+        ang = freud.environment.AngularSeparationNeighbor(r_guess,
                                                           num_neighbors)
         ang.compute(box, points, ors,
-                    equiv_orientations=equivalent_orientations)
+                    equiv_orientations=equivalent_orientations,
+                    neighbors=dict(num_neighbors=num_neighbors,
+                                   r_guess=r_guess))
 
         # Should find that the angular separation between the first particle
         # and its neighbor is pi/3. The second particle's nearest neighbor will

--- a/tests/test_environment_BondOrder.py
+++ b/tests/test_environment_BondOrder.py
@@ -25,7 +25,7 @@ class TestBondOrder(unittest.TestCase):
         # Test that there are exactly 12 non-zero bins for a perfect FCC
         # structure.
         bo.compute(box, positions, quats,
-                   query_args={'num_neighbors': num_neighbors, 'r_max': r_max})
+                   neighbors={'num_neighbors': num_neighbors, 'r_max': r_max})
         op_value = bo.bond_order.copy()
         self.assertEqual(np.sum(op_value > 0), 12)
 
@@ -52,7 +52,7 @@ class TestBondOrder(unittest.TestCase):
         with self.assertRaises(AttributeError):
             bo.bond_order
 
-        test_set = util.make_raw_query_nlist_test_set(
+        test_set = util.make_raw_query_nlist_test_set_new(
             box, positions, positions, "nearest", r_max, num_neighbors, True)
         for ts in test_set:
             bo.reset()
@@ -60,8 +60,7 @@ class TestBondOrder(unittest.TestCase):
             # same.
             #TODO: Find a way to test a rotated system to ensure that lbod gives  # noqa
             # the desired results.
-            bo.accumulate(box, ts[0], quats, mode='lbod', nlist=ts[1],
-                          query_args=ts[2])
+            bo.accumulate(box, ts[0], quats, mode='lbod', neighbors=ts[1])
             self.assertTrue(np.allclose(bo.bond_order, op_value))
 
             # Test access
@@ -70,35 +69,31 @@ class TestBondOrder(unittest.TestCase):
 
             # Test that obcd gives identical results when orientations are the
             # same.
-            bo.compute(box, ts[0], quats, mode='obcd', nlist=ts[1],
-                       query_args=ts[2])
+            bo.compute(box, ts[0], quats, mode='obcd', neighbors=ts[1])
             self.assertTrue(np.allclose(bo.bond_order, op_value))
 
             # Test that normal bod looks ordered for randomized orientations.
             np.random.seed(10893)
             random_quats = rowan.random.rand(len(positions))
-            bo.compute(box, ts[0], random_quats, nlist=ts[1], query_args=ts[2])
+            bo.compute(box, ts[0], random_quats, neighbors=ts[1])
             self.assertTrue(np.allclose(bo.bond_order, op_value))
 
             # Ensure that obcd looks random for the randomized orientations.
-            bo.compute(box, ts[0], random_quats, mode='obcd', nlist=ts[1],
-                       query_args=ts[2])
+            bo.compute(box, ts[0], random_quats, mode='obcd', neighbors=ts[1])
             self.assertTrue(not np.allclose(bo.bond_order, op_value))
             self.assertEqual(np.sum(bo.bond_order > 0), bo.bond_order.size)
 
             # Test that oocd shows exactly one peak when all orientations
             # are the same.
             bo.reset()
-            bo.accumulate(box, ts[0], quats, mode='oocd', nlist=ts[1],
-                          query_args=ts[2])
+            bo.accumulate(box, ts[0], quats, mode='oocd', neighbors=ts[1])
             self.assertEqual(np.sum(bo.bond_order > 0), 1)
             self.assertTrue(bo.bond_order[0, 0] > 0)
 
             # Test that oocd is highly disordered with random quaternions. In
             # practice, the edge bins may still not get any values, so just
             # check that we get a lot of values.
-            bo.compute(box, ts[0], random_quats, mode='oocd', nlist=ts[1],
-                       query_args=ts[2])
+            bo.compute(box, ts[0], random_quats, mode='oocd', neighbors=ts[1])
             self.assertGreater(np.sum(bo.bond_order > 0), 30)
 
     def test_repr(self):
@@ -118,7 +113,7 @@ class TestBondOrder(unittest.TestCase):
         num_neighbors = 12
         n_bins_theta = 30
         n_bins_phi = 2
-        test_set = util.make_raw_query_nlist_test_set(
+        test_set = util.make_raw_query_nlist_test_set_new(
             box, points, query_points, "nearest", r_max, num_neighbors, False)
         for ts in test_set:
             bod = freud.environment.BondOrder(
@@ -129,8 +124,7 @@ class TestBondOrder(unittest.TestCase):
             orientations = np.array([[1, 0, 0, 0]]*len(query_points))
 
             bod.compute(box, ts[0], ref_orientations,
-                        query_points, orientations, nlist=ts[1],
-                        query_args=ts[2])
+                        query_points, orientations, neighbors=ts[1])
 
             # we want to make sure that we get 12 nonzero places, so we can
             # test whether we are not considering neighbors between points

--- a/tests/test_environment_BondOrder.py
+++ b/tests/test_environment_BondOrder.py
@@ -52,7 +52,7 @@ class TestBondOrder(unittest.TestCase):
         with self.assertRaises(AttributeError):
             bo.bond_order
 
-        test_set = util.make_raw_query_nlist_test_set_new(
+        test_set = util.make_raw_query_nlist_test_set(
             box, positions, positions, "nearest", r_max, num_neighbors, True)
         for ts in test_set:
             bo.reset()
@@ -113,7 +113,7 @@ class TestBondOrder(unittest.TestCase):
         num_neighbors = 12
         n_bins_theta = 30
         n_bins_phi = 2
-        test_set = util.make_raw_query_nlist_test_set_new(
+        test_set = util.make_raw_query_nlist_test_set(
             box, points, query_points, "nearest", r_max, num_neighbors, False)
         for ts in test_set:
             bod = freud.environment.BondOrder(

--- a/tests/test_environment_LocalBondProjection.py
+++ b/tests/test_environment_LocalBondProjection.py
@@ -11,7 +11,8 @@ class TestLocalBondProjection(unittest.TestCase):
         boxlen = 10
         N = 500
         num_neighbors = 8
-        r_max = 3
+        r_guess = 3
+        query_args = dict(num_neighbors=num_neighbors, r_guess=r_guess)
 
         N_query = N//3
 
@@ -20,8 +21,9 @@ class TestLocalBondProjection(unittest.TestCase):
         ors = rowan.random.rand(N)
         proj_vecs = np.asarray([[0, 0, 1]])
 
-        ang = freud.environment.LocalBondProjection(r_max, num_neighbors)
-        ang.compute(box, proj_vecs, points, ors, query_points)
+        ang = freud.environment.LocalBondProjection(r_guess, num_neighbors)
+        ang.compute(box, proj_vecs, points, ors, query_points,
+                    neighbors=query_args)
         self.assertEqual(ang.num_points, N)
         self.assertEqual(ang.num_query_points, N_query)
 
@@ -29,28 +31,30 @@ class TestLocalBondProjection(unittest.TestCase):
         boxlen = 10
         N = 500
         num_neighbors = 8
-        r_max = 3
+        r_guess = 3
+        query_args = dict(num_neighbors=num_neighbors, r_guess=r_guess)
 
         box, points = make_box_and_random_points(boxlen, N, True)
         ors = rowan.random.rand(N)
         proj_vecs = np.asarray([[0, 0, 1]])
 
-        ang = freud.environment.LocalBondProjection(r_max, num_neighbors)
-        ang.compute(box, proj_vecs, points, ors)
+        ang = freud.environment.LocalBondProjection(r_guess, num_neighbors)
+        ang.compute(box, proj_vecs, points, ors, neighbors=query_args)
         npt.assert_equal(ang.num_proj_vectors, 1)
 
     def test_box(self):
         boxlen = 10
         N = 500
         num_neighbors = 8
-        r_max = 3
+        r_guess = 3
+        query_args = dict(num_neighbors=num_neighbors, r_guess=r_guess)
 
         box, points = make_box_and_random_points(boxlen, N)
         ors = rowan.random.rand(N)
         proj_vecs = np.asarray([[0, 0, 1]])
 
-        ang = freud.environment.LocalBondProjection(r_max, num_neighbors)
-        ang.compute(box, proj_vecs, points, ors)
+        ang = freud.environment.LocalBondProjection(r_guess, num_neighbors)
+        ang.compute(box, proj_vecs, points, ors, neighbors=query_args)
 
         npt.assert_equal(ang.box.Lx, boxlen)
         npt.assert_equal(ang.box.Ly, boxlen)
@@ -63,13 +67,14 @@ class TestLocalBondProjection(unittest.TestCase):
         boxlen = 10
         N = 100
         num_neighbors = 8
-        r_max = 3
+        r_guess = 3
+        query_args = dict(num_neighbors=num_neighbors, r_guess=r_guess)
 
         box, points = make_box_and_random_points(boxlen, N, True)
         ors = rowan.random.rand(N)
         proj_vecs = np.asarray([[0, 0, 1]])
 
-        ang = freud.environment.LocalBondProjection(r_max, num_neighbors)
+        ang = freud.environment.LocalBondProjection(r_guess, num_neighbors)
 
         with self.assertRaises(AttributeError):
             ang.nlist
@@ -86,7 +91,7 @@ class TestLocalBondProjection(unittest.TestCase):
         with self.assertRaises(AttributeError):
             ang.box
 
-        ang.compute(box, proj_vecs, points, ors)
+        ang.compute(box, proj_vecs, points, ors, neighbors=query_args)
 
         ang.nlist
         ang.projections
@@ -99,7 +104,8 @@ class TestLocalBondProjection(unittest.TestCase):
     def test_compute(self):
         boxlen = 4
         num_neighbors = 1
-        r_max = 2
+        r_guess = 2
+        query_args = dict(num_neighbors=num_neighbors, r_guess=r_guess)
 
         box = freud.box.Box.cube(boxlen)
 
@@ -122,12 +128,12 @@ class TestLocalBondProjection(unittest.TestCase):
 
         # First have no particle symmetry
 
-        ang = freud.environment.LocalBondProjection(r_max, num_neighbors)
-        ang.compute(box, proj_vecs, points, ors)
+        ang = freud.environment.LocalBondProjection(r_guess, num_neighbors)
+        ang.compute(box, proj_vecs, points, ors, neighbors=query_args)
 
         dnlist = freud.locality.make_default_nlist(
             box, points, None,
-            dict(num_neighbors=num_neighbors, r_guess=r_max), None)
+            dict(num_neighbors=num_neighbors, r_guess=r_guess), None)
         bonds = [(i[0], i[1]) for i in dnlist]
 
         # We will look at the bond between [1, 0, 0] as ref_point
@@ -174,7 +180,7 @@ class TestLocalBondProjection(unittest.TestCase):
             equiv_quats.append(np.array([q[0], -q[1], -q[2], -q[3]]))
         equiv_quats = np.asarray(equiv_quats, dtype=np.float32)
 
-        ang.compute(box, proj_vecs, points, ors, None, equiv_quats)
+        ang.compute(box, proj_vecs, points, ors, None, equiv_quats, query_args)
 
         # Now all projections should be cos(0)=1
         npt.assert_allclose(ang.projections[1], 1, atol=1e-6)

--- a/tests/test_environment_LocalBondProjection.py
+++ b/tests/test_environment_LocalBondProjection.py
@@ -22,7 +22,7 @@ class TestLocalBondProjection(unittest.TestCase):
         ors = rowan.random.rand(N)
         proj_vecs = np.asarray([[0, 0, 1]])
 
-        ang = freud.environment.LocalBondProjection(r_guess, num_neighbors)
+        ang = freud.environment.LocalBondProjection()
         ang.compute(box, proj_vecs, points, ors, query_points,
                     neighbors=query_args)
 
@@ -42,7 +42,7 @@ class TestLocalBondProjection(unittest.TestCase):
         ors = rowan.random.rand(N)
         proj_vecs = np.asarray([[0, 0, 1]])
 
-        ang = freud.environment.LocalBondProjection(r_guess, num_neighbors)
+        ang = freud.environment.LocalBondProjection()
 
         with self.assertRaises(AttributeError):
             ang.nlist
@@ -84,7 +84,7 @@ class TestLocalBondProjection(unittest.TestCase):
 
         # First have no particle symmetry
 
-        ang = freud.environment.LocalBondProjection(r_guess, num_neighbors)
+        ang = freud.environment.LocalBondProjection()
         ang.compute(box, proj_vecs, points, ors, neighbors=query_args)
 
         dnlist = freud.locality.make_default_nlist(
@@ -147,7 +147,7 @@ class TestLocalBondProjection(unittest.TestCase):
         npt.assert_allclose(ang.normed_projections[2], 1, atol=1e-6)
 
     def test_repr(self):
-        ang = freud.environment.LocalBondProjection(3.0, 8)
+        ang = freud.environment.LocalBondProjection()
         self.assertEqual(str(ang), str(eval(repr(ang))))
 
 

--- a/tests/test_environment_LocalBondProjection.py
+++ b/tests/test_environment_LocalBondProjection.py
@@ -7,62 +7,6 @@ from util import make_box_and_random_points
 
 
 class TestLocalBondProjection(unittest.TestCase):
-    def test_num_points(self):
-        boxlen = 10
-        N = 500
-        num_neighbors = 8
-        r_guess = 3
-        query_args = dict(num_neighbors=num_neighbors, r_guess=r_guess)
-
-        N_query = N//3
-
-        box, points = make_box_and_random_points(boxlen, N, True)
-        _, query_points = make_box_and_random_points(boxlen, N_query, True)
-        ors = rowan.random.rand(N)
-        proj_vecs = np.asarray([[0, 0, 1]])
-
-        ang = freud.environment.LocalBondProjection(r_guess, num_neighbors)
-        ang.compute(box, proj_vecs, points, ors, query_points,
-                    neighbors=query_args)
-        self.assertEqual(ang.num_points, N)
-        self.assertEqual(ang.num_query_points, N_query)
-
-    def test_num_proj_vectors(self):
-        boxlen = 10
-        N = 500
-        num_neighbors = 8
-        r_guess = 3
-        query_args = dict(num_neighbors=num_neighbors, r_guess=r_guess)
-
-        box, points = make_box_and_random_points(boxlen, N, True)
-        ors = rowan.random.rand(N)
-        proj_vecs = np.asarray([[0, 0, 1]])
-
-        ang = freud.environment.LocalBondProjection(r_guess, num_neighbors)
-        ang.compute(box, proj_vecs, points, ors, neighbors=query_args)
-        npt.assert_equal(ang.num_proj_vectors, 1)
-
-    def test_box(self):
-        boxlen = 10
-        N = 500
-        num_neighbors = 8
-        r_guess = 3
-        query_args = dict(num_neighbors=num_neighbors, r_guess=r_guess)
-
-        box, points = make_box_and_random_points(boxlen, N)
-        ors = rowan.random.rand(N)
-        proj_vecs = np.asarray([[0, 0, 1]])
-
-        ang = freud.environment.LocalBondProjection(r_guess, num_neighbors)
-        ang.compute(box, proj_vecs, points, ors, neighbors=query_args)
-
-        npt.assert_equal(ang.box.Lx, boxlen)
-        npt.assert_equal(ang.box.Ly, boxlen)
-        npt.assert_equal(ang.box.Lz, boxlen)
-        npt.assert_equal(ang.box.xy, 0)
-        npt.assert_equal(ang.box.xz, 0)
-        npt.assert_equal(ang.box.yz, 0)
-
     def test_nlist(self):
         """Check that the internally generated NeighborList is correct."""
         boxlen = 10
@@ -106,24 +50,12 @@ class TestLocalBondProjection(unittest.TestCase):
             ang.projections
         with self.assertRaises(AttributeError):
             ang.normed_projections
-        with self.assertRaises(AttributeError):
-            ang.num_points
-        with self.assertRaises(AttributeError):
-            ang.num_points
-        with self.assertRaises(AttributeError):
-            ang.num_proj_vectors
-        with self.assertRaises(AttributeError):
-            ang.box
 
         ang.compute(box, proj_vecs, points, ors, neighbors=query_args)
 
         ang.nlist
         ang.projections
         ang.normed_projections
-        ang.num_query_points
-        ang.num_points
-        ang.num_proj_vectors
-        ang.box
 
     def test_compute(self):
         boxlen = 4

--- a/tests/test_environment_LocalBondProjection.py
+++ b/tests/test_environment_LocalBondProjection.py
@@ -63,6 +63,30 @@ class TestLocalBondProjection(unittest.TestCase):
         npt.assert_equal(ang.box.xz, 0)
         npt.assert_equal(ang.box.yz, 0)
 
+    def test_nlist(self):
+        """Check that the internally generated NeighborList is correct."""
+        boxlen = 10
+        N = 500
+        num_neighbors = 8
+        r_guess = 3
+        query_args = dict(num_neighbors=num_neighbors, r_guess=r_guess)
+
+        N_query = N//3
+
+        box, points = make_box_and_random_points(boxlen, N, True)
+        _, query_points = make_box_and_random_points(boxlen, N_query, True)
+        ors = rowan.random.rand(N)
+        proj_vecs = np.asarray([[0, 0, 1]])
+
+        ang = freud.environment.LocalBondProjection(r_guess, num_neighbors)
+        ang.compute(box, proj_vecs, points, ors, query_points,
+                    neighbors=query_args)
+
+        aq = freud.locality.AABBQuery(box, points)
+        nlist = aq.query(query_points, query_args).toNeighborList()
+
+        npt.assert_array_equal(nlist[:], ang.nlist[:])
+
     def test_attribute_access(self):
         boxlen = 10
         N = 100

--- a/tests/test_environment_LocalDescriptors.py
+++ b/tests/test_environment_LocalDescriptors.py
@@ -231,7 +231,7 @@ class TestLocalDescriptors(unittest.TestCase):
             # Test all allowable values of l.
             for L in range(2, l_max+1):
                 steinhardt = freud.order.Steinhardt(L)
-                steinhardt.compute(box, points, nlist=nl)
+                steinhardt.compute(box, points, neighbors=nl)
                 # Some of the calculations done for Steinhardt can be imprecise
                 # in cases where there is no symmetry. Since simple cubic
                 # should have a 0 Ql value in many cases, we need to set high
@@ -276,7 +276,7 @@ class TestLocalDescriptors(unittest.TestCase):
             # Test all allowable values of l.
             for L in range(2, l_max+1):
                 steinhardt = freud.order.Steinhardt(L, weighted=True)
-                steinhardt.compute(box, points, nlist=nl)
+                steinhardt.compute(box, points, neighbors=nl)
                 # Some of the calculations done for Steinhardt can be imprecise
                 # in cases where there is no symmetry. Since simple cubic
                 # should have a 0 Ql value in many cases, we need to set high
@@ -317,7 +317,7 @@ class TestLocalDescriptors(unittest.TestCase):
             # Test all allowable values of l.
             for L in range(2, l_max+1):
                 steinhardt = freud.order.Steinhardt(L, Wl=True)
-                steinhardt.compute(box, points, nlist=nl)
+                steinhardt.compute(box, points, neighbors=nl)
                 npt.assert_array_almost_equal(steinhardt.order, Wl[:, L])
 
     @skipIfMissing('scipy.special')

--- a/tests/test_environment_LocalDescriptors.py
+++ b/tests/test_environment_LocalDescriptors.py
@@ -102,7 +102,8 @@ class TestLocalDescriptors(unittest.TestCase):
         with self.assertRaises(AttributeError):
             comp.num_sphs
 
-        comp.compute(box, num_neighbors, positions)
+        comp.compute(box, positions, neighbors={'num_neighbors':
+                                                num_neighbors})
 
         # Test access
         comp.sph
@@ -127,7 +128,8 @@ class TestLocalDescriptors(unittest.TestCase):
 
         comp = freud.environment.LocalDescriptors(
             num_neighbors, l_max, .5, True)
-        comp.compute(box, num_neighbors, positions, mode='global')
+        comp.compute(box, positions, mode='global',
+                     neighbors=dict(num_neighbors=num_neighbors))
 
         sphs = comp.sph
 
@@ -148,10 +150,12 @@ class TestLocalDescriptors(unittest.TestCase):
             num_neighbors, l_max, .5, True)
 
         with self.assertRaises(RuntimeError):
-            comp.compute(box, num_neighbors, positions, mode='particle_local')
+            comp.compute(box, positions, mode='particle_local',
+                         neighbors=dict(num_neighbors=num_neighbors))
 
-        comp.compute(box, num_neighbors, positions,
-                     orientations=orientations, mode='particle_local')
+        comp.compute(box, positions,
+                     orientations=orientations, mode='particle_local',
+                     neighbors=dict(num_neighbors=num_neighbors))
 
         sphs = comp.sph
 
@@ -169,8 +173,9 @@ class TestLocalDescriptors(unittest.TestCase):
             num_neighbors, l_max, .5, True)
 
         with self.assertRaises(RuntimeError):
-            comp.compute(box, num_neighbors, positions,
-                         mode='particle_local_wrong')
+            comp.compute(box, positions,
+                         mode='particle_local_wrong',
+                         neighbors=dict(num_neighbors=num_neighbors))
 
     def test_shape_twosets(self):
         N = 1000
@@ -184,7 +189,8 @@ class TestLocalDescriptors(unittest.TestCase):
 
         comp = freud.environment.LocalDescriptors(
             num_neighbors, l_max, .5, True)
-        comp.compute(box, num_neighbors, positions, positions2)
+        comp.compute(box, positions, positions2, neighbors={'num_neighbors':
+                                                            num_neighbors})
         sphs = comp.sph
         self.assertEqual(sphs.shape[0], N//3*num_neighbors)
 
@@ -213,7 +219,7 @@ class TestLocalDescriptors(unittest.TestCase):
                                num_neighbors=num_neighbors)).toNeighborList()
             ld = freud.environment.LocalDescriptors(
                 num_neighbors, l_max, r_max)
-            ld.compute(box, num_neighbors, points, mode='global', nlist=nl)
+            ld.compute(box, points, mode='global', neighbors=nl)
 
             Ql = get_Ql(points, ld, nl)
 
@@ -254,7 +260,7 @@ class TestLocalDescriptors(unittest.TestCase):
                                num_neighbors=num_neighbors)).toNeighborList()
             ld = freud.environment.LocalDescriptors(
                 num_neighbors, l_max, r_max)
-            ld.compute(box, num_neighbors, points, mode='global', nlist=nl)
+            ld.compute(box, points, mode='global', neighbors=nl)
 
             # Generate random weights for each bond
             nl = freud.locality.NeighborList.from_arrays(
@@ -303,7 +309,7 @@ class TestLocalDescriptors(unittest.TestCase):
                                num_neighbors=num_neighbors)).toNeighborList()
             ld = freud.environment.LocalDescriptors(
                 num_neighbors, l_max, r_max)
-            ld.compute(box, num_neighbors, points, mode='global', nlist=nl)
+            ld.compute(box, points, mode='global', neighbors=nl)
 
             Wl = get_Wl(points, ld, nl)
 
@@ -336,7 +342,7 @@ class TestLocalDescriptors(unittest.TestCase):
 
         ld = freud.environment.LocalDescriptors(
             num_neighbors, l_max, r_max)
-        ld.compute(box, num_neighbors, points, mode='global', nlist=nl)
+        ld.compute(box, points, mode='global', neighbors=nl)
 
         # Loop over the sphs and compute them explicitly.
         for idx, (i, j) in enumerate(nl):
@@ -399,8 +405,8 @@ class TestLocalDescriptors(unittest.TestCase):
 
         ld = freud.environment.LocalDescriptors(
             num_neighbors, l_max, r_max)
-        ld.compute(box, num_neighbors, ref_points, points, mode='global',
-                   nlist=nl)
+        ld.compute(box, ref_points, points, mode='global',
+                   neighbors=nl)
 
         # Loop over the sphs and compute them explicitly.
         for idx, (i, j) in enumerate(nl):

--- a/tests/test_environment_LocalDescriptors.py
+++ b/tests/test_environment_LocalDescriptors.py
@@ -177,6 +177,27 @@ class TestLocalDescriptors(unittest.TestCase):
                          mode='particle_local_wrong',
                          neighbors=dict(num_neighbors=num_neighbors))
 
+    def test_nlist(self):
+        """Check that the internally generated NeighborList is correct."""
+        N = 1000
+        num_neighbors = 4
+        l_max = 8
+        L = 10
+
+        box, positions = make_box_and_random_points(L, N)
+        positions2 = np.random.uniform(-L/2, L/2,
+                                       size=(N//3, 3)).astype(np.float32)
+
+        comp = freud.environment.LocalDescriptors(
+            num_neighbors, l_max, .5, True)
+        qargs = {'num_neighbors': num_neighbors}
+        comp.compute(box, positions, positions2, neighbors=qargs)
+
+        aq = freud.locality.AABBQuery(box, positions)
+        nlist = aq.query(positions2, qargs).toNeighborList()
+
+        npt.assert_array_equal(nlist[:], comp.nlist[:])
+
     def test_shape_twosets(self):
         N = 1000
         num_neighbors = 4

--- a/tests/test_environment_LocalDescriptors.py
+++ b/tests/test_environment_LocalDescriptors.py
@@ -117,8 +117,8 @@ class TestLocalDescriptors(unittest.TestCase):
 
         box, positions = make_box_and_random_points(L, N)
 
-        comp = freud.environment.LocalDescriptors(l_max, True)
-        comp.compute(box, positions, mode='global',
+        comp = freud.environment.LocalDescriptors(l_max, True, 'global')
+        comp.compute(box, positions,
                      neighbors=dict(num_neighbors=num_neighbors))
 
         sphs = comp.sph
@@ -136,14 +136,15 @@ class TestLocalDescriptors(unittest.TestCase):
         orientations /= np.sqrt(np.sum(orientations**2,
                                        axis=-1))[:, np.newaxis]
 
-        comp = freud.environment.LocalDescriptors(l_max, True)
+        comp = freud.environment.LocalDescriptors(l_max, True,
+                                                  mode='particle_local')
 
         with self.assertRaises(RuntimeError):
-            comp.compute(box, positions, mode='particle_local',
+            comp.compute(box, positions,
                          neighbors=dict(num_neighbors=num_neighbors))
 
         comp.compute(box, positions,
-                     orientations=orientations, mode='particle_local',
+                     orientations=orientations,
                      neighbors=dict(num_neighbors=num_neighbors))
 
         sphs = comp.sph
@@ -152,18 +153,14 @@ class TestLocalDescriptors(unittest.TestCase):
 
     def test_unknown_modes(self):
         N = 1000
-        num_neighbors = 4
         l_max = 8
         L = 10
 
         box, positions = make_box_and_random_points(L, N)
 
-        comp = freud.environment.LocalDescriptors(l_max, True)
-
-        with self.assertRaises(RuntimeError):
-            comp.compute(box, positions,
-                         mode='particle_local_wrong',
-                         neighbors=dict(num_neighbors=num_neighbors))
+        with self.assertRaises(ValueError):
+            freud.environment.LocalDescriptors(
+                l_max, True, mode='particle_local_wrong')
 
     def test_nlist(self):
         """Check that the internally generated NeighborList is correct."""
@@ -223,8 +220,8 @@ class TestLocalDescriptors(unittest.TestCase):
             nl = lc.query(points,
                           dict(exclude_ii=True,
                                num_neighbors=num_neighbors)).toNeighborList()
-            ld = freud.environment.LocalDescriptors(l_max)
-            ld.compute(box, points, mode='global', neighbors=nl)
+            ld = freud.environment.LocalDescriptors(l_max, mode='global')
+            ld.compute(box, points, neighbors=nl)
 
             Ql = get_Ql(points, ld, nl)
 
@@ -262,8 +259,8 @@ class TestLocalDescriptors(unittest.TestCase):
             nl = lc.query(points,
                           dict(exclude_ii=True,
                                num_neighbors=num_neighbors)).toNeighborList()
-            ld = freud.environment.LocalDescriptors(l_max)
-            ld.compute(box, points, mode='global', neighbors=nl)
+            ld = freud.environment.LocalDescriptors(l_max, mode='global')
+            ld.compute(box, points, neighbors=nl)
 
             # Generate random weights for each bond
             nl = freud.locality.NeighborList.from_arrays(
@@ -309,8 +306,8 @@ class TestLocalDescriptors(unittest.TestCase):
             nl = lc.query(points,
                           dict(exclude_ii=True,
                                num_neighbors=num_neighbors)).toNeighborList()
-            ld = freud.environment.LocalDescriptors(l_max)
-            ld.compute(box, points, mode='global', neighbors=nl)
+            ld = freud.environment.LocalDescriptors(l_max, mode='global')
+            ld.compute(box, points, neighbors=nl)
 
             Wl = get_Wl(points, ld, nl)
 
@@ -340,8 +337,8 @@ class TestLocalDescriptors(unittest.TestCase):
                       dict(exclude_ii=True,
                            num_neighbors=num_neighbors)).toNeighborList()
 
-        ld = freud.environment.LocalDescriptors(l_max)
-        ld.compute(box, points, mode='global', neighbors=nl)
+        ld = freud.environment.LocalDescriptors(l_max, mode='global')
+        ld.compute(box, points, neighbors=nl)
 
         # Loop over the sphs and compute them explicitly.
         for idx, (i, j) in enumerate(nl):
@@ -401,9 +398,8 @@ class TestLocalDescriptors(unittest.TestCase):
                       dict(exclude_ii=True,
                            num_neighbors=num_neighbors)).toNeighborList()
 
-        ld = freud.environment.LocalDescriptors(l_max)
-        ld.compute(box, ref_points, points, mode='global',
-                   neighbors=nl)
+        ld = freud.environment.LocalDescriptors(l_max, mode='global')
+        ld.compute(box, ref_points, points, neighbors=nl)
 
         # Loop over the sphs and compute them explicitly.
         for idx, (i, j) in enumerate(nl):

--- a/tests/test_environment_LocalDescriptors.py
+++ b/tests/test_environment_LocalDescriptors.py
@@ -85,14 +85,12 @@ class TestLocalDescriptors(unittest.TestCase):
         N = 1000
         num_neighbors = 4
         l_max = 8
-        r_max = 0.5
         L = 10
 
         box, positions = make_box_and_random_points(L, N)
         positions.flags['WRITEABLE'] = False
 
-        comp = freud.environment.LocalDescriptors(
-            num_neighbors, l_max, r_max, True)
+        comp = freud.environment.LocalDescriptors(l_max, True)
 
         # Test access
         with self.assertRaises(AttributeError):
@@ -126,8 +124,7 @@ class TestLocalDescriptors(unittest.TestCase):
 
         box, positions = make_box_and_random_points(L, N)
 
-        comp = freud.environment.LocalDescriptors(
-            num_neighbors, l_max, .5, True)
+        comp = freud.environment.LocalDescriptors(l_max, True)
         comp.compute(box, positions, mode='global',
                      neighbors=dict(num_neighbors=num_neighbors))
 
@@ -146,8 +143,7 @@ class TestLocalDescriptors(unittest.TestCase):
         orientations /= np.sqrt(np.sum(orientations**2,
                                        axis=-1))[:, np.newaxis]
 
-        comp = freud.environment.LocalDescriptors(
-            num_neighbors, l_max, .5, True)
+        comp = freud.environment.LocalDescriptors(l_max, True)
 
         with self.assertRaises(RuntimeError):
             comp.compute(box, positions, mode='particle_local',
@@ -169,8 +165,7 @@ class TestLocalDescriptors(unittest.TestCase):
 
         box, positions = make_box_and_random_points(L, N)
 
-        comp = freud.environment.LocalDescriptors(
-            num_neighbors, l_max, .5, True)
+        comp = freud.environment.LocalDescriptors(l_max, True)
 
         with self.assertRaises(RuntimeError):
             comp.compute(box, positions,
@@ -188,8 +183,7 @@ class TestLocalDescriptors(unittest.TestCase):
         positions2 = np.random.uniform(-L/2, L/2,
                                        size=(N//3, 3)).astype(np.float32)
 
-        comp = freud.environment.LocalDescriptors(
-            num_neighbors, l_max, .5, True)
+        comp = freud.environment.LocalDescriptors(l_max, True)
         qargs = {'num_neighbors': num_neighbors}
         comp.compute(box, positions, positions2, neighbors=qargs)
 
@@ -208,15 +202,14 @@ class TestLocalDescriptors(unittest.TestCase):
         positions2 = np.random.uniform(-L/2, L/2,
                                        size=(N//3, 3)).astype(np.float32)
 
-        comp = freud.environment.LocalDescriptors(
-            num_neighbors, l_max, .5, True)
+        comp = freud.environment.LocalDescriptors(l_max, True)
         comp.compute(box, positions, positions2, neighbors={'num_neighbors':
                                                             num_neighbors})
         sphs = comp.sph
         self.assertEqual(sphs.shape[0], N//3*num_neighbors)
 
     def test_repr(self):
-        comp = freud.environment.LocalDescriptors(4, 8, 0.5, True)
+        comp = freud.environment.LocalDescriptors(8, True)
         self.assertEqual(str(comp), str(eval(repr(comp))))
 
     def test_ql(self):
@@ -227,7 +220,6 @@ class TestLocalDescriptors(unittest.TestCase):
         # Steinhardt.
         num_neighbors = 6
         l_max = 12
-        r_max = 2
 
         for struct_func in [make_sc, make_bcc, make_fcc]:
             box, points = struct_func(5, 5, 5)
@@ -238,8 +230,7 @@ class TestLocalDescriptors(unittest.TestCase):
             nl = lc.query(points,
                           dict(exclude_ii=True,
                                num_neighbors=num_neighbors)).toNeighborList()
-            ld = freud.environment.LocalDescriptors(
-                num_neighbors, l_max, r_max)
+            ld = freud.environment.LocalDescriptors(l_max)
             ld.compute(box, points, mode='global', neighbors=nl)
 
             Ql = get_Ql(points, ld, nl)
@@ -268,7 +259,6 @@ class TestLocalDescriptors(unittest.TestCase):
         # Steinhardt.
         num_neighbors = 6
         l_max = 12
-        r_max = 2
 
         for struct_func in [make_sc, make_bcc, make_fcc]:
             box, points = struct_func(5, 5, 5)
@@ -279,8 +269,7 @@ class TestLocalDescriptors(unittest.TestCase):
             nl = lc.query(points,
                           dict(exclude_ii=True,
                                num_neighbors=num_neighbors)).toNeighborList()
-            ld = freud.environment.LocalDescriptors(
-                num_neighbors, l_max, r_max)
+            ld = freud.environment.LocalDescriptors(l_max)
             ld.compute(box, points, mode='global', neighbors=nl)
 
             # Generate random weights for each bond
@@ -317,7 +306,6 @@ class TestLocalDescriptors(unittest.TestCase):
         # Steinhardt.
         num_neighbors = 6
         l_max = 12
-        r_max = 2
 
         for struct_func in [make_sc, make_bcc, make_fcc]:
             box, points = struct_func(5, 5, 5)
@@ -328,8 +316,7 @@ class TestLocalDescriptors(unittest.TestCase):
             nl = lc.query(points,
                           dict(exclude_ii=True,
                                num_neighbors=num_neighbors)).toNeighborList()
-            ld = freud.environment.LocalDescriptors(
-                num_neighbors, l_max, r_max)
+            ld = freud.environment.LocalDescriptors(l_max)
             ld.compute(box, points, mode='global', neighbors=nl)
 
             Wl = get_Wl(points, ld, nl)
@@ -351,7 +338,6 @@ class TestLocalDescriptors(unittest.TestCase):
         box, points = make_box_and_random_points(L, N)
 
         num_neighbors = 1
-        r_max = 2
         l_max = 2
 
         # We want to provide the NeighborList ourselves since we need to use it
@@ -361,8 +347,7 @@ class TestLocalDescriptors(unittest.TestCase):
                       dict(exclude_ii=True,
                            num_neighbors=num_neighbors)).toNeighborList()
 
-        ld = freud.environment.LocalDescriptors(
-            num_neighbors, l_max, r_max)
+        ld = freud.environment.LocalDescriptors(l_max)
         ld.compute(box, points, mode='global', neighbors=nl)
 
         # Loop over the sphs and compute them explicitly.
@@ -414,7 +399,6 @@ class TestLocalDescriptors(unittest.TestCase):
         ref_points = np.random.rand(N, 3)*L - L/2
 
         num_neighbors = 1
-        r_max = 2
         l_max = 2
 
         # We want to provide the NeighborList ourselves since we need to use it
@@ -424,8 +408,7 @@ class TestLocalDescriptors(unittest.TestCase):
                       dict(exclude_ii=True,
                            num_neighbors=num_neighbors)).toNeighborList()
 
-        ld = freud.environment.LocalDescriptors(
-            num_neighbors, l_max, r_max)
+        ld = freud.environment.LocalDescriptors(l_max)
         ld.compute(box, ref_points, points, mode='global',
                    neighbors=nl)
 

--- a/tests/test_environment_LocalDescriptors.py
+++ b/tests/test_environment_LocalDescriptors.py
@@ -96,8 +96,6 @@ class TestLocalDescriptors(unittest.TestCase):
         with self.assertRaises(AttributeError):
             comp.sph
         with self.assertRaises(AttributeError):
-            comp.num_particles
-        with self.assertRaises(AttributeError):
             comp.num_sphs
 
         comp.compute(box, positions, neighbors={'num_neighbors':
@@ -105,14 +103,9 @@ class TestLocalDescriptors(unittest.TestCase):
 
         # Test access
         comp.sph
-        comp.num_particles
         comp.num_sphs
 
         self.assertEqual(comp.sph.shape[0], N*num_neighbors)
-
-        self.assertEqual(comp.num_particles, positions.shape[0])
-
-        self.assertEqual(comp.num_sphs/comp.num_particles, num_neighbors)
 
         self.assertEqual(comp.l_max, l_max)
 

--- a/tests/test_locality_NeighborQuery.py
+++ b/tests/test_locality_NeighborQuery.py
@@ -667,7 +667,7 @@ class TestMultipleMethods(unittest.TestCase):
         r_max = 1.6
         num_neighbors = 12
 
-        test_set = util.make_raw_query_nlist_test_set_new(
+        test_set = util.make_raw_query_nlist_test_set(
             box, points, query_points, "nearest", r_max, num_neighbors, False)
         nlist = test_set[-1][1]
         for ts in test_set:

--- a/tests/test_locality_NeighborQuery.py
+++ b/tests/test_locality_NeighborQuery.py
@@ -667,14 +667,14 @@ class TestMultipleMethods(unittest.TestCase):
         r_max = 1.6
         num_neighbors = 12
 
-        test_set = util.make_raw_query_nlist_test_set(
+        test_set = util.make_raw_query_nlist_test_set_new(
             box, points, query_points, "nearest", r_max, num_neighbors, False)
         nlist = test_set[-1][1]
         for ts in test_set:
             if not isinstance(ts[0], freud.locality.NeighborQuery):
                 continue
             check_nlist = ts[0].query(
-                query_points, query_args=ts[2]).toNeighborList()
+                query_points, ts[1]).toNeighborList()
             self.assertTrue(nlist_equal(nlist, check_nlist))
 
 

--- a/tests/test_order_Hexatic.py
+++ b/tests/test_order_Hexatic.py
@@ -51,7 +51,7 @@ class TestHexatic(unittest.TestCase):
         with self.assertRaises(AttributeError):
             hop.order
 
-        test_set = util.make_raw_query_nlist_test_set_new(
+        test_set = util.make_raw_query_nlist_test_set(
             box, points, points, 'nearest', r_max, 6, True)
         for ts in test_set:
             hop.compute(box, ts[0], neighbors=ts[1])

--- a/tests/test_order_Hexatic.py
+++ b/tests/test_order_Hexatic.py
@@ -51,10 +51,10 @@ class TestHexatic(unittest.TestCase):
         with self.assertRaises(AttributeError):
             hop.order
 
-        test_set = util.make_raw_query_nlist_test_set(
+        test_set = util.make_raw_query_nlist_test_set_new(
             box, points, points, 'nearest', r_max, 6, True)
         for ts in test_set:
-            hop.compute(box, ts[0], nlist=ts[1])
+            hop.compute(box, ts[0], neighbors=ts[1])
             # Test access
             hop.k
             hop.order

--- a/tests/test_order_SolidLiquid.py
+++ b/tests/test_order_SolidLiquid.py
@@ -73,6 +73,8 @@ class TestSolidLiquid(unittest.TestCase):
         with self.assertRaises(AttributeError):
             comp.num_connections
         with self.assertRaises(AttributeError):
+            comp.Ql_ij
+        with self.assertRaises(AttributeError):
             comp.plot()
 
         comp.compute(box, positions, neighbors=dict(r_max=2.0))
@@ -81,6 +83,7 @@ class TestSolidLiquid(unittest.TestCase):
         comp.cluster_sizes
         comp.cluster_idx
         comp.num_connections
+        comp.Ql_ij
         comp._repr_png_()
 
     def test_repr(self):

--- a/tests/test_order_SolidLiquid.py
+++ b/tests/test_order_SolidLiquid.py
@@ -12,7 +12,7 @@ class TestSolidLiquid(unittest.TestCase):
         box, positions = util.make_box_and_random_points(L, N)
 
         comp = freud.order.SolidLiquid(6, Q_threshold=.7, S_threshold=6)
-        comp.compute(box, positions, query_args=dict(r_max=2.0))
+        comp.compute(box, positions, neighbors=dict(r_max=2.0))
 
         npt.assert_equal(comp.cluster_idx.shape, (N,))
 
@@ -26,7 +26,7 @@ class TestSolidLiquid(unittest.TestCase):
 
         for comp in (comp_default, comp_no_norm):
             for query_args in (dict(r_max=2.0), dict(num_neighbors=12)):
-                comp.compute(box, positions, query_args=query_args)
+                comp.compute(box, positions, neighbors=query_args)
                 self.assertEqual(comp.largest_cluster_size, len(positions))
                 self.assertEqual(len(comp.cluster_sizes), 1)
                 self.assertEqual(comp.cluster_sizes[0], len(positions))
@@ -59,7 +59,7 @@ class TestSolidLiquid(unittest.TestCase):
         with self.assertRaises(AttributeError):
             comp.plot()
 
-        comp.compute(box, positions, query_args=dict(r_max=2.0))
+        comp.compute(box, positions, neighbors=dict(r_max=2.0))
 
         comp.largest_cluster_size
         comp.cluster_sizes

--- a/tests/test_order_SolidLiquid.py
+++ b/tests/test_order_SolidLiquid.py
@@ -16,6 +16,22 @@ class TestSolidLiquid(unittest.TestCase):
 
         npt.assert_equal(comp.cluster_idx.shape, (N,))
 
+    def test_nlist(self):
+        """Check that the internally generated NeighborList is correct."""
+        N = 1000
+        L = 10
+
+        box, positions = util.make_box_and_random_points(L, N)
+
+        query_args = dict(r_max=2.0, exclude_ii=True)
+        comp = freud.order.SolidLiquid(6, Q_threshold=.7, S_threshold=6)
+        comp.compute(box, positions, neighbors=query_args)
+
+        aq = freud.locality.AABBQuery(box, positions)
+        nlist = aq.query(positions, query_args).toNeighborList()
+
+        npt.assert_array_equal(nlist[:], comp.nlist[:])
+
     def test_identical_environments(self):
         box, positions = util.make_fcc(4, 4, 4)
 

--- a/tests/test_order_Steinhardt.py
+++ b/tests/test_order_Steinhardt.py
@@ -55,7 +55,7 @@ class TestSteinhardt(unittest.TestCase):
     def test_identical_environments_Ql(self):
         (box, positions) = util.make_fcc(4, 4, 4)
         r_max = 1.5
-        test_set = util.make_raw_query_nlist_test_set_new(
+        test_set = util.make_raw_query_nlist_test_set(
             box, positions, positions, 'ball', r_max, 0, True)
         for ts in test_set:
             comp = freud.order.Steinhardt(6)
@@ -77,7 +77,7 @@ class TestSteinhardt(unittest.TestCase):
 
         r_max = 1.5
         n = 12
-        test_set = util.make_raw_query_nlist_test_set_new(
+        test_set = util.make_raw_query_nlist_test_set(
             box, positions, positions, 'nearest', r_max, n, True)
         for ts in test_set:
             comp = freud.order.Steinhardt(6)
@@ -98,7 +98,7 @@ class TestSteinhardt(unittest.TestCase):
         perturbed_positions = positions.copy()
         perturbed_positions[-1] += [0.1, 0, 0]
 
-        test_set = util.make_raw_query_nlist_test_set_new(
+        test_set = util.make_raw_query_nlist_test_set(
             box, perturbed_positions, perturbed_positions,
             'nearest', r_max, n, True)
         # Ensure exactly 13 values change for the perturbed system
@@ -119,7 +119,7 @@ class TestSteinhardt(unittest.TestCase):
         (box, positions) = util.make_fcc(4, 4, 4)
 
         r_max = 1.5
-        test_set = util.make_raw_query_nlist_test_set_new(
+        test_set = util.make_raw_query_nlist_test_set(
             box, positions, positions, 'ball', r_max, 0, True)
         for ts in test_set:
             comp = freud.order.Steinhardt(6, Wl=True)
@@ -140,7 +140,7 @@ class TestSteinhardt(unittest.TestCase):
         (box, positions) = util.make_fcc(4, 4, 4)
         r_max = 1.5
         n = 12
-        test_set = util.make_raw_query_nlist_test_set_new(
+        test_set = util.make_raw_query_nlist_test_set(
             box, positions, positions, 'nearest', r_max, n, True)
         for ts in test_set:
             comp = freud.order.Steinhardt(6, Wl=True)
@@ -163,7 +163,7 @@ class TestSteinhardt(unittest.TestCase):
         (box, positions) = util.make_fcc(4, 4, 4)
         r_max = 1.5
         n = 12
-        test_set = util.make_raw_query_nlist_test_set_new(
+        test_set = util.make_raw_query_nlist_test_set(
             box, positions, positions, 'nearest', r_max, n, True)
 
         # Skip test sets without an explicit neighbor list

--- a/tests/test_order_Steinhardt.py
+++ b/tests/test_order_Steinhardt.py
@@ -18,7 +18,7 @@ class TestSteinhardt(unittest.TestCase):
         box, positions = util.make_box_and_random_points(L, N)
 
         comp = freud.order.Steinhardt(6)
-        comp.compute(box, positions, query_args={'r_max': 1.5})
+        comp.compute(box, positions, neighbors={'r_max': 1.5})
 
         npt.assert_equal(comp.order.shape[0], N)
 
@@ -30,7 +30,7 @@ class TestSteinhardt(unittest.TestCase):
         box, positions = util.make_box_and_random_points(L, N)
 
         comp = freud.order.Steinhardt(0)
-        comp.compute(box, positions, query_args={'r_max': 1.5})
+        comp.compute(box, positions, neighbors={'r_max': 1.5})
 
         npt.assert_allclose(comp.order, 1, atol=1e-5)
 
@@ -44,29 +44,29 @@ class TestSteinhardt(unittest.TestCase):
 
         for odd_l in range(1, 20, 2):
             comp = freud.order.Steinhardt(odd_l)
-            comp.compute(box, positions, query_args={'num_neighbors': 2})
+            comp.compute(box, positions, neighbors={'num_neighbors': 2})
             npt.assert_allclose(comp.order, [1, 0, 1], atol=1e-5)
 
         for even_l in range(0, 20, 2):
             comp = freud.order.Steinhardt(even_l)
-            comp.compute(box, positions, query_args={'num_neighbors': 2})
+            comp.compute(box, positions, neighbors={'num_neighbors': 2})
             npt.assert_allclose(comp.order, 1, atol=1e-5)
 
     def test_identical_environments_Ql(self):
         (box, positions) = util.make_fcc(4, 4, 4)
         r_max = 1.5
-        test_set = util.make_raw_query_nlist_test_set(
+        test_set = util.make_raw_query_nlist_test_set_new(
             box, positions, positions, 'ball', r_max, 0, True)
         for ts in test_set:
             comp = freud.order.Steinhardt(6)
-            comp.compute(box, ts[0], nlist=ts[1], query_args=ts[2])
+            comp.compute(box, ts[0], neighbors=ts[1])
             npt.assert_allclose(
                 np.average(comp.order), PERFECT_FCC_Q6, atol=1e-5)
             npt.assert_allclose(comp.order, comp.order[0], atol=1e-5)
             self.assertAlmostEqual(comp.norm, PERFECT_FCC_Q6, delta=1e-5)
 
             comp = freud.order.Steinhardt(6, average=True)
-            comp.compute(box, ts[0], nlist=ts[1], query_args=ts[2])
+            comp.compute(box, ts[0], neighbors=ts[1])
             npt.assert_allclose(
                 np.average(comp.order), PERFECT_FCC_Q6, atol=1e-5)
             npt.assert_allclose(comp.order, comp.order[0], atol=1e-5)
@@ -77,18 +77,18 @@ class TestSteinhardt(unittest.TestCase):
 
         r_max = 1.5
         n = 12
-        test_set = util.make_raw_query_nlist_test_set(
+        test_set = util.make_raw_query_nlist_test_set_new(
             box, positions, positions, 'nearest', r_max, n, True)
         for ts in test_set:
             comp = freud.order.Steinhardt(6)
-            comp.compute(box, ts[0], nlist=ts[1], query_args=ts[2])
+            comp.compute(box, ts[0], neighbors=ts[1])
             npt.assert_allclose(
                 np.average(comp.order), PERFECT_FCC_Q6, atol=1e-5)
             npt.assert_allclose(comp.order, comp.order[0], atol=1e-5)
             self.assertAlmostEqual(comp.norm, PERFECT_FCC_Q6, delta=1e-5)
 
             comp = freud.order.Steinhardt(6, average=True)
-            comp.compute(box, ts[0], nlist=ts[1], query_args=ts[2])
+            comp.compute(box, ts[0], neighbors=ts[1])
             npt.assert_allclose(
                 np.average(comp.order), PERFECT_FCC_Q6, atol=1e-5)
             npt.assert_allclose(comp.order, comp.order[0], atol=1e-5)
@@ -98,20 +98,20 @@ class TestSteinhardt(unittest.TestCase):
         perturbed_positions = positions.copy()
         perturbed_positions[-1] += [0.1, 0, 0]
 
-        test_set = util.make_raw_query_nlist_test_set(
+        test_set = util.make_raw_query_nlist_test_set_new(
             box, perturbed_positions, perturbed_positions,
             'nearest', r_max, n, True)
         # Ensure exactly 13 values change for the perturbed system
         for ts in test_set:
             comp = freud.order.Steinhardt(6)
-            comp.compute(box, ts[0], nlist=ts[1], query_args=ts[2])
+            comp.compute(box, ts[0], neighbors=ts[1])
             self.assertEqual(
                 sum(~np.isclose(comp.Ql, PERFECT_FCC_Q6, rtol=1e-6)), 13)
 
             # More than 13 particles should change for
             # Ql averaged over neighbors
             comp = freud.order.Steinhardt(6, average=True)
-            comp.compute(box, ts[0], nlist=ts[1], query_args=ts[2])
+            comp.compute(box, ts[0], neighbors=ts[1])
             self.assertGreater(
                 sum(~np.isclose(comp.order, PERFECT_FCC_Q6, rtol=1e-6)), 13)
 
@@ -119,18 +119,18 @@ class TestSteinhardt(unittest.TestCase):
         (box, positions) = util.make_fcc(4, 4, 4)
 
         r_max = 1.5
-        test_set = util.make_raw_query_nlist_test_set(
+        test_set = util.make_raw_query_nlist_test_set_new(
             box, positions, positions, 'ball', r_max, 0, True)
         for ts in test_set:
             comp = freud.order.Steinhardt(6, Wl=True)
-            comp.compute(box, ts[0], nlist=ts[1], query_args=ts[2])
+            comp.compute(box, ts[0], neighbors=ts[1])
             npt.assert_allclose(
                 np.average(comp.order), PERFECT_FCC_W6, atol=1e-5)
             npt.assert_allclose(comp.order, comp.order[0], atol=1e-5)
             self.assertAlmostEqual(comp.norm, PERFECT_FCC_W6, delta=1e-5)
 
             comp = freud.order.Steinhardt(6, Wl=True, average=True)
-            comp.compute(box, ts[0], nlist=ts[1], query_args=ts[2])
+            comp.compute(box, ts[0], neighbors=ts[1])
             npt.assert_allclose(
                 np.average(comp.order), PERFECT_FCC_W6, atol=1e-5)
             npt.assert_allclose(comp.order, comp.order[0], atol=1e-5)
@@ -140,11 +140,11 @@ class TestSteinhardt(unittest.TestCase):
         (box, positions) = util.make_fcc(4, 4, 4)
         r_max = 1.5
         n = 12
-        test_set = util.make_raw_query_nlist_test_set(
+        test_set = util.make_raw_query_nlist_test_set_new(
             box, positions, positions, 'nearest', r_max, n, True)
         for ts in test_set:
             comp = freud.order.Steinhardt(6, Wl=True)
-            comp.compute(box, ts[0], nlist=ts[1], query_args=ts[2])
+            comp.compute(box, ts[0], neighbors=ts[1])
             npt.assert_allclose(
                 np.real(np.average(comp.order)), PERFECT_FCC_W6, atol=1e-5)
             npt.assert_allclose(comp.order, comp.order[0], atol=1e-5)
@@ -152,7 +152,7 @@ class TestSteinhardt(unittest.TestCase):
                 np.real(comp.norm), PERFECT_FCC_W6, delta=1e-5)
 
             comp = freud.order.Steinhardt(6, Wl=True, average=True)
-            comp.compute(box, ts[0], nlist=ts[1], query_args=ts[2])
+            comp.compute(box, ts[0], neighbors=ts[1])
             npt.assert_allclose(
                 np.real(np.average(comp.order)), PERFECT_FCC_W6, atol=1e-5)
             npt.assert_allclose(comp.order, comp.order[0], atol=1e-5)
@@ -163,11 +163,12 @@ class TestSteinhardt(unittest.TestCase):
         (box, positions) = util.make_fcc(4, 4, 4)
         r_max = 1.5
         n = 12
-        test_set = util.make_raw_query_nlist_test_set(
+        test_set = util.make_raw_query_nlist_test_set_new(
             box, positions, positions, 'nearest', r_max, n, True)
 
         # Skip test sets without an explicit neighbor list
-        for ts in filter(lambda ts: ts[1] is not None, test_set):
+        for ts in filter(lambda ts: type(ts[1]) == freud.locality.NeighborList,
+                         test_set):
             nlist = ts[1]
 
             for wt in [0, 0.1, 0.9, 1.1, 10, 1e6]:
@@ -182,7 +183,7 @@ class TestSteinhardt(unittest.TestCase):
                     weights)
 
                 comp = freud.order.Steinhardt(6, weighted=True)
-                comp.compute(box, ts[0], nlist=weighted_nlist)
+                comp.compute(box, ts[0], neighbors=weighted_nlist)
 
                 # Unequal neighbor weighting in a perfect FCC structure
                 # appears to increase the Q6 order parameter
@@ -192,7 +193,7 @@ class TestSteinhardt(unittest.TestCase):
 
                 # Ensure that W6 values are altered by changing the weights
                 comp = freud.order.Steinhardt(6, Wl=True, weighted=True)
-                comp.compute(box, ts[0], nlist=weighted_nlist)
+                comp.compute(box, ts[0], neighbors=weighted_nlist)
                 with self.assertRaises(AssertionError):
                     npt.assert_allclose(
                         np.real(np.average(comp.order)),
@@ -210,7 +211,7 @@ class TestSteinhardt(unittest.TestCase):
             comp.order
 
         (box, positions) = util.make_fcc(4, 4, 4)
-        comp.compute(box, positions, query_args={'r_max': 1.5})
+        comp.compute(box, positions, neighbors={'r_max': 1.5})
 
         comp.norm
         comp.order
@@ -222,8 +223,8 @@ class TestSteinhardt(unittest.TestCase):
         box, points = util.make_box_and_random_points(L, num_points, seed=0)
 
         st = freud.order.Steinhardt(6)
-        first_result = st.compute(box, points, query_args={'r_max': 1.5}).norm
-        second_result = st.compute(box, points, query_args={'r_max': 1.5}).norm
+        first_result = st.compute(box, points, neighbors={'r_max': 1.5}).norm
+        second_result = st.compute(box, points, neighbors={'r_max': 1.5}).norm
 
         npt.assert_array_almost_equal(first_result, second_result)
 
@@ -251,9 +252,9 @@ class TestSteinhardt(unittest.TestCase):
         q6 = freud.order.Steinhardt(6)
         w6 = freud.order.Steinhardt(6, Wl=True)
 
-        q6.compute(box, positions, nlist=nlist)
+        q6.compute(box, positions, neighbors=nlist)
         q6_unrotated_order = q6.order[0]
-        w6.compute(box, positions, nlist=nlist)
+        w6.compute(box, positions, neighbors=nlist)
         w6_unrotated_order = w6.order[0]
 
         for i in range(10):
@@ -262,12 +263,12 @@ class TestSteinhardt(unittest.TestCase):
             positions_rotated = rowan.rotate(quat, positions)
 
             # Ensure Q6 is rotationally invariant
-            q6.compute(box, positions_rotated, nlist=nlist)
+            q6.compute(box, positions_rotated, neighbors=nlist)
             npt.assert_allclose(q6.order[0], q6_unrotated_order, rtol=1e-5)
             npt.assert_allclose(q6.order[0], PERFECT_FCC_Q6, rtol=1e-5)
 
             # Ensure W6 is rotationally invariant
-            w6.compute(box, positions_rotated, nlist=nlist)
+            w6.compute(box, positions_rotated, neighbors=nlist)
             npt.assert_allclose(w6.order[0], w6_unrotated_order, rtol=1e-5)
             npt.assert_allclose(w6.order[0], PERFECT_FCC_W6, rtol=1e-5)
 

--- a/tests/test_order_Translational.py
+++ b/tests/test_order_Translational.py
@@ -26,7 +26,7 @@ class TestTranslational(unittest.TestCase):
         test_set = util.make_raw_query_nlist_test_set(
             box, positions, positions, 'nearest', r_max, n, True)
         for ts in test_set:
-            trans.compute(box, ts[0], nlist=ts[1])
+            trans.compute(box, ts[0], neighbors=ts[1])
             # Test access
             trans.order
 

--- a/tests/test_order_Translational.py
+++ b/tests/test_order_Translational.py
@@ -23,7 +23,7 @@ class TestTranslational(unittest.TestCase):
         with self.assertRaises(AttributeError):
             trans.order
 
-        test_set = util.make_raw_query_nlist_test_set(
+        test_set = util.make_raw_query_nlist_test_set_new(
             box, positions, positions, 'nearest', r_max, n, True)
         for ts in test_set:
             trans.compute(box, ts[0], neighbors=ts[1])

--- a/tests/test_order_Translational.py
+++ b/tests/test_order_Translational.py
@@ -23,7 +23,7 @@ class TestTranslational(unittest.TestCase):
         with self.assertRaises(AttributeError):
             trans.order
 
-        test_set = util.make_raw_query_nlist_test_set_new(
+        test_set = util.make_raw_query_nlist_test_set(
             box, positions, positions, 'nearest', r_max, n, True)
         for ts in test_set:
             trans.compute(box, ts[0], neighbors=ts[1])

--- a/tests/test_pmft.py
+++ b/tests/test_pmft.py
@@ -148,7 +148,7 @@ class TestPMFTR12(unittest.TestCase):
         absoluteTolerance = 0.1
 
         r_max = maxR
-        test_set = util.make_raw_query_nlist_test_set_new(
+        test_set = util.make_raw_query_nlist_test_set(
             box, points, points, 'ball', r_max, 0, True)
         for ts in test_set:
             myPMFT = freud.pmft.PMFTR12(maxR, (nbinsR, nbinsT1, nbinsT2))
@@ -182,7 +182,7 @@ class TestPMFTR12(unittest.TestCase):
         orientations = np.array([0]*len(points))
         query_orientations = np.array([0]*len(query_points))
 
-        test_set = util.make_raw_query_nlist_test_set_new(
+        test_set = util.make_raw_query_nlist_test_set(
             box, points, query_points, "ball", r_max, 0, False)
         for ts in test_set:
             pmft = freud.pmft.PMFTR12(r_max, nbins)
@@ -341,7 +341,7 @@ class TestPMFTXYT(unittest.TestCase):
         absoluteTolerance = 0.1
 
         r_max = np.sqrt(maxX**2 + maxY**2)
-        test_set = util.make_raw_query_nlist_test_set_new(
+        test_set = util.make_raw_query_nlist_test_set(
             box, points, points, 'ball', r_max, 0, True)
         for ts in test_set:
             myPMFT = freud.pmft.PMFTXYT(maxX, maxY, (nbinsX, nbinsY, nbinsT))
@@ -380,7 +380,7 @@ class TestPMFTXYT(unittest.TestCase):
         query_orientations = np.array([0]*len(query_points))
 
         r_max = np.sqrt(x_max**2 + y_max**2)
-        test_set = util.make_raw_query_nlist_test_set_new(
+        test_set = util.make_raw_query_nlist_test_set(
             box, points, query_points, 'ball', r_max, 0, False)
 
         for ts in test_set:
@@ -524,7 +524,7 @@ class TestPMFTXY2D(unittest.TestCase):
         absoluteTolerance = 0.1
 
         r_max = np.sqrt(maxX**2 + maxY**2)
-        test_set = util.make_raw_query_nlist_test_set_new(
+        test_set = util.make_raw_query_nlist_test_set(
             box, points, points, 'ball', r_max, 0, True)
         for ts in test_set:
             myPMFT = freud.pmft.PMFTXY2D(maxX, maxY, (nbinsX, nbinsY))
@@ -580,7 +580,7 @@ class TestPMFTXY2D(unittest.TestCase):
         orientations = np.array([0]*len(points))
 
         r_max = np.sqrt(x_max**2 + y_max**2)
-        test_set = util.make_raw_query_nlist_test_set_new(
+        test_set = util.make_raw_query_nlist_test_set(
             box, points, query_points, 'ball', r_max, 0, False)
 
         for ts in test_set:
@@ -783,7 +783,7 @@ class TestPMFTXYZ(unittest.TestCase):
         absoluteTolerance = 0.1
 
         r_max = np.sqrt(maxX**2 + maxY**2 + maxZ**2)
-        test_set = util.make_raw_query_nlist_test_set_new(
+        test_set = util.make_raw_query_nlist_test_set(
             box, points, points, 'ball', r_max, 0, True)
         for ts in test_set:
             myPMFT = freud.pmft.PMFTXYZ(

--- a/tests/test_pmft.py
+++ b/tests/test_pmft.py
@@ -148,19 +148,19 @@ class TestPMFTR12(unittest.TestCase):
         absoluteTolerance = 0.1
 
         r_max = maxR
-        test_set = util.make_raw_query_nlist_test_set(
+        test_set = util.make_raw_query_nlist_test_set_new(
             box, points, points, 'ball', r_max, 0, True)
         for ts in test_set:
             myPMFT = freud.pmft.PMFTR12(maxR, (nbinsR, nbinsT1, nbinsT2))
-            myPMFT.accumulate(box, ts[0], angles, nlist=ts[1])
+            myPMFT.accumulate(box, ts[0], angles, neighbors=ts[1])
             npt.assert_allclose(myPMFT.bin_counts, correct_bin_counts,
                                 atol=absoluteTolerance)
             myPMFT.reset()
-            myPMFT.compute(box, ts[0], angles, nlist=ts[1])
+            myPMFT.compute(box, ts[0], angles, neighbors=ts[1])
             npt.assert_allclose(myPMFT.bin_counts, correct_bin_counts,
                                 atol=absoluteTolerance)
 
-            myPMFT.compute(box, ts[0], angles, nlist=ts[1])
+            myPMFT.compute(box, ts[0], angles, neighbors=ts[1])
             npt.assert_allclose(myPMFT.bin_counts, correct_bin_counts,
                                 atol=absoluteTolerance)
 
@@ -182,13 +182,13 @@ class TestPMFTR12(unittest.TestCase):
         orientations = np.array([0]*len(points))
         query_orientations = np.array([0]*len(query_points))
 
-        test_set = util.make_raw_query_nlist_test_set(
+        test_set = util.make_raw_query_nlist_test_set_new(
             box, points, query_points, "ball", r_max, 0, False)
         for ts in test_set:
             pmft = freud.pmft.PMFTR12(r_max, nbins)
             pmft.compute(box, ts[0],
                          orientations, query_points,
-                         query_orientations, nlist=ts[1])
+                         query_orientations, neighbors=ts[1])
 
             self.assertEqual(np.count_nonzero(np.isinf(pmft.PMFT) == 0), 12)
             self.assertEqual(len(np.unique(pmft.PMFT)), 3)
@@ -341,19 +341,19 @@ class TestPMFTXYT(unittest.TestCase):
         absoluteTolerance = 0.1
 
         r_max = np.sqrt(maxX**2 + maxY**2)
-        test_set = util.make_raw_query_nlist_test_set(
+        test_set = util.make_raw_query_nlist_test_set_new(
             box, points, points, 'ball', r_max, 0, True)
         for ts in test_set:
             myPMFT = freud.pmft.PMFTXYT(maxX, maxY, (nbinsX, nbinsY, nbinsT))
-            myPMFT.accumulate(box, ts[0], angles, nlist=ts[1])
+            myPMFT.accumulate(box, ts[0], angles, neighbors=ts[1])
             npt.assert_allclose(myPMFT.bin_counts, correct_bin_counts,
                                 atol=absoluteTolerance)
             myPMFT.reset()
-            myPMFT.compute(box, ts[0], angles, nlist=ts[1])
+            myPMFT.compute(box, ts[0], angles, neighbors=ts[1])
             npt.assert_allclose(myPMFT.bin_counts, correct_bin_counts,
                                 atol=absoluteTolerance)
 
-            myPMFT.compute(box, ts[0], angles, nlist=ts[1])
+            myPMFT.compute(box, ts[0], angles, neighbors=ts[1])
             npt.assert_allclose(myPMFT.bin_counts, correct_bin_counts,
                                 atol=absoluteTolerance)
 
@@ -380,14 +380,14 @@ class TestPMFTXYT(unittest.TestCase):
         query_orientations = np.array([0]*len(query_points))
 
         r_max = np.sqrt(x_max**2 + y_max**2)
-        test_set = util.make_raw_query_nlist_test_set(
+        test_set = util.make_raw_query_nlist_test_set_new(
             box, points, query_points, 'ball', r_max, 0, False)
 
         for ts in test_set:
             pmft = freud.pmft.PMFTXYT(x_max, y_max, (n_x, n_y, n_t))
             pmft.compute(box, ts[0],
                          orientations, query_points,
-                         query_orientations, nlist=ts[1])
+                         query_orientations, neighbors=ts[1])
 
             # when rotated slightly, for each ref point, each quadrant
             # (corresponding to two consecutive bins) should contain 3 points.
@@ -524,19 +524,19 @@ class TestPMFTXY2D(unittest.TestCase):
         absoluteTolerance = 0.1
 
         r_max = np.sqrt(maxX**2 + maxY**2)
-        test_set = util.make_raw_query_nlist_test_set(
+        test_set = util.make_raw_query_nlist_test_set_new(
             box, points, points, 'ball', r_max, 0, True)
         for ts in test_set:
             myPMFT = freud.pmft.PMFTXY2D(maxX, maxY, (nbinsX, nbinsY))
-            myPMFT.accumulate(box, ts[0], angles, nlist=ts[1])
+            myPMFT.accumulate(box, ts[0], angles, neighbors=ts[1])
             npt.assert_allclose(myPMFT.bin_counts, correct_bin_counts,
                                 atol=absoluteTolerance)
             myPMFT.reset()
-            myPMFT.compute(box, ts[0], angles, nlist=ts[1])
+            myPMFT.compute(box, ts[0], angles, neighbors=ts[1])
             npt.assert_allclose(myPMFT.bin_counts, correct_bin_counts,
                                 atol=absoluteTolerance)
 
-            myPMFT.compute(box, ts[0], angles, nlist=ts[1])
+            myPMFT.compute(box, ts[0], angles, neighbors=ts[1])
             npt.assert_allclose(myPMFT.bin_counts, correct_bin_counts,
                                 atol=absoluteTolerance)
 
@@ -580,7 +580,7 @@ class TestPMFTXY2D(unittest.TestCase):
         orientations = np.array([0]*len(points))
 
         r_max = np.sqrt(x_max**2 + y_max**2)
-        test_set = util.make_raw_query_nlist_test_set(
+        test_set = util.make_raw_query_nlist_test_set_new(
             box, points, query_points, 'ball', r_max, 0, False)
 
         for ts in test_set:
@@ -609,7 +609,7 @@ class TestPMFTXY2D(unittest.TestCase):
         nbins = 3
         pmft = freud.pmft.PMFTXY2D(max_width, max_width, nbins)
         pmft.compute(box, points, angles, query_points,
-                     query_args={'mode': 'nearest', 'num_neighbors': 1})
+                     neighbors={'mode': 'nearest', 'num_neighbors': 1})
         # Now every point in query_points will find the origin as a neighbor.
         npt.assert_array_equal(
             pmft.bin_counts,
@@ -618,7 +618,7 @@ class TestPMFTXY2D(unittest.TestCase):
              [0, 1, 0]])
         # Now there will be only one neighbor for the single point.
         pmft.compute(box, query_points, query_angles, points,
-                     query_args={'mode': 'nearest', 'num_neighbors': 1})
+                     neighbors={'mode': 'nearest', 'num_neighbors': 1})
         npt.assert_array_equal(
             pmft.bin_counts,
             [[0, 1, 0],
@@ -637,7 +637,7 @@ class TestPMFTXY2D(unittest.TestCase):
         pmft = freud.pmft.PMFTXY2D(max_width, max_width, nbins)
         with self.assertRaises(ValueError):
             pmft.compute(box, points, angles,
-                         query_args={'mode': 'nearest', 'num_neighbors': 1})
+                         neighbors={'mode': 'nearest', 'num_neighbors': 1})
 
 
 class TestPMFTXYZ(unittest.TestCase):
@@ -783,40 +783,40 @@ class TestPMFTXYZ(unittest.TestCase):
         absoluteTolerance = 0.1
 
         r_max = np.sqrt(maxX**2 + maxY**2 + maxZ**2)
-        test_set = util.make_raw_query_nlist_test_set(
+        test_set = util.make_raw_query_nlist_test_set_new(
             box, points, points, 'ball', r_max, 0, True)
         for ts in test_set:
             myPMFT = freud.pmft.PMFTXYZ(
                 maxX, maxY, maxZ, (nbinsX, nbinsY, nbinsZ))
-            myPMFT.accumulate(box, ts[0], orientations, nlist=ts[1])
+            myPMFT.accumulate(box, ts[0], orientations, neighbors=ts[1])
             npt.assert_allclose(myPMFT.bin_counts, correct_bin_counts,
                                 atol=absoluteTolerance)
             myPMFT.reset()
-            myPMFT.compute(box, ts[0], orientations, nlist=ts[1])
+            myPMFT.compute(box, ts[0], orientations, neighbors=ts[1])
             npt.assert_allclose(myPMFT.bin_counts, correct_bin_counts,
                                 atol=absoluteTolerance)
 
             # Test face orientations, shape (N_faces, 4)
             face_orientations = np.array([[1., 0., 0., 0.]])
-            myPMFT.compute(box, ts[0], orientations, nlist=ts[1],
+            myPMFT.compute(box, ts[0], orientations, neighbors=ts[1],
                            face_orientations=face_orientations)
             npt.assert_allclose(myPMFT.bin_counts, correct_bin_counts,
                                 atol=absoluteTolerance)
             # Test face orientations, shape (1, N_faces, 4)
             face_orientations = np.array([[[1., 0., 0., 0.]]])
-            myPMFT.compute(box, ts[0], orientations, nlist=ts[1],
+            myPMFT.compute(box, ts[0], orientations, neighbors=ts[1],
                            face_orientations=face_orientations)
             npt.assert_allclose(myPMFT.bin_counts, correct_bin_counts,
                                 atol=absoluteTolerance)
             # Test face orientations, shape (N_particles, N_faces, 4)
             face_orientations = np.array([[[1., 0., 0., 0.]],
                                           [[1., 0., 0., 0.]]])
-            myPMFT.compute(box, ts[0], orientations, nlist=ts[1],
+            myPMFT.compute(box, ts[0], orientations, neighbors=ts[1],
                            face_orientations=face_orientations)
             npt.assert_allclose(myPMFT.bin_counts, correct_bin_counts,
                                 atol=absoluteTolerance)
 
-            myPMFT.compute(box, ts[0], orientations, nlist=ts[1])
+            myPMFT.compute(box, ts[0], orientations, neighbors=ts[1])
             npt.assert_allclose(myPMFT.bin_counts, correct_bin_counts,
                                 atol=absoluteTolerance)
 
@@ -873,7 +873,7 @@ class TestPMFTXYZ(unittest.TestCase):
         nbins = 3
         pmft = freud.pmft.PMFTXYZ(max_width, max_width, max_width, nbins)
         pmft.compute(box, points, angles, query_points,
-                     query_args={'mode': 'nearest', 'num_neighbors': 1})
+                     neighbors={'mode': 'nearest', 'num_neighbors': 1})
 
         # Now every point in query_points will find the origin as a neighbor.
         npt.assert_array_equal(
@@ -889,7 +889,7 @@ class TestPMFTXYZ(unittest.TestCase):
               [0, 0, 0]]])
 
         pmft.compute(box, query_points, query_angles, points,
-                     query_args={'mode': 'nearest', 'num_neighbors': 1})
+                     neighbors={'mode': 'nearest', 'num_neighbors': 1})
         # The only nonzero bin is in the left bin for x, but the center for
         # everything else (0 distance in y and z).
         self.assertEqual(pmft.bin_counts[0, 1, 1], 1)

--- a/tests/util.py
+++ b/tests/util.py
@@ -60,6 +60,64 @@ def make_raw_query_nlist_test_set(box, points, query_points, mode, r_max,
     return test_set
 
 
+def make_raw_query_nlist_test_set_new(box, points, query_points, mode, r_max,
+                                      num_neighbors, exclude_ii):
+    """Helper function to test multiple neighbor-finding data structures.
+
+    .. moduleauthor:: Jin Soo Ihm <jinihm@umich.edu>
+    .. moduleauthor:: Bradley Dice <bdice@bradleydice.com>
+
+    Args:
+        box (:class:`freud.box.Box`):
+            Simulation box.
+        points ((:math:`N_{points}`, 3) :class:`numpy.ndarray`):
+            Reference points used to calculate the correlation function.
+        query_points ((:math:`N_{query_points}`, 3) :class:`numpy.ndarray`, optional):
+            query_points used to calculate the correlation function.
+            Uses :code:`points` if not provided or :code:`None`.
+            (Default value = :code:`None`).
+        mode (str):
+            String indicating query mode.
+        r_max (float):
+            Maximum cutoff distance.
+        num_neighbors (int):
+            Number of nearest neighbors to include.
+        exclude_ii (bool):
+            Whether to exclude self-neighbors.
+
+    Returns:
+        tuple:
+            Contains points or :class:`freud.locality.NeighborQuery`,
+            :class:`freud.locality.NeighborList` or :code:`None`,
+            query_args :class:`dict` or :code:`None`.
+    """  # noqa: E501
+    test_set = []
+    query_args = {'mode': mode, 'exclude_ii': exclude_ii}
+    if mode == "ball":
+        query_args['r_max'] = r_max
+
+    if mode == 'nearest':
+        query_args['num_neighbors'] = num_neighbors
+        query_args['r_guess'] = r_max
+
+    test_set.append((points, query_args))
+    test_set.append((freud.locality.RawPoints(box, points), query_args))
+    test_set.append((freud.locality.AABBQuery(box, points), query_args))
+    test_set.append(
+        (freud.locality.LinkCell(box, r_max, points), query_args))
+    if mode == "ball":
+        nlist = freud.locality.make_default_nlist(
+            box, points, query_points,
+            dict(r_max=r_max, exclude_ii=exclude_ii), None)
+    if mode == "nearest":
+        nlist = freud.locality.make_default_nlist(
+            box, points, query_points,
+            dict(num_neighbors=num_neighbors, exclude_ii=exclude_ii,
+                 r_guess=r_max), None)
+    test_set.append((points, nlist))
+    return test_set
+
+
 def make_box_and_random_points(box_size, num_points, is2D=False, seed=0):
     R"""Helper function to make random points with a cubic or square box.
 

--- a/tests/util.py
+++ b/tests/util.py
@@ -2,8 +2,8 @@ import numpy as np
 import freud
 
 
-def make_raw_query_nlist_test_set_new(box, points, query_points, mode, r_max,
-                                      num_neighbors, exclude_ii):
+def make_raw_query_nlist_test_set(box, points, query_points, mode, r_max,
+                                  num_neighbors, exclude_ii):
     """Helper function to test multiple neighbor-finding data structures.
 
     Args:

--- a/tests/util.py
+++ b/tests/util.py
@@ -2,70 +2,9 @@ import numpy as np
 import freud
 
 
-def make_raw_query_nlist_test_set(box, points, query_points, mode, r_max,
-                                  num_neighbors, exclude_ii):
-    """Helper function to test multiple neighbor-finding data structures.
-
-    .. moduleauthor:: Jin Soo Ihm <jinihm@umich.edu>
-    .. moduleauthor:: Bradley Dice <bdice@bradleydice.com>
-
-    Args:
-        box (:class:`freud.box.Box`):
-            Simulation box.
-        points ((:math:`N_{points}`, 3) :class:`numpy.ndarray`):
-            Reference points used to calculate the correlation function.
-        query_points ((:math:`N_{query_points}`, 3) :class:`numpy.ndarray`, optional):
-            query_points used to calculate the correlation function.
-            Uses :code:`points` if not provided or :code:`None`.
-            (Default value = :code:`None`).
-        mode (str):
-            String indicating query mode.
-        r_max (float):
-            Maximum cutoff distance.
-        num_neighbors (int):
-            Number of nearest neighbors to include.
-        exclude_ii (bool):
-            Whether to exclude self-neighbors.
-
-    Returns:
-        tuple:
-            Contains points or :class:`freud.locality.NeighborQuery`,
-            :class:`freud.locality.NeighborList` or :code:`None`,
-            query_args :class:`dict` or :code:`None`.
-    """  # noqa: E501
-    test_set = []
-    query_args = {'mode': mode, 'exclude_ii': exclude_ii}
-    if mode == "ball":
-        query_args['r_max'] = r_max
-
-    if mode == 'nearest':
-        query_args['num_neighbors'] = num_neighbors
-        query_args['r_guess'] = r_max
-
-    test_set.append((points, None, query_args))
-    test_set.append((freud.locality.RawPoints(box, points), None, query_args))
-    test_set.append((freud.locality.AABBQuery(box, points), None, query_args))
-    test_set.append(
-        (freud.locality.LinkCell(box, r_max, points), None, query_args))
-    if mode == "ball":
-        nlist = freud.locality.make_default_nlist(
-            box, points, query_points,
-            dict(r_max=r_max, exclude_ii=exclude_ii), None)
-    if mode == "nearest":
-        nlist = freud.locality.make_default_nlist(
-            box, points, query_points,
-            dict(num_neighbors=num_neighbors, exclude_ii=exclude_ii,
-                 r_guess=r_max), None)
-    test_set.append((points, nlist, None))
-    return test_set
-
-
 def make_raw_query_nlist_test_set_new(box, points, query_points, mode, r_max,
                                       num_neighbors, exclude_ii):
     """Helper function to test multiple neighbor-finding data structures.
-
-    .. moduleauthor:: Jin Soo Ihm <jinihm@umich.edu>
-    .. moduleauthor:: Bradley Dice <bdice@bradleydice.com>
 
     Args:
         box (:class:`freud.box.Box`):
@@ -123,8 +62,6 @@ def make_box_and_random_points(box_size, num_points, is2D=False, seed=0):
 
     This function has a side effect that it will set the random seed of numpy.
 
-    .. moduleauthor:: Jin Soo Ihm <jinihm@umich.edu>
-
     Args:
         box_size (float): Size of box.
         num_points (int): Number of points.
@@ -156,8 +93,6 @@ def make_alternating_lattice(lattice_size, angle=0, extra_shell=2):
     distance 1 for each point in points_1. Setting extra_shell to 2 will give
     8 more neighboring points in points_2 at distance :math:`\sqrt{5}` for each
     point in points_1 and so on.
-
-    .. moduleauthor:: Jin Soo Ihm <jinihm@umich.edu>
 
     Args:
         lattice_size (int): Size of lattice for points_1.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Standardize the usage of a `neighbors` argument everywhere. This argument can be either a dictionary or a `NeighborList` (or `None` if a class has default query arguments), and this object is resolved by standard preprocessing in the `PairCompute` class.

Note that I have intentionally chosen _not_ to update the docstrings. #348 will help in providing a standard place to provide documentation, which all these docstrings need to point to. I prefer to do this all at once so that we can put some thought into the appropriate docstring.

## Motivation and Context
This resolves #466 and the second part of #463. Also contributes to #266 and #179. 

## How Has This Been Tested?
Existing tests pass after being adapted to use the new API.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds or improves functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/glotzerlab/freud/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] I have updated the documentation (if relevant).
- [x] I have added tests that cover my changes (if relevant).
- [x] All new and existing tests passed.
- [ ] I have updated the [Changelog](https://github.com/glotzerlab/freud/blob/master/ChangeLog.md).
