### PR TITLE
Feature/enable 2d quaternions

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -18,6 +18,7 @@ and this project adheres to
 * Steinhardt now supports l = 0, 1.
 * C++ BondHistogramCompute class encapsulates logic of histogram-based methods.
 * NeighborLists and query arguments are now accepted on equal footing by compute methods that involve neighbor finding.
+* 2D PMFTs accept quaternions as well as angles for their orientations.
 
 ### Changed
 * All compute objects that perform neighbor computations now use NeighborQuery internally.

--- a/cpp/density/LocalDensity.cc
+++ b/cpp/density/LocalDensity.cc
@@ -11,7 +11,7 @@
 namespace freud { namespace density {
 
 LocalDensity::LocalDensity(float r_max, float diameter)
-    : m_box(box::Box()), m_r_max(r_max), m_diameter(diameter), m_n_points(0)
+    : m_box(box::Box()), m_r_max(r_max), m_diameter(diameter)
 {}
 
 LocalDensity::~LocalDensity() {}
@@ -22,13 +22,13 @@ void LocalDensity::compute(const freud::locality::NeighborQuery* neighbor_query,
 {
     m_box = neighbor_query->getBox();
 
-    unsigned int n_points = neighbor_query->getNPoints();
+    const unsigned int n_points = neighbor_query->getNPoints();
 
     m_density_array.prepare(n_points);
     m_num_neighbors_array.prepare(n_points);
 
-    float area = M_PI * m_r_max * m_r_max;
-    float volume = float(4.0/3.0) * M_PI * m_r_max * m_r_max * m_r_max;
+    const float area = M_PI * m_r_max * m_r_max;
+    const float volume = float(4.0/3.0) * M_PI * m_r_max * m_r_max * m_r_max;
     // compute the local density
     freud::locality::loopOverNeighborsIterator(neighbor_query, query_points, n_query_points, qargs, nlist,
     [=](size_t i, std::shared_ptr<freud::locality::NeighborPerPointIterator> ppiter)
@@ -62,7 +62,6 @@ void LocalDensity::compute(const freud::locality::NeighborQuery* neighbor_query,
             }
         }
     });
-    m_n_points = n_points;
 }
 
 }; }; // end namespace freud::density

--- a/cpp/density/LocalDensity.h
+++ b/cpp/density/LocalDensity.h
@@ -51,12 +51,6 @@ public:
                  unsigned int n_query_points, const freud::locality::NeighborList* nlist,
                  freud::locality::QueryArgs qargs);
 
-    //! Get the number of reference particles
-    unsigned int getNPoints() const
-    {
-        return m_n_points;
-    }
-
     //! Get a reference to the last computed density
     const util::ManagedArray<float> &getDensity() const
     {
@@ -73,7 +67,6 @@ private:
     box::Box m_box;       //!< Simulation box where the particles belong
     float m_r_max;         //!< Maximum neighbor distance
     float m_diameter;     //!< Diameter of the particles
-    unsigned int m_n_points; //!< Last number of points computed
 
     util::ManagedArray<float> m_density_array;       //!< density array computed
     util::ManagedArray<float> m_num_neighbors_array; //!< number of neighbors array computed

--- a/doc/source/credits.rst
+++ b/doc/source/credits.rst
@@ -88,6 +88,7 @@ Vyas Ramasubramani - **Lead developer**
 * Standardized all attribute access into C++ with Python properties.
 * Standardized variable naming of points/query\_points across all of freud.
 * Standardized vector directionality in computes.
+* Enabled usage of quaternions in place of angles for orientations in 2D PMFT calculations.
 
 Bradley Dice - **Lead developer**
 

--- a/freud/_density.pxd
+++ b/freud/_density.pxd
@@ -46,7 +46,6 @@ cdef extern from "LocalDensity.h" namespace "freud::density":
             const vec3[float]*,
             unsigned int, const freud._locality.NeighborList *,
             freud._locality.QueryArgs) except +
-        unsigned int getNPoints() const
         const freud.util.ManagedArray[float] &getDensity() const
         const freud.util.ManagedArray[float] &getNumNeighbors() const
         float getRMax() const

--- a/freud/pmft.pyx
+++ b/freud/pmft.pyx
@@ -42,6 +42,7 @@ import numpy as np
 import freud.common
 import freud.locality
 import warnings
+import rowan
 
 from freud.common cimport Compute
 from freud.locality cimport SpatialHistogram
@@ -58,6 +59,44 @@ cimport numpy as np
 # numpy must be initialized. When using numpy from C or Cython you must
 # _always_ do that, or you will have segfaults
 np.import_array()
+
+
+def _quat_to_z_angle(orientations, num_points):
+    """If orientations are quaternions, convert them to angles.
+
+    For consistency with the boxes and points in freud, we require that
+    the orientations represent rotations about the z-axis. If last
+    dimension is of length 4, it's a quaternion, unless we have exactly
+    4 points, in which case it could be 4 angles. In that case, we also
+    have to check that orientations are of shape (4, 4)
+    """
+    # Either we have a 1D array of length 4 (and we don't have exactly 4
+    # points), or we have a 2D array with the second dimension having length 4.
+    is_quat = (
+        (len(orientations.shape) == 1 and orientations.shape[0] == 4 and
+            num_points != 4) or
+        (len(orientations.shape) == 2 and orientations.shape[1] == 4)
+    )
+
+    if is_quat:
+        axes, orientations = rowan.to_axis_angle(orientations)
+        if not np.allclose(axes, [0, 0, 1]):
+            raise ValueError("Orientations provided as quaternions "
+                             "must represent rotations about the z-axis.")
+    return orientations
+
+
+def _gen_angle_array(orientations, shape):
+    """Generates properly shaped, freud-compliant arrays of angles.
+
+    This computation is specific to 2D calculations that require angles as
+    orientations. It performs the conversion of quaternion inputs if needed and
+    ensures that singleton arrays are treated correctly."""
+
+    return freud.common.convert_array(
+        np.atleast_1d(_quat_to_z_angle(orientations.squeeze(), shape[0])),
+        shape=shape)
+
 
 cdef class _PMFT(SpatialHistogram):
     R"""Compute the PMFT [vanAndersKlotsa2014]_ [vanAndersAhmed2014]_ for a
@@ -144,15 +183,26 @@ cdef class PMFTR12(_PMFT):
                 Simulation box.
             points ((:math:`N_{particles}`, 3) :class:`numpy.ndarray`):
                 Reference points used in computation.
-            orientations ((:math:`N_{particles}`, 1) or (:math:`N_{particles}`,) :class:`numpy.ndarray`):
-                Reference orientations as angles used in computation.
+            orientations (:class:`numpy.ndarray`):
+                Orientations used in computation. May be provided as an array
+                of shape (:math:`N_{particles}`, 1) or
+                (:math:`N_{particles}`,), in which case it is treated as an
+                array of angles, or as an array of shape
+                (:math:`N_{particles}`, 4) or (4,), in which case it is treated
+                as an array of quaternions representing rotations about the
+                :math:`z` axis.
             query_points ((:math:`N_{particles}`, 3) :class:`numpy.ndarray`, optional):
                 Points used in computation. Uses :code:`points` if not
                 provided or :code:`None`. (Default value = :code:`None`).
             query_orientations ((:math:`N_{particles}`, 1) or (:math:`N_{particles}`,) :class:`numpy.ndarray`, optional):
-                Orientations as angles used in computation. Uses
-                :code:`orientations` if not provided or :code:`None`.
-                (Default value = :code:`None`).
+                Query orientations used in computation. May be provided as
+                an array of shape (:math:`N_{particles}`, 1) or
+                (:math:`N_{particles}`,), in which case it is treated as an
+                array of angles, or as an array of shape
+                (:math:`N_{particles}`, 4) or (4,), in which case it is treated
+                as an array of quaternions representing rotations about the
+                :math:`z` axis. Uses :code:`orientations` if omitted or or
+                :code:`None` is provided. (Default value = :code:`None`).
             nlist (:class:`freud.locality.NeighborList`, optional):
                 NeighborList used to find bonds (Default value =
                 :code:`None`).
@@ -169,15 +219,13 @@ cdef class PMFTR12(_PMFT):
             self.preprocess_arguments(
                 box, points, query_points, neighbors, dimensions=2)
 
-        orientations = freud.common.convert_array(
-            np.atleast_1d(orientations.squeeze()),
-            shape=(nq.points.shape[0], ))
+        orientations = _gen_angle_array(
+            orientations, shape=(nq.points.shape[0], ))
         if query_orientations is None:
             query_orientations = orientations
         else:
-            query_orientations = freud.common.convert_array(
-                np.atleast_1d(query_orientations.squeeze()),
-                shape=(l_query_points.shape[0], ))
+            query_orientations = _gen_angle_array(
+                query_orientations, shape=(l_query_points.shape[0], ))
         cdef const float[::1] l_orientations = orientations
         cdef const float[::1] l_query_orientations = query_orientations
 
@@ -200,15 +248,26 @@ cdef class PMFTR12(_PMFT):
                 Simulation box.
             points ((:math:`N_{particles}`, 3) :class:`numpy.ndarray`):
                 Reference points used in computation.
-            orientations ((:math:`N_{particles}`, 1) or (:math:`N_{particles}`,) :class:`numpy.ndarray`):
-                Reference orientations as angles used in computation.
+            orientations (:class:`numpy.ndarray`):
+                Orientations used in computation. May be provided as an array
+                of shape (:math:`N_{particles}`, 1) or
+                (:math:`N_{particles}`,), in which case it is treated as an
+                array of angles, or as an array of shape
+                (:math:`N_{particles}`, 4) or (4,), in which case it is treated
+                as an array of quaternions representing rotations about the
+                :math:`z` axis.
             query_points ((:math:`N_{particles}`, 3) :class:`numpy.ndarray`, optional):
                 Points used in computation. Uses :code:`points` if not
                 provided or :code:`None`. (Default value = :code:`None`).
             query_orientations ((:math:`N_{particles}`, 1) or (:math:`N_{particles}`,) :class:`numpy.ndarray`, optional):
-                Orientations as angles used in computation. Uses
-                :code:`orientations` if not provided or :code:`None`.
-                (Default value = :code:`None`).
+                Query orientations used in computation. May be provided as
+                an array of shape (:math:`N_{particles}`, 1) or
+                (:math:`N_{particles}`,), in which case it is treated as an
+                array of angles, or as an array of shape
+                (:math:`N_{particles}`, 4) or (4,), in which case it is treated
+                as an array of quaternions representing rotations about the
+                :math:`z` axis. Uses :code:`orientations` if omitted or or
+                :code:`None` is provided. (Default value = :code:`None`).
             nlist (:class:`freud.locality.NeighborList`, optional):
                 NeighborList used to find bonds (Default value =
                 :code:`None`).
@@ -292,15 +351,26 @@ cdef class PMFTXYT(_PMFT):
                 Simulation box.
             points ((:math:`N_{particles}`, 3) :class:`numpy.ndarray`):
                 Reference points used in computation.
-            orientations ((:math:`N_{particles}`, 1) or (:math:`N_{particles}`,) :class:`numpy.ndarray`):
-                Reference orientations as angles used in computation.
+            orientations (:class:`numpy.ndarray`):
+                Orientations used in computation. May be provided as an array
+                of shape (:math:`N_{particles}`, 1) or
+                (:math:`N_{particles}`,), in which case it is treated as an
+                array of angles, or as an array of shape
+                (:math:`N_{particles}`, 4) or (4,), in which case it is treated
+                as an array of quaternions representing rotations about the
+                :math:`z` axis.
             query_points ((:math:`N_{particles}`, 3) :class:`numpy.ndarray`, optional):
                 Points used in computation. Uses :code:`points` if not
                 provided or :code:`None`. (Default value = :code:`None`).
-            query_orientations ((:math:`N_{particles}`, 1) or (:math:`N_{particles}`,) :class:`numpy.ndarray`, optional):
-                Orientations as angles used in computation. Uses
-                :code:`orientations` if not provided or :code:`None`.
-                (Default value = :code:`None`).
+            query_orientations (:class:`numpy.ndarray`, optional):
+                Query orientations used in computation. May be provided as
+                an array of shape (:math:`N_{particles}`, 1) or
+                (:math:`N_{particles}`,), in which case it is treated as an
+                array of angles, or as an array of shape
+                (:math:`N_{particles}`, 4) or (4,), in which case it is treated
+                as an array of quaternions representing rotations about the
+                :math:`z` axis. Uses :code:`orientations` if omitted or or
+                :code:`None` is provided. (Default value = :code:`None`).
             nlist (:class:`freud.locality.NeighborList`, optional):
                 NeighborList used to find bonds (Default value =
                 :code:`None`).
@@ -317,15 +387,13 @@ cdef class PMFTXYT(_PMFT):
             self.preprocess_arguments(
                 box, points, query_points, neighbors, dimensions=2)
 
-        orientations = freud.common.convert_array(
-            np.atleast_1d(orientations.squeeze()),
-            shape=(nq.points.shape[0], ))
+        orientations = _gen_angle_array(
+            orientations, shape=(nq.points.shape[0], ))
         if query_orientations is None:
             query_orientations = orientations
         else:
-            query_orientations = freud.common.convert_array(
-                np.atleast_1d(query_orientations.squeeze()),
-                shape=(query_points.shape[0], ))
+            query_orientations = _gen_angle_array(
+                query_orientations, shape=(l_query_points.shape[0], ))
         cdef const float[::1] l_orientations = orientations
         cdef const float[::1] l_query_orientations = query_orientations
 
@@ -348,15 +416,26 @@ cdef class PMFTXYT(_PMFT):
                 Simulation box.
             points ((:math:`N_{particles}`, 3) :class:`numpy.ndarray`):
                 Reference points used in computation.
-            orientations ((:math:`N_{particles}`, 1) or (:math:`N_{particles}`,) :class:`numpy.ndarray`):
-                Reference orientations as angles used in computation.
+            orientations (:class:`numpy.ndarray`):
+                Orientations used in computation. May be provided as an array
+                of shape (:math:`N_{particles}`, 1) or
+                (:math:`N_{particles}`,), in which case it is treated as an
+                array of angles, or as an array of shape
+                (:math:`N_{particles}`, 4) or (4,), in which case it is treated
+                as an array of quaternions representing rotations about the
+                :math:`z` axis.
             query_points ((:math:`N_{particles}`, 3) :class:`numpy.ndarray`, optional):
                 Points used in computation. Uses :code:`points` if not
                 provided or :code:`None`. (Default value = :code:`None`).
-            query_orientations ((:math:`N_{particles}`, 1) or (:math:`N_{particles}`,) :class:`numpy.ndarray`, optional):
-                Orientations as angles used in computation. Uses
-                :code:`orientations` if not provided or :code:`None`.
-                (Default value = :code:`None`).
+            query_orientations (:class:`numpy.ndarray`, optional):
+                Query orientations used in computation. May be provided as
+                an array of shape (:math:`N_{particles}`, 1) or
+                (:math:`N_{particles}`,), in which case it is treated as an
+                array of angles, or as an array of shape
+                (:math:`N_{particles}`, 4) or (4,), in which case it is treated
+                as an array of quaternions representing rotations about the
+                :math:`z` axis. Uses :code:`orientations` if omitted or or
+                :code:`None` is provided. (Default value = :code:`None`).
             nlist (:class:`freud.locality.NeighborList`, optional):
                 NeighborList used to find bonds (Default value =
                 :code:`None`).
@@ -439,8 +518,14 @@ cdef class PMFTXY2D(_PMFT):
                 Simulation box.
             points ((:math:`N_{particles}`, 3) :class:`numpy.ndarray`):
                 Reference points used in computation.
-            orientations ((:math:`N_{particles}`, 1) or (:math:`N_{particles}`,) :class:`numpy.ndarray`):
-                Reference orientations as angles used in computation.
+            orientations (:class:`numpy.ndarray`):
+                Orientations used in computation. May be provided as an array
+                of shape (:math:`N_{particles}`, 1) or
+                (:math:`N_{particles}`,), in which case it is treated as an
+                array of angles, or as an array of shape
+                (:math:`N_{particles}`, 4) or (4,), in which case it is treated
+                as an array of quaternions representing rotations about the
+                :math:`z` axis.
             query_points ((:math:`N_{particles}`, 3) :class:`numpy.ndarray`, optional):
                 Points used in computation. Uses :code:`points` if not
                 provided or :code:`None`. (Default value = :code:`None`).
@@ -460,9 +545,8 @@ cdef class PMFTXY2D(_PMFT):
             self.preprocess_arguments(
                 box, points, query_points, neighbors, dimensions=2)
 
-        orientations = freud.common.convert_array(
-            np.atleast_1d(orientations.squeeze()),
-            shape=(nq.points.shape[0], ))
+        orientations = _gen_angle_array(
+            orientations, shape=(nq.points.shape[0], ))
         cdef const float[::1] l_orientations = orientations
 
         self.pmftxy2dptr.accumulate(nq.get_ptr(),
@@ -483,8 +567,14 @@ cdef class PMFTXY2D(_PMFT):
                 Simulation box.
             points ((:math:`N_{particles}`, 3) :class:`numpy.ndarray`):
                 Reference points used in computation.
-            orientations ((:math:`N_{particles}`, 1) or (:math:`N_{particles}`,) :class:`numpy.ndarray`):
-                Reference orientations as angles used in computation.
+            orientations (:class:`numpy.ndarray`):
+                Orientations used in computation. May be provided as an array
+                of shape (:math:`N_{particles}`, 1) or
+                (:math:`N_{particles}`,), in which case it is treated as an
+                array of angles, or as an array of shape
+                (:math:`N_{particles}`, 4) or (4,), in which case it is treated
+                as an array of quaternions representing rotations about the
+                :math:`z` axis.
             query_points ((:math:`N_{particles}`, 3) :class:`numpy.ndarray`, optional):
                 Points used in computation. Uses :code:`points` if not
                 provided or :code:`None`. (Default value = :code:`None`).
@@ -493,8 +583,7 @@ cdef class PMFTXY2D(_PMFT):
                 :code:`None`).
         """  # noqa: E501
         self.reset()
-        self.accumulate(box, points, orientations,
-                        query_points, neighbors)
+        self.accumulate(box, points, orientations, query_points, neighbors)
         return self
 
     @Compute._computed_property()

--- a/freud/pmft.pyx
+++ b/freud/pmft.pyx
@@ -80,7 +80,7 @@ def _quat_to_z_angle(orientations, num_points):
 
     if is_quat:
         axes, orientations = rowan.to_axis_angle(orientations)
-        if not np.allclose(axes, [0, 0, 1]):
+        if not (np.allclose(orientations, 0) or np.allclose(axes, [0, 0, 1])):
             raise ValueError("Orientations provided as quaternions "
                              "must represent rotations about the z-axis.")
     return orientations

--- a/setup.py
+++ b/setup.py
@@ -431,8 +431,8 @@ try:
               url='https://github.com/glotzerlab/freud',
               packages=['freud'],
               python_requires='>=3.5',
-              install_requires=['numpy>=1.10'],
-              tests_require=['matplotlib>=2.0', 'rowan>=1.0', 'sympy>=1.0'],
+              install_requires=['numpy>=1.10', 'rowan>=1.0'],
+              tests_require=['matplotlib>=2.0', 'sympy>=1.0'],
               ext_modules=extensions)
 except SystemExit:
     # The errors we're explicitly checking for are whether or not

--- a/setup.py
+++ b/setup.py
@@ -431,7 +431,7 @@ try:
               url='https://github.com/glotzerlab/freud',
               packages=['freud'],
               python_requires='>=3.5',
-              install_requires=['numpy>=1.10', 'rowan>=1.0'],
+              install_requires=['numpy>=1.10', 'rowan>=1.2'],
               tests_require=['matplotlib>=2.0', 'sympy>=1.0'],
               ext_modules=extensions)
 except SystemExit:


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above. -->

## Description
Enabled passing quaternions as arguments to the 2D PMFTs.

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- Replace ??? with the issue number that this pull request resolves, if applicable. -->
Resolves: #200

## How Has This Been Tested?
Added tests using quaternions.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds or improves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!-- Put an `x` in all the boxes that apply. If you're unsure about any of
     these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/glotzerlab/freud/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] I have updated the documentation (if relevant).
- [x] I have added tests that cover my changes (if relevant).
- [x] All new and existing tests passed.
- [x] I have updated the [credits](https://github.com/glotzerlab/freud/blob/master/doc/source/credits.rst).
- [x] I have updated the [Changelog](https://github.com/glotzerlab/freud/blob/master/ChangeLog.md).
