### PR TITLE
Feature/standardize vector directions

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -38,7 +38,7 @@ and this project adheres to
 * Renamed several Box methods, ParticleBuffer is now PeriodicBuffer.
 * Refactored and renamed attributes of Cluster and ClusterProperties modules.
 * All class attributes are stored in the C++ members and accessed via getters wrapped as Python properties.
-* Vector directionality is standardized for all computes that use it (always points from point to query\_point).
+* Bond vector directionality is standardized for all computes that use it (always from query\_point to point).
 * Neighbor-based compute methods now accept NeighborQuery objects as the first object, including (box, point) tuples.
 * Documentation uses automodule instead of autoclass.
 

--- a/cpp/density/GaussianDensity.cc
+++ b/cpp/density/GaussianDensity.cc
@@ -46,18 +46,19 @@ void GaussianDensity::compute(const box::Box& box, const vec3<float>* points, un
     }
     m_density_array.prepare({width.x, width.y, width.z});
     util::ThreadStorage<float> local_bin_counts({width.x, width.y, width.z});
+
     util::forLoopWrapper(0, n_points, [&](size_t begin, size_t end) {
         // set up some constants first
-        float lx = m_box.getLx();
-        float ly = m_box.getLy();
-        float lz = m_box.getLz();
+        const float lx = m_box.getLx();
+        const float ly = m_box.getLy();
+        const float lz = m_box.getLz();
 
-        float grid_size_x = lx / m_width.x;
-        float grid_size_y = ly / m_width.y;
-        float grid_size_z = lz / m_width.z;
+        const float grid_size_x = lx / m_width.x;
+        const float grid_size_y = ly / m_width.y;
+        const float grid_size_z = lz / m_width.z;
 
-        float sigmasq = m_sigma * m_sigma;
-        float A = sqrt(1.0f / (2.0f * M_PI * sigmasq));
+        const float sigmasq = m_sigma * m_sigma;
+        const float A = std::sqrt(1.0f / (2.0f * M_PI * sigmasq));
 
         // for each reference point
         for (size_t idx = begin; idx < end; ++idx)
@@ -85,34 +86,34 @@ void GaussianDensity::compute(const box::Box& box, const vec3<float>* points, un
             // to reduce the number of computations
             for (int k = bin_z - bin_cut_z; k <= bin_z + bin_cut_z; k++)
             {
-                float dz = float((grid_size_z * k + grid_size_z / 2.0f) - points[idx].z - lz / 2.0f);
+                const float dz = float((grid_size_z * k + grid_size_z / 2.0f) - points[idx].z - lz / 2.0f);
 
                 for (int j = bin_y - bin_cut_y; j <= bin_y + bin_cut_y; j++)
                 {
-                    float dy = float((grid_size_y * j + grid_size_y / 2.0f) - points[idx].y - ly / 2.0f);
+                    const float dy = float((grid_size_y * j + grid_size_y / 2.0f) - points[idx].y - ly / 2.0f);
 
                     for (int i = bin_x - bin_cut_x; i <= bin_x + bin_cut_x; i++)
                     {
-                        // Calculate the distance from the grid cell to particular particle
-                        float dx = float((grid_size_x * i + grid_size_x / 2.0f) - points[idx].x - lx / 2.0f);
+                        // Calculate the distance from the particle to the grid cell
+                        const float dx = float((grid_size_x * i + grid_size_x / 2.0f) - points[idx].x - lx / 2.0f);
                         vec3<float> delta = m_box.wrap(vec3<float>(dx, dy, dz));
 
-                        float r_sq = dot(delta, delta);
-                        float r_sqrt = sqrtf(r_sq);
+                        const float r_sq = dot(delta, delta);
+                        const float r_sqrt = std::sqrt(r_sq);
 
                         // Check to see if this distance is within the specified r_max
                         if (r_sqrt < m_r_max)
                         {
                             // Evaluate the gaussian ...
-                            float x_gaussian = A * exp((-1.0f) * (delta.x * delta.x) / (2.0f * sigmasq));
-                            float y_gaussian = A * exp((-1.0f) * (delta.y * delta.y) / (2.0f * sigmasq));
-                            float z_gaussian = A * exp((-1.0f) * (delta.z * delta.z) / (2.0f * sigmasq));
+                            const float x_gaussian = A * exp((-1.0f) * (delta.x * delta.x) / (2.0f * sigmasq));
+                            const float y_gaussian = A * exp((-1.0f) * (delta.y * delta.y) / (2.0f * sigmasq));
+                            const float z_gaussian = A * exp((-1.0f) * (delta.z * delta.z) / (2.0f * sigmasq));
 
                             // Assure that out of range indices are corrected for storage
                             // in the array i.e. bin -1 is actually bin 29 for nbins = 30
-                            unsigned int ni = (i + m_width.x) % m_width.x;
-                            unsigned int nj = (j + m_width.y) % m_width.y;
-                            unsigned int nk = (k + m_width.z) % m_width.z;
+                            const unsigned int ni = (i + m_width.x) % m_width.x;
+                            const unsigned int nj = (j + m_width.y) % m_width.y;
+                            const unsigned int nk = (k + m_width.z) % m_width.z;
 
                             // store the product of these values in an array - n[i, j, k]
                             // = gx*gy*gz

--- a/cpp/density/GaussianDensity.cc
+++ b/cpp/density/GaussianDensity.cc
@@ -55,7 +55,12 @@ void GaussianDensity::compute(const box::Box& box, const vec3<float>* points, un
 
         const float grid_size_x = lx / m_width.x;
         const float grid_size_y = ly / m_width.y;
-        const float grid_size_z = lz / m_width.z;
+        const float grid_size_z = m_box.is2D() ? lz / m_width.z : 0;
+
+        // Find the number of bins within r_max
+        const int bin_cut_x = int(m_r_max / grid_size_x);
+        const int bin_cut_y = int(m_r_max / grid_size_y);
+        const int bin_cut_z = m_box.is2D() ? int(m_r_max / grid_size_z) : 0;
 
         const float sigmasq = m_sigma * m_sigma;
         const float A = std::sqrt(1.0f / (2.0f * M_PI * sigmasq));
@@ -70,18 +75,12 @@ void GaussianDensity::compute(const box::Box& box, const vec3<float>* points, un
             int bin_y = int((points[idx].y + ly / 2.0f) / grid_size_y);
             int bin_z = int((points[idx].z + lz / 2.0f) / grid_size_z);
 
-            // Find the number of bins within r_max
-            int bin_cut_x = int(m_r_max / grid_size_x);
-            int bin_cut_y = int(m_r_max / grid_size_y);
-            int bin_cut_z = int(m_r_max / grid_size_z);
-
             // in 2D, only loop over the 0 z plane
             if (m_box.is2D())
             {
                 bin_z = 0;
-                bin_cut_z = 0;
-                grid_size_z = 0;
             }
+
             // Only evaluate over bins that are within the cut off
             // to reduce the number of computations
             for (int k = bin_z - bin_cut_z; k <= bin_z + bin_cut_z; k++)

--- a/cpp/locality/NeighborComputeFunctional.h
+++ b/cpp/locality/NeighborComputeFunctional.h
@@ -32,7 +32,7 @@ NeighborList makeDefaultNlist(const NeighborQuery *nq, const NeighborList
 inline vec3<float> bondVector(const NeighborBond &nb, const NeighborQuery *nq,
         const vec3<float> *query_points)
 {
-    return nq->getBox().wrap(query_points[nb.query_point_idx] - (*nq)[nb.point_idx]);
+    return nq->getBox().wrap((*nq)[nb.point_idx] - query_points[nb.query_point_idx]);
 }
 
 //! Implementation of per-point finding logic for NeighborList objects.

--- a/cpp/order/HexaticTranslational.cc
+++ b/cpp/order/HexaticTranslational.cc
@@ -23,11 +23,10 @@ void HexaticTranslational<T>::computeGeneral(Func func, const freud::locality::N
 
         for(freud::locality::NeighborBond nb = ppiter->next(); !ppiter->end(); nb = ppiter->next())
         {
-            // Compute vector between the two particles
+            // Compute vector from query_point to point
             const vec3<float> delta = box.wrap((*points)[nb.point_idx] - ref);
 
-            // Compute psi for neighboring particle
-            // (only constructed for 2d)
+            // Compute psi for this vector
             m_psi_array[i] += func(delta);
         }
 

--- a/doc/source/credits.rst
+++ b/doc/source/credits.rst
@@ -118,7 +118,8 @@ Bradley Dice - **Lead developer**
 * Rewrote Voronoi implementation to leverage voro++.
 * Implemented Voronoi bond weighting to enable Minkowski structure metrics.
 * Refactored methods in Box and PeriodicBuffer for v2.0.
-* Refactored cluster module
+* Refactored cluster module.
+* Standardized vector directionality in computes.
 
 Richmond Newman
 

--- a/tests/test_environment_LocalBondProjection.py
+++ b/tests/test_environment_LocalBondProjection.py
@@ -88,40 +88,39 @@ class TestLocalBondProjection(unittest.TestCase):
         ang.compute((box, points), ors, proj_vecs, neighbors=query_args)
 
         dnlist = freud.locality.make_default_nlist(
-            box, points, None,
-            dict(num_neighbors=num_neighbors, r_guess=r_guess), None)
+            box, points, None, query_args, None)
         bonds = [(i[0], i[1]) for i in dnlist]
 
-        # We will look at the bond between [1, 0, 0] as ref_point
+        # We will look at the bond between [1, 0, 0] as query_point
         # and [0, 0, 0] as point
         # This will give bond [-1, 0, 0].
-        # Since [1, 0, 0] is the ref_point at index 1, we rotate
+        # Since [1, 0, 0] is the query_point at index 1, we rotate
         # this about y axis by pi/2, which will give
-        # [0, 0, -1].
-        # The projection onto [0, 0, 1] is cos(pi) = -1.
+        # [0, 0, 1].
+        # The projection onto [0, 0, 1] is cos(0) = 1.
         index = bonds.index((0, 1))
-        npt.assert_allclose(ang.projections[index], -1, atol=1e-6)
-        npt.assert_allclose(ang.normed_projections[index], -1, atol=1e-6)
+        npt.assert_allclose(ang.projections[index], 1, atol=1e-6)
+        npt.assert_allclose(ang.normed_projections[index], 1, atol=1e-6)
 
-        # We will look at the bond between [0, 0, 0] as ref_point
+        # We will look at the bond between [0, 0, 0] as query_point
         # and [1, 0, 0] as point
-        # This will give bond [1, 0, 0].
-        # Since [0, 0, 0] is the ref_point at index 0, we rotate
-        # this by the identity, which will give [1, 0, 0].
+        # This will give bond [-1, 0, 0].
+        # Since [0, 0, 0] is the query_point at index 0, we rotate
+        # this by the identity, which will give [-1, 0, 0].
         # The projection onto [0, 0, 1] is 0.
         index = bonds.index((1, 0))
         npt.assert_allclose(ang.projections[index], 0, atol=1e-6)
         npt.assert_allclose(ang.normed_projections[index], 0, atol=1e-6)
 
-        # We will look at the bond between [0, 0, 0] as ref_point
-        # and [0, 0, 1.5] as point
-        # This will give bond [0, 0, 1.5].
-        # Since [0, 0, 0] is the ref_point at index 0, we rotate
-        # this by the identity, which will give [0, 0, 1.5].
-        # The projection onto [0, 0, 1] is 1.5.
+        # We will look at the bond between [0, 0, 1.5] as query_point
+        # and [0, 0, 0] as point
+        # This will give bond [0, 0, -1.5].
+        # Since [0, 0, 0] is the query_point at index 0, we rotate
+        # this by the identity, which will give [0, 0, -1.5].
+        # The projection onto [0, 0, 1] is -1.5.
         index = bonds.index((2, 0))
-        npt.assert_allclose(ang.projections[index], 1.5, atol=1e-6)
-        npt.assert_allclose(ang.normed_projections[index], 1, atol=1e-6)
+        npt.assert_allclose(ang.projections[index], -1.5, atol=1e-6)
+        npt.assert_allclose(ang.normed_projections[index], -1, atol=1e-6)
 
         # Specify that rotations about y by +/-pi/2 and rotations about x by pi
         # result in equivalent particle shapes

--- a/tests/test_environment_LocalDescriptors.py
+++ b/tests/test_environment_LocalDescriptors.py
@@ -342,7 +342,7 @@ class TestLocalDescriptors(unittest.TestCase):
 
         # Loop over the sphs and compute them explicitly.
         for idx, (i, j) in enumerate(nl):
-            bond = box.wrap(points[i] - points[j])
+            bond = box.wrap(points[j] - points[i])
             r = np.linalg.norm(bond)
             theta = np.arccos(bond[2]/r)
             phi = np.arctan2(bond[1], bond[0])
@@ -378,7 +378,7 @@ class TestLocalDescriptors(unittest.TestCase):
                     count += 1
 
     @skipIfMissing('scipy.special')
-    def test_ref_point_ne_points(self):
+    def test_query_point_ne_points(self):
         """Verify the behavior of LocalDescriptors by explicitly calculating
         spherical harmonics manually and verifying them."""
         from scipy.special import sph_harm
@@ -386,7 +386,7 @@ class TestLocalDescriptors(unittest.TestCase):
         L = 8
         N = 100
         box, points = make_box_and_random_points(L, N)
-        ref_points = np.random.rand(N, 3)*L - L/2
+        query_points = np.random.rand(N, 3)*L - L/2
 
         num_neighbors = 1
         l_max = 2
@@ -399,11 +399,11 @@ class TestLocalDescriptors(unittest.TestCase):
                            num_neighbors=num_neighbors)).toNeighborList()
 
         ld = freud.environment.LocalDescriptors(l_max, mode='global')
-        ld.compute((box, ref_points), points, neighbors=nl)
+        ld.compute((box, points), query_points, neighbors=nl)
 
         # Loop over the sphs and compute them explicitly.
         for idx, (i, j) in enumerate(nl):
-            bond = box.wrap(points[i] - ref_points[j])
+            bond = box.wrap(points[j] - query_points[i])
             r = np.linalg.norm(bond)
             theta = np.arccos(bond[2]/r)
             phi = np.arctan2(bond[1], bond[0])


### PR DESCRIPTION
## Description
Reverses bond direction, so that all bonds go from `query_point` to `point`. That is, a bond vector is defined by `point - query_point`.

## Motivation and Context
Resolves: #480.

## How Has This Been Tested?
Swapped directions in direction-sensitive tests.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds or improves functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!-- Put an `x` in all the boxes that apply. If you're unsure about any of
     these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/glotzerlab/freud/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] I have updated the documentation (if relevant).
- [x] I have added tests that cover my changes (if relevant).
- [x] All new and existing tests passed.
- [x] I have updated the [credits](https://github.com/glotzerlab/freud/blob/master/doc/source/credits.rst).
- [x] I have updated the [Changelog](https://github.com/glotzerlab/freud/blob/master/ChangeLog.md).
