### PR TITLE
Use voro++ to compute Voronoi diagrams.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,6 +4,9 @@
 [submodule "extern/Eigen"]
 	path = extern/Eigen
 	url = https://github.com/glotzerlab/eigen-git-mirror.git
+[submodule "extern/voro++"]
+	path = extern/voro++
+	url = https://github.com/chr1shr/voro.git
 [submodule "doc/source/examples"]
 	path = doc/source/examples
 	url = https://github.com/glotzerlab/freud-examples.git

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -41,6 +41,7 @@ and this project adheres to
 * Vector directionality is standardized for all computes that use it (always points from point to query\_point).
 * Neighbor-based compute methods now accept NeighborQuery objects as the first object, including (box, point) tuples.
 * Documentation uses automodule instead of autoclass.
+* The Voronoi class was rewritten to use voro++ for vastly improved performance and correctness in edge cases.
 
 ### Fixed
 * Steinhardt uses the ThreadStorage class and properly resets memory where needed.

--- a/cpp/locality/Voronoi.cc
+++ b/cpp/locality/Voronoi.cc
@@ -28,6 +28,10 @@ void Voronoi::compute(const box::Box &box, const vec3<double>* points, unsigned 
         } else {
             boxLatticeVectors[2] = box.getLatticeVector(2);
         }
+        // TODO: This container uses 3 blocks in x, y, and z, and an initial
+        // memory allocation of 3, which should be improved. Ideally, this code
+        // should use a pre_container or implement its own heuristics to choose
+        // a number of blocks.
         voro::container_periodic container(
             boxLatticeVectors[0].x,
             boxLatticeVectors[1].x,

--- a/cpp/locality/Voronoi.h
+++ b/cpp/locality/Voronoi.h
@@ -5,10 +5,10 @@
 #define VORONOI_H
 
 #include "Box.h"
-#include "NeighborList.h"
-#include "NeighborBond.h"
+#include "ManagedArray.h"
 #include "VectorMath.h"
 #include "NeighborList.h"
+#include <voro++/src/voro++.hh>
 
 namespace freud { namespace locality {
 
@@ -16,22 +16,32 @@ class Voronoi
 {
 public:
     // default constructor
-    Voronoi();
-
-    void compute(const box::Box &box, const vec3<double>* vertices,
-        const int* ridge_points, const int* ridge_vertices,
-        unsigned int n_ridges, unsigned int N, const int* expanded_ids,
-        const vec3<double>* expanded_points, const int* ridge_vertex_indices);
-
-    NeighborList *getNeighborList()
+    Voronoi() : m_neighbor_list(std::make_shared<NeighborList>())
     {
-        return &m_neighbor_list;
+    }
+
+    void compute(const box::Box &box, const vec3<double>* points, unsigned int n_points);
+
+    std::shared_ptr<NeighborList> getNeighborList() const
+    {
+        return m_neighbor_list;
+    }
+
+    const std::vector<std::vector<vec3<double> > > getPolytopes() const
+    {
+        return m_polytopes;
+    }
+
+    const util::ManagedArray<double> &getVolumes() const
+    {
+        return m_volumes;
     }
 
 private:
     box::Box m_box;
-    NeighborList m_neighbor_list; //!< Stored neighbor list
-
+    std::shared_ptr<NeighborList> m_neighbor_list; //!< Stored neighbor list
+    std::vector<std::vector<vec3<double> > > m_polytopes; //!< Voronoi polytopes
+    util::ManagedArray<double> m_volumes; //!< Voronoi cell volumes
 };
 }; }; // end namespace freud::locality
 

--- a/freud/_locality.pxd
+++ b/freud/_locality.pxd
@@ -137,14 +137,10 @@ cdef extern from "Voronoi.h" namespace "freud::locality":
         void compute(
             const freud._box.Box &,
             const vec3[double]*,
-            const int*,
-            const int*,
-            unsigned int,
-            unsigned int,
-            const int*,
-            const vec3[double]*,
-            const int*) except +
-        NeighborList * getNeighborList()
+            const unsigned int) nogil except +
+        vector[vector[vec3[double]]] getPolytopes() const
+        const freud.util.ManagedArray[double] &getVolumes() const
+        shared_ptr[NeighborList] getNeighborList() const
 
 cdef extern from "BondHistogramCompute.h" namespace "freud::locality":
     cdef cppclass BondHistogramCompute:

--- a/freud/common.pyx
+++ b/freud/common.pyx
@@ -116,7 +116,7 @@ cdef class Compute:
 
     @staticmethod
     def _reset(func):
-        R"""Decorator that sets all compute flag to be false.
+        R"""Decorator that sets all compute flags to be false.
 
         Returns:
             Decorator decorating appropriate reset method.

--- a/freud/locality.pxd
+++ b/freud/locality.pxd
@@ -3,6 +3,7 @@
 
 from libcpp cimport bool as cbool
 from libcpp.memory cimport shared_ptr
+from freud.common cimport Compute
 
 from cython.operator cimport dereference
 from freud.common cimport Compute
@@ -66,12 +67,6 @@ cdef class RawPoints(NeighborQuery):
 cdef class _QueryArgs:
     cdef freud._locality.QueryArgs * thisptr
 
-cdef class _Voronoi:
-    cdef freud._locality.Voronoi * thisptr
-    cdef NeighborList _nlist
-    cdef _volumes
-    cdef _polytopes
-
 cdef class PairCompute(Compute):
     pass
 
@@ -81,3 +76,8 @@ cdef class SpatialHistogram(PairCompute):
 
 cdef class SpatialHistogram1D(SpatialHistogram):
     pass
+
+cdef class Voronoi(Compute):
+    cdef freud._locality.Voronoi * thisptr
+    cdef NeighborList _nlist
+    cdef freud.box.Box _box

--- a/freud/locality.pyx
+++ b/freud/locality.pyx
@@ -17,26 +17,15 @@ from libcpp cimport bool as cbool
 from freud.util cimport vec3
 from cython.operator cimport dereference
 from libcpp.memory cimport shared_ptr
-from freud._locality cimport ITERATOR_TERMINATOR
 from libcpp.vector cimport vector
+from freud._locality cimport ITERATOR_TERMINATOR
+from freud.common cimport Compute
 
 cimport freud._locality
 cimport freud.box
 cimport numpy as np
 
 logger = logging.getLogger(__name__)
-
-try:
-    from scipy.spatial import Voronoi as qvoronoi
-    from scipy.spatial import ConvexHull
-    _SCIPY_AVAILABLE = True
-except ImportError:
-    qvoronoi = None
-    msg = ('scipy.spatial.Voronoi is not available (requires scipy 0.12+), '
-           'so freud.voronoi is not available.')
-    logger.warning(msg)
-    _SCIPY_AVAILABLE = False
-
 
 # numpy must be initialized. When using numpy from C or Cython you must
 # _always_ do that, or you will have segfaults
@@ -861,230 +850,126 @@ cdef class LinkCell(NeighborQuery):
         return result
 
 
-cdef class _Voronoi:
-    R"""Compute the Voronoi tessellation of a 2D or 3D system using qhull.
-    This uses :class:`scipy.spatial.Voronoi`, accounting for periodic
-    boundary conditions.
+cdef class Voronoi(Compute):
+    R"""Computes Voronoi diagrams using voro++.
 
-    Since qhull does not support periodic boundary conditions natively, we
-    expand the box to include a portion of the particles' periodic images.
-    The buffer width is given by the parameter :code:`buffer`. The
-    computation of Voronoi tessellations and neighbors is only guaranteed
-    to be correct if :code:`buffer >= L/2` where :code:`L` is the longest side
-    of the simulation box. For dense systems with particles filling the
-    entire simulation volume, a smaller value for :code:`buffer` is acceptable.
-    If the buffer width is too small, then some polytopes may not be closed
-    (they may have a boundary at infinity), and these polytopes' vertices are
-    excluded from the list.  If either the polytopes or volumes lists that are
-    computed is different from the size of the array of positions used in the
-    :meth:`freud.locality.Voronoi.compute()` method, try recomputing using a
-    larger buffer width.
+    Voronoi diagrams (`Wikipedia
+    <https://en.wikipedia.org/wiki/Voronoi_diagram>`_) are composed of convex
+    polytopes (polyhedra in 3D, polygons in 2D) called cells, corresponding to
+    each input point. The cells bound a region of Euclidean space for which all
+    contained points are closer to a corresponding input point than any other
+    input point. A ridge is defined as a boundary between cells, which contains
+    points equally close to two or more input points.
+
+    The voro++ library [Rycroft2009]_ is used for fast computations of the
+    Voronoi diagram.
+
+    .. [Rycroft2009] Rycroft, Chris (2009). Voro++: a three-dimensional Voronoi
+       cell library in C++. Technical Report. https://doi.org/10.2172/946741
 
     Attributes:
         nlist (:class:`~.locality.NeighborList`):
-            Returns a weighted neighbor list.  In 2D systems, the bond weight
-            is the "ridge length" of the Voronoi boundary line between the
-            neighboring particles.  In 3D systems, the bond weight is the
-            "ridge area" of the Voronoi boundary polygon between the
-            neighboring particles.
+            Returns a neighbor list weighted by ridge area (length in 2D).
         polytopes (list[:class:`numpy.ndarray`]):
-            List of arrays, each containing Voronoi polytope vertices.
-        volumes ((:math:`\left(N_{cells} \right)`) :class:`numpy.ndarray`):
-            Returns an array of volumes (areas in 2D) corresponding to Voronoi
-            cells.
+            A list of :class:`numpy.ndarray` defining Voronoi polytope vertices
+            for each cell.
+        volumes (:math:`\left(N_{points} \right)` :class:`numpy.ndarray`):
+            Returns an array of Voronoi cell volumes (areas in 2D).
     """
 
-    def __init__(self):
-        if not _SCIPY_AVAILABLE:
-            raise RuntimeError("You cannot use this class without SciPy")
+    def __cinit__(self):
         self.thisptr = new freud._locality.Voronoi()
         self._nlist = NeighborList()
 
-    def _qhull_compute(self, box, positions, buffer, images):
-        R"""Calls PeriodicBuffer and qhull
+    def __dealloc__(self):
+        del self.thisptr
 
-        Args:
-            box (:class:`freud.box.Box`):
-                Simulation box (Default value = :code:`None`).
-            positions ((:math:`N_{particles}`, 3) :class:`numpy.ndarray`):
-                Points to calculate Voronoi diagram for.
-            buffer (float):
-                Buffer distance within which to look for images
-                (Default value = :code:`None`).
-            images (bool):
-                If ``False``, ``buffer`` is a distance. If ``True``
-                (default),``buffer`` is a number of images to replicate in each
-                dimension.
-        """
-        # Compute the buffer particles in C++
-        pbuff = freud.box.PeriodicBuffer(box)
-        pbuff.compute(positions, buffer, images)
-        buffer_points = pbuff.buffer_points
-        buffer_ids = pbuff.buffer_ids
-
-        if buffer_points.size > 0:
-            expanded_points = np.concatenate((positions, buffer_points))
-            expanded_ids = np.concatenate((
-                np.arange(len(positions)), buffer_ids))
-        else:
-            expanded_points = positions
-            expanded_ids = np.arange(len(positions))
-
-        # Use only the first two components if the box is 2D
-        if box.is2D:
-            expanded_points = expanded_points[:, :2]
-
-        expanded_points = freud.common.convert_array(
-            np.atleast_2d(expanded_points),
-            shape=(None, 2 if box.is2D else 3))
-
-        # Use qhull to get the points
-        return qvoronoi(expanded_points), expanded_ids, expanded_points
-
-    def compute(self, box, positions, buffer=2, images=True):
+    @Compute._compute()
+    def compute(self, box, points):
         R"""Compute Voronoi diagram.
 
         Args:
             box (:class:`freud.box.Box`):
                 Simulation box.
-            positions ((:math:`N_{particles}`, 3) :class:`numpy.ndarray`):
-                Points to calculate Voronoi diagram for.
-            buffer (float):
-                Buffer distance within which to look for images.
-                (Default value = 2).
-            images (bool):
-                If ``False``, ``buffer`` is a distance. If ``True``
-                (default),``buffer`` is a number of images to replicate in each
-                dimension.
+            points ((:math:`N_{points}`, 3) :class:`numpy.ndarray`):
+                Points used to calculate Voronoi diagram.
         """
-        # If box or buff is not specified, revert to object quantities
-        cdef freud.box.Box b
-        if box is None:
-            b = self._box
-        else:
-            b = freud.common.convert_box(box)
+        self._box = freud.common.convert_box(box)
 
-        voronoi, expanded_id, expanded_point = self._qhull_compute(
-            b, positions, buffer, images)
-
-        vertices = voronoi.vertices
-
-        # Add a z-component of 0 if the box is 2D
-        if b.is2D:
-            vertices = np.insert(vertices, 2, 0, 1)
-
-        # compute neighbors
-        cdef const int[:, ::1] ridge_points = np.asarray(
-            voronoi.ridge_points, dtype=np.int32)
-        cdef unsigned int n_ridges = ridge_points.shape[0]
-        cdef const int[::1] ridge_vertices = np.asarray(list(
-            itertools.chain.from_iterable(
-                voronoi.ridge_vertices)), dtype=np.int32)
-
-        # Must keep this in double precision
-        cdef const double[:, ::1] vor_vertices = np.asarray(
-            vertices, dtype=np.float64)
-        cdef unsigned int N = len(positions)
-
-        indices = [0]
-        indices.extend(np.cumsum(
-            [len(ridge) for ridge in voronoi.ridge_vertices]))
-        cdef const int[::1] expanded_ids = \
-            np.asarray(expanded_id, dtype=np.int32)
-
-        cdef const double[:, ::1] expanded_points = \
-            np.asarray(expanded_point, dtype=np.float64)
-
-        cdef const int[::1] ridge_vertex_indices = np.asarray(
-            indices, dtype=np.int32)
+        # voro++ uses double precision
+        points = freud.common.convert_array(points, shape=(None, 3),
+                                            dtype=np.float64)
+        cdef const double[:, ::1] l_points = points
+        cdef unsigned int n_points = len(points)
 
         self.thisptr.compute(
-            dereference(b.thisptr),
-            <vec3[double]*> &vor_vertices[0, 0],
-            <int*> &ridge_points[0, 0],
-            <int*> &ridge_vertices[0],
-            n_ridges, N,
-            <int*> &expanded_ids[0], <vec3[double]*> &expanded_points[0, 0],
-            <int*> &ridge_vertex_indices[0])
-
-        self._nlist = nlist_from_cnlist(self.thisptr.getNeighborList())
-
-        # Construct a list of polytope vertices
-        self._polytopes = list()
-        for region in voronoi.point_region[:N]:
-            if -1 in voronoi.regions[region]:
-                continue
-            self._polytopes.append(vertices[voronoi.regions[region]])
+            dereference(self._box.thisptr),
+            <vec3[double]*> &l_points[0, 0],
+            n_points)
 
         return self
 
-    @property
+    @Compute._computed_property()
     def polytopes(self):
-        R"""Returns a list of polytope vertices corresponding to Voronoi cells.
-
-        If the buffer width is too small, then some polytopes may not be
-        closed (they may have a boundary at infinity), and these polytopes'
-        vertices are excluded from the list.
-
-        The length of the list returned by this method should be the same
-        as the array of positions used in the
-        :meth:`freud.locality.Voronoi.compute()` method, if all the polytopes
-        are closed. Otherwise try using a larger buffer width.
+        R"""Polytope vertices of each Voronoi cell.
 
         Returns:
             list:
-                List of :class:`numpy.ndarray` containing Voronoi polytope
-                vertices.
+                List of :class:`numpy.ndarray` defining Voronoi polytope
+                vertices for each cell.
         """
-        return self._polytopes
+        polytopes = []
+        cdef vector[vector[vec3[double]]] raw_polytopes = \
+            self.thisptr.getPolytopes()
+        cdef size_t i
+        cdef size_t j
+        cdef size_t num_verts
+        cdef vector[vec3[double]] raw_vertices
+        cdef double[:, ::1] polytope_vertices
+        for i in range(raw_polytopes.size()):
+            raw_vertices = raw_polytopes[i]
+            num_verts = raw_vertices.size()
+            polytope_vertices = np.empty((num_verts, 3), dtype=np.float64)
+            for j in range(num_verts):
+                polytope_vertices[j, 0] = raw_vertices[j].x
+                polytope_vertices[j, 1] = raw_vertices[j].y
+                polytope_vertices[j, 2] = raw_vertices[j].z
+            polytopes.append(np.asarray(polytope_vertices))
+        return polytopes
 
-    @property
+    @Compute._computed_property()
+    def volumes(self):
+        R"""Returns an array of volumes (areas in 2D) of the Voronoi cells.
+
+        Returns:
+            :math:`\left(N_{points} \right)` :class:`numpy.ndarray`:
+                Array of Voronoi polytope volumes (areas in 2D).
+        """
+        return freud.util.make_managed_numpy_array(
+            &self.thisptr.getVolumes(),
+            freud.util.arr_type_t.DOUBLE)
+
+    @Compute._computed_property()
     def nlist(self):
-        R"""Returns a neighbor list object.
+        R"""Returns the computed :class:`~.locality.NeighborList`.
 
-        In the neighbor list, each neighbor pair has a weight value.
+        The :class:`~.locality.NeighborList` computed by this class is
+        weighted. In 2D systems, the bond weight is the length of the ridge
+        (boundary line) between the neighboring points' Voronoi cells. In 3D
+        systems, the bond weight is the area of the ridge (boundary polygon)
+        between the neighboring points' Voronoi cells. The weights are not
+        normalized, and the weights for each query point sum to the surface
+        area (perimeter in 2D) of the polytope.
 
-        In 2D systems, the bond weight is the "ridge length" of the Voronoi
-        boundary line between the neighboring particles.
-
-        In 3D systems, the bond weight is the "ridge area" of the Voronoi
-        boundary polygon between the neighboring particles.
+        It is possible for pairs of points to appear multiple times in the
+        neighbor list. For example, in a small unit cell, points may neighbor
+        one another on multiple sides because of periodic boundary conditions.
 
         Returns:
             :class:`~.locality.NeighborList`: Neighbor list.
         """
+        self._nlist = nlist_from_cnlist(self.thisptr.getNeighborList().get())
         return self._nlist
-
-    @property
-    def volumes(self):
-        R"""Returns an array of volumes (areas in 2D) corresponding to Voronoi
-        cells.
-
-        Must call :meth:`freud.locality.Voronoi.compute()` before this
-        method.
-
-        If the buffer width is too small, then some polytopes may not be
-        closed (they may have a boundary at infinity), and these polytopes'
-        volumes/areas are excluded from the list.
-
-        The length of the list returned by this method should be the same
-        as the array of positions used in the
-        :meth:`freud.locality.Voronoi.compute()` method, if all the polytopes
-        are closed. Otherwise try using a larger buffer width.
-
-        Returns:
-            (:math:`\left(N_{cells} \right)`) :class:`numpy.ndarray`:
-                Voronoi polytope volumes/areas.
-        """
-
-        self._volumes = np.zeros((len(self._polytopes)))
-
-        for i, verts in enumerate(self._polytopes):
-            is2D = np.all(self._polytopes[0][:, -1] == 0)
-            hull = ConvexHull(verts[:, :2 if is2D else 3])
-            self._volumes[i] = hull.volume
-
-        return self._volumes
 
     def __repr__(self):
         return "freud.locality.{cls}()".format(
@@ -1103,7 +988,7 @@ cdef class _Voronoi:
                 (Default value = :code:`None`)
 
         Returns:
-            (:class:`matplotlib.axes.Axes`): Axis with the plot.
+            :class:`matplotlib.axes.Axes`: Axis with the plot.
         """
         import freud.plot
         if not self._box.is2D:

--- a/setup.py
+++ b/setup.py
@@ -374,6 +374,18 @@ extra_module_sources = dict(
     environment=[
         os.path.join("cpp", "util", "diagonalize.cc"),
     ],
+    locality=[
+        os.path.join("extern", "voro++", "src", "cell.cc"),
+        os.path.join("extern", "voro++", "src", "common.cc"),
+        os.path.join("extern", "voro++", "src", "container.cc"),
+        os.path.join("extern", "voro++", "src", "unitcell.cc"),
+        os.path.join("extern", "voro++", "src", "v_compute.cc"),
+        os.path.join("extern", "voro++", "src", "c_loops.cc"),
+        os.path.join("extern", "voro++", "src", "v_base.cc"),
+        os.path.join("extern", "voro++", "src", "wall.cc"),
+        os.path.join("extern", "voro++", "src", "pre_container.cc"),
+        os.path.join("extern", "voro++", "src", "container_prd.cc"),
+    ],
     order=[
         os.path.join("cpp", "util", "diagonalize.cc"),
         os.path.join("cpp", "cluster", "Cluster.cc"),

--- a/tests/test_locality_Voronoi.py
+++ b/tests/test_locality_Voronoi.py
@@ -5,46 +5,81 @@ import unittest
 import util
 
 
-@util.skipIfMissing('scipy.spatial')
+def sort_rounded_xyz_array(arr, decimals=4):
+    arr = np.asarray(arr)
+    arr = arr.round(decimals)
+    indices = np.lexsort((arr[:, 2], arr[:, 1], arr[:, 0]))
+    return arr[indices]
+
+
 class TestVoronoi(unittest.TestCase):
-    def test_basic(self):
+    def test_basic_2d(self):
         # Test that voronoi tessellations of random systems have the same
         # number of points and polytopes
         L = 10  # Box length
         N = 50  # Number of particles
-        vor = freud.locality._Voronoi()
-        box, positions = util.make_box_and_random_points(L, N, True)
-        vor.compute(box=box, positions=positions, buffer=L/2)
+        box, points = util.make_box_and_random_points(L, N, is2D=True)
+        vor = freud.locality.Voronoi()
+        vor.compute(box, points)
 
-        result = vor.polytopes
+        npt.assert_equal(len(vor.polytopes), len(points))
+        npt.assert_equal(len(vor.volumes), len(points))
+        npt.assert_almost_equal(np.sum(vor.volumes), box.volume)
 
-        npt.assert_equal(len(result), len(positions))
+    def test_basic_3d(self):
+        # Test that voronoi tessellations of random systems have the same
+        # number of points and polytopes
+        L = 10  # Box length
+        N = 50  # Number of particles
+        box, points = util.make_box_and_random_points(L, N, is2D=False)
+        vor = freud.locality.Voronoi()
+        vor.compute(box, points)
+
+        npt.assert_equal(len(vor.polytopes), len(points))
+        npt.assert_equal(len(vor.volumes), len(points))
+        npt.assert_almost_equal(np.sum(vor.volumes), box.volume)
 
     def test_voronoi_tess_2d(self):
         # Test that the voronoi polytope works for a 2D system
         L = 10  # Box length
         box = freud.box.Box.square(L)
-        vor = freud.locality._Voronoi()
+        vor = freud.locality.Voronoi()
         # Make a regular grid
         positions = np.array(
             [[0, 0, 0], [0, 1, 0], [0, 2, 0],
              [1, 0, 0], [1, 1, 0], [1, 2, 0],
-             [2, 0, 0], [2, 1, 0], [2, 2, 0]]).astype(np.float32)
-        vor.compute(box, positions, 0, False)
-        polytope_centers = set(tuple(point)
-                               for point in vor.polytopes[0].tolist())
-        check_centers = set([(1.5, 1.5, 0), (0.5, 1.5, 0),
-                             (0.5, 0.5, 0), (1.5, 0.5, 0)])
-        self.assertEqual(polytope_centers, check_centers)
+             [2, 0, 0], [2, 1, 0], [2, 2, 0]]).astype(np.float64)
+        vor.compute(box, positions)
+        center_polytope = sort_rounded_xyz_array(vor.polytopes[4])
+        expected_polytope = sort_rounded_xyz_array(
+            [[1.5, 1.5, 0], [0.5, 1.5, 0], [0.5, 0.5, 0], [1.5, 0.5, 0]])
+        npt.assert_almost_equal(center_polytope, expected_polytope)
 
-        # # Verify the cell areas
-        npt.assert_equal(vor.volumes, [1])
+        # Verify the cell areas
+        npt.assert_almost_equal(vor.volumes[4], 1)
+        npt.assert_almost_equal(np.sum(vor.volumes), box.volume)
+
+        # Verify the neighbor list weights
+        npt.assert_almost_equal(
+            vor.nlist.weights[vor.nlist.query_point_indices == 4], 1)
+
+        # Double the points (still inside the box) and test again
+        positions *= 2
+        vor.compute(box, positions)
+        center_polytope = sort_rounded_xyz_array(vor.polytopes[4])
+        expected_polytope = sort_rounded_xyz_array(
+            [[3, 3, 0], [1, 3, 0], [1, 1, 0], [3, 1, 0]])
+        npt.assert_almost_equal(center_polytope, expected_polytope)
+        npt.assert_almost_equal(vor.volumes[4], 4)
+        npt.assert_almost_equal(np.sum(vor.volumes), box.volume)
+        npt.assert_almost_equal(
+            vor.nlist.weights[vor.nlist.query_point_indices == 4], 2)
 
     def test_voronoi_tess_3d(self):
         # Test that the voronoi polytope works for a 3D system
         L = 10  # Box length
         box = freud.box.Box.cube(L)
-        vor = freud.locality._Voronoi()
+        vor = freud.locality.Voronoi()
         # Make a regular grid
         positions = np.array(
             [[0, 0, 0], [0, 1, 0], [0, 2, 0],
@@ -55,52 +90,73 @@ class TestVoronoi(unittest.TestCase):
              [2, 0, 1], [2, 1, 1], [2, 2, 1],
              [0, 0, 2], [0, 1, 2], [0, 2, 2],
              [1, 0, 2], [1, 1, 2], [1, 2, 2],
-             [2, 0, 2], [2, 1, 2], [2, 2, 2]]).astype(np.float32)
-        vor.compute(box, positions, 0, False)
-        polytope_centers = set(tuple(point)
-                               for point in vor.polytopes[0].tolist())
-        check_centers = set([(1.5, 1.5, 1.5), (1.5, 0.5, 1.5), (1.5, 0.5, 0.5),
-                             (1.5, 1.5, 0.5), (0.5, 0.5, 0.5), (0.5, 0.5, 1.5),
-                             (0.5, 1.5, 0.5), (0.5, 1.5, 1.5)])
-        self.assertEqual(polytope_centers, check_centers)
+             [2, 0, 2], [2, 1, 2], [2, 2, 2]]).astype(np.float64)
+        vor.compute(box, positions)
+
+        center_polytope = sort_rounded_xyz_array(vor.polytopes[13])
+        expected_polytope = sort_rounded_xyz_array(
+            [[1.5, 1.5, 1.5], [1.5, 0.5, 1.5], [1.5, 0.5, 0.5],
+             [1.5, 1.5, 0.5], [0.5, 0.5, 0.5], [0.5, 0.5, 1.5],
+             [0.5, 1.5, 0.5], [0.5, 1.5, 1.5]])
+        npt.assert_almost_equal(center_polytope, expected_polytope)
 
         # Verify the cell volumes
-        npt.assert_equal(vor.volumes, [1])
+        npt.assert_almost_equal(vor.volumes[13], 1)
+        npt.assert_almost_equal(np.sum(vor.volumes), box.volume)
+
+        # Verify the neighbor list weights
+        npt.assert_almost_equal(
+            vor.nlist.weights[vor.nlist.query_point_indices == 13], 1)
+
+        # Double the points (still inside the box) and test again
+        positions *= 2
+        vor.compute(box, positions)
+        center_polytope = sort_rounded_xyz_array(vor.polytopes[13])
+        expected_polytope = sort_rounded_xyz_array(
+            [[3, 3, 3], [3, 1, 3], [3, 1, 1],
+             [3, 3, 1], [1, 1, 1], [1, 1, 3],
+             [1, 3, 1], [1, 3, 3]])
+        npt.assert_almost_equal(center_polytope, expected_polytope)
+        npt.assert_almost_equal(vor.volumes[13], 8)
+        npt.assert_almost_equal(np.sum(vor.volumes), box.volume)
+        npt.assert_almost_equal(
+            vor.nlist.weights[vor.nlist.query_point_indices == 13], 4)
 
     def test_voronoi_neighbors_wrapped(self):
-        # Test that voronoi neighbors in the first shell are
-        # correct for a wrapped 3D system
+        # Test that voronoi neighbors in the first shell are correct for a
+        # wrapped 3D system, also tests multiple compute calls
 
-        L = 3.0  # Box length
-        box = freud.box.Box.cube(L)
-        rbuf = L/2
+        n = 10
+        structure_neighbors = {
+            'sc': (util.make_sc, 6),
+            'bcc': (util.make_bcc, 14),
+            'fcc': (util.make_fcc, 12),
+        }
+        vor = freud.locality.Voronoi()
 
-        # Make a simple cubic structure
-        positions = np.array([[i + 0.5 - L/2,
-                               j + 0.5 - L/2,
-                               k + 0.5 - L/2]
-                              for i in range(int(L))
-                              for j in range(int(L))
-                              for k in range(int(L))]).astype(np.float32)
-        vor = freud.locality._Voronoi()
-        vor.compute(box, positions, rbuf)
-        nlist = vor.nlist
+        for func, neighbors in structure_neighbors.values():
+            box, points = func(nx=n, ny=n, nz=n)
+            vor.compute(box, points)
+            nlist = vor.nlist
 
-        # Drop the tiny facets that come from numerical imprecision
-        nlist = nlist.filter(nlist.weights > 1e-7)
+            # Drop the tiny facets that come from numerical imprecision
+            nlist = nlist.filter(nlist.weights > 1e-5)
 
-        # Every particle should have six neighbors
-        npt.assert_equal(nlist.neighbor_counts, np.full(len(positions), 6))
+            unique_indices, counts = np.unique(nlist.query_point_indices,
+                                               return_counts=True)
+
+            # Every particle should have six neighbors
+            npt.assert_equal(counts, neighbors)
+            npt.assert_almost_equal(np.sum(vor.volumes), box.volume)
 
     def test_voronoi_weights_fcc(self):
         # Test that voronoi neighbor weights are computed properly for 3D FCC
 
-        L = 3
-        box, positions = util.make_fcc(nx=L, ny=L, nz=L)
-        rbuf = np.max(box.L)/2
+        n = 3
+        box, positions = util.make_fcc(nx=n, ny=n, nz=n)
 
-        vor = freud.locality._Voronoi()
-        vor.compute(box, positions, rbuf, False)
+        vor = freud.locality.Voronoi()
+        vor.compute(box, positions)
         nlist = vor.nlist
 
         # Drop the tiny facets that come from numerical imprecision
@@ -116,20 +172,18 @@ class TestVoronoi(unittest.TestCase):
 
         # Every cell should have volume 2
         vor.compute(box, positions)
-        npt.assert_allclose(vor.compute(box, positions, rbuf, False).volumes,
+        npt.assert_allclose(vor.compute(box, positions).volumes,
                             np.full(len(vor.polytopes), 2.),
                             atol=1e-5)
 
     def test_nlist_symmetric(self):
         # Test that the voronoi neighborlist is symmetric
         L = 10  # Box length
-        rbuf = 3  # Cutoff radius
         N = 40  # Number of particles
 
-        box, points = util.make_box_and_random_points(L, N)
-        vor = freud.locality._Voronoi()
-        vor.compute(
-            box=box, positions=points, buffer=rbuf, images=False)
+        box, points = util.make_box_and_random_points(L, N, is2D=False)
+        vor = freud.locality.Voronoi()
+        vor.compute(box, points)
         nlist = vor.nlist
 
         ijs = set(zip(nlist.query_point_indices, nlist.point_indices))
@@ -139,8 +193,61 @@ class TestVoronoi(unittest.TestCase):
         self.assertTrue(all((j, i) in jis for (i, j) in ijs))
 
     def test_repr(self):
-        vor = freud.locality._Voronoi()
+        vor = freud.locality.Voronoi()
         self.assertEqual(str(vor), str(eval(repr(vor))))
+
+    def test_attributes(self):
+        # Test that the class attributes are protected
+        L = 10  # Box length
+        N = 40  # Number of particles
+        vor = freud.locality.Voronoi()
+        with self.assertRaises(AttributeError):
+            vor.nlist
+        with self.assertRaises(AttributeError):
+            vor.polytopes
+        with self.assertRaises(AttributeError):
+            vor.volumes
+        box, points = util.make_box_and_random_points(L, N, is2D=False)
+        vor.compute(box, points)
+
+        # Ensure attributes are accessible after calling compute
+        vor.nlist
+        vor.polytopes
+        vor.volumes
+
+    def test_repr_png(self):
+        L = 10  # Box length
+        box = freud.box.Box.square(L)
+        vor = freud.locality.Voronoi()
+
+        with self.assertRaises(AttributeError):
+            vor.plot()
+        self.assertEqual(vor._repr_png_(), None)
+
+        # Make a regular grid
+        positions = np.array(
+            [[0, 0, 0], [0, 1, 0], [0, 2, 0],
+             [1, 0, 0], [1, 1, 0], [1, 2, 0],
+             [2, 0, 0], [2, 1, 0], [2, 2, 0]]).astype(np.float32)
+        vor.compute(box, positions)
+        vor._repr_png_()
+
+        L = 10  # Box length
+        box = freud.box.Box.cube(L)
+        vor = freud.locality.Voronoi()
+        # Make a regular grid
+        positions = np.array(
+            [[0, 0, 0], [0, 1, 0], [0, 2, 0],
+             [1, 0, 0], [1, 1, 0], [1, 2, 0],
+             [2, 0, 0], [2, 1, 0], [2, 2, 0],
+             [0, 0, 1], [0, 1, 1], [0, 2, 1],
+             [1, 0, 1], [1, 1, 1], [1, 2, 1],
+             [2, 0, 1], [2, 1, 1], [2, 2, 1],
+             [0, 0, 2], [0, 1, 2], [0, 2, 2],
+             [1, 0, 2], [1, 1, 2], [1, 2, 2],
+             [2, 0, 2], [2, 1, 2], [2, 2, 2]]).astype(np.float32)
+        vor.compute(box, positions)
+        self.assertEqual(vor._repr_png_(), None)
 
 
 if __name__ == '__main__':

--- a/tests/test_locality_Voronoi.py
+++ b/tests/test_locality_Voronoi.py
@@ -6,6 +6,10 @@ import util
 
 
 def sort_rounded_xyz_array(arr, decimals=4):
+    """The order of Voronoi polytopes' vertices is not well-defined. Instead of
+    testing a fixed array, arrays must be sorted by their rounded
+    representations in order to compare their values.
+    """
     arr = np.asarray(arr)
     arr = arr.round(decimals)
     indices = np.lexsort((arr[:, 2], arr[:, 1], arr[:, 0]))


### PR DESCRIPTION
**This PR replaces #362, which I rewrote to use a git submodule.** PR #362 was too far out of sync with `next` to salvage.

## Description
This PR adds the voro++ library ([homepage](http://math.lbl.gov/voro++/), [GitHub repo](https://github.com/chr1shr/voro)) written by Chris Rycroft (@chr1shr) to freud. This will replace the existing Voronoi methods, which used less sophisticated algorithms and were quite slow.

## Motivation and Context
Issue #305 describes challenges with Voronoi performance -- this continues to be a bottleneck for my current analyses, so I found it worthwhile to rewrite this entire feature using voro++.

## How Has This Been Tested?
I have adapted existing Voronoi tests, which work as expected in both 2D and 3D systems. Some changes (like reordering of vertices in a Voronoi cell) are expected, so I added functions to sort the vertices in a deterministic way for the purpose of testing. Currently, this new approach is about 32x faster for a system of 5000 random points in a cubic box of side length 10.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds or improves functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!-- Put an `x` in all the boxes that apply. If you're unsure about any of
     these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/glotzerlab/freud/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] I have updated the documentation (if relevant).
- [x] I have added tests that cover my changes (if relevant).
- [x] All new and existing tests passed.
- [x] I have updated the [credits](https://github.com/glotzerlab/freud/blob/master/doc/source/credits.rst).
- [x] I have updated the [Changelog](https://github.com/glotzerlab/freud/blob/master/ChangeLog.md).
