### PR TITLE
Refactor/update locality matchenv apis

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -42,6 +42,7 @@ and this project adheres to
 * Neighbor-based compute methods now accept NeighborQuery objects as the first object, including (box, point) tuples.
 * Documentation uses automodule instead of autoclass.
 * The Voronoi class was rewritten to use voro++ for vastly improved performance and correctness in edge cases.
+* MatchEnv has been split into separate classes for the different types of computations it is capable of performing, and these classes all use v2.0-style APIs.
 
 ### Fixed
 * Steinhardt uses the ThreadStorage class and properly resets memory where needed.

--- a/cpp/environment/MatchEnv.cc
+++ b/cpp/environment/MatchEnv.cc
@@ -603,7 +603,7 @@ void MatchEnv::cluster(const freud::locality::NeighborList* env_nlist,
 
     // done looping over points. All clusters are now determined. Renumber
     // them from zero to num_clusters-1.
-    populateEnv(dj, true);
+    populateEnv(dj, m_env_index, m_env, m_tot_env, true);
 }
 
 void MatchEnv::matchMotif(const freud::locality::NeighborList* nlist, const vec3<float>* points,
@@ -675,7 +675,7 @@ void MatchEnv::matchMotif(const freud::locality::NeighborList* nlist, const vec3
     // DON'T renumber the clusters in the disjoint set from zero to
     // num_clusters-1. The way I have set it up here, the "0th" cluster
     // is the one that matches the motif.
-    populateEnv(dj, false);
+    populateEnv(dj, m_env_index, m_env, m_tot_env, false);
 }
 
 std::vector<float> MatchEnv::minRMSDMotif(const freud::locality::NeighborList* nlist,
@@ -754,12 +754,12 @@ std::vector<float> MatchEnv::minRMSDMotif(const freud::locality::NeighborList* n
     // DON'T renumber the clusters in the disjoint set from zero to
     // num_clusters-1. The way I have set it up here, the "0th" cluster
     // is the one that matches the motif.
-    populateEnv(dj, false);
+    populateEnv(dj, m_env_index, m_env, m_tot_env, false);
 
     return min_rmsd_vec;
 }
 
-void MatchEnv::populateEnv(EnvDisjointSet dj, bool reLabel)
+void MatchEnv::populateEnv(EnvDisjointSet dj, util::ManagedArray<unsigned int> &env_index, std::map<unsigned int, std::vector<vec3<float> > > &env, util::ManagedArray<vec3<float> > &tot_env, bool reLabel)
 {
     std::map<unsigned int, unsigned int> label_map;
 
@@ -783,7 +783,7 @@ void MatchEnv::populateEnv(EnvDisjointSet dj, bool reLabel)
                 label_map[c] = cur_set;
                 std::vector<vec3<float>> vecs = dj.getAvgEnv(c);
                 label_ind = reLabel ? label_map[c] : c;
-                m_env[label_ind] = vecs;
+                env[label_ind] = vecs;
                 cur_set++;
             }
             else
@@ -792,10 +792,10 @@ void MatchEnv::populateEnv(EnvDisjointSet dj, bool reLabel)
             }
 
             // label this particle in m_env_index
-            m_env_index[particle_ind] = label_ind;
+            env_index[particle_ind] = label_ind;
             for (unsigned int m = 0; m < part_vecs.size(); m++)
             {
-                m_tot_env(particle_ind, m) = part_vecs[m];
+                tot_env(particle_ind, m) = part_vecs[m];
             }
             particle_ind++;
         }

--- a/cpp/environment/MatchEnv.cc
+++ b/cpp/environment/MatchEnv.cc
@@ -485,7 +485,6 @@ std::map<unsigned int, unsigned int> minimizeRMSD(const box::Box &box, const vec
 /************
  * MatchEnv *
  ************/
-
 MatchEnv::MatchEnv(const box::Box& box, float r_max, unsigned int num_neighbors) : m_box(box), m_r_max(r_max), m_num_neighbors(num_neighbors)
 {
     m_max_num_neighbors = 0;
@@ -667,9 +666,9 @@ unsigned int EnvironmentCluster::populateEnv(EnvDisjointSet dj)
     return cur_set;
 }
 
-/**********************
- * EnvironmentCluster *
- **********************/
+/*************************
+ * EnvironmentMotifMatch *
+ *************************/
 void EnvironmentMotifMatch::compute(const freud::locality::NeighborList* nlist, const vec3<float>* points,
                           unsigned int Np, const vec3<float>* motif, unsigned int motif_size, float threshold,
                           bool registration)

--- a/cpp/environment/MatchEnv.cc
+++ b/cpp/environment/MatchEnv.cc
@@ -547,8 +547,8 @@ void EnvironmentCluster::compute(const freud::locality::NeighborQuery* nq, const
         dj.m_max_num_neigh = std::max(dj.m_max_num_neigh, ei.num_vecs);;
     }
 
-    // reallocate the m_particle_environments array
-    m_particle_environments.prepare({Np, dj.m_max_num_neigh});
+    // reallocate the m_point_environments array
+    m_point_environments.prepare({Np, dj.m_max_num_neigh});
 
     size_t bond(0);
     // loop through points
@@ -643,7 +643,7 @@ unsigned int EnvironmentCluster::populateEnv(EnvDisjointSet dj)
             m_env_index[particle_ind] = label_ind;
             for (unsigned int m = 0; m < part_vecs.size(); m++)
             {
-                m_particle_environments(particle_ind, m) = part_vecs[m];
+                m_point_environments(particle_ind, m) = part_vecs[m];
             }
             particle_ind++;
         }
@@ -680,8 +680,8 @@ void EnvironmentMotifMatch::compute(const freud::locality::NeighborQuery* nq, co
     EnvDisjointSet dj(Np + 1);
     dj.m_max_num_neigh = motif_size;
 
-    // reallocate the m_particle_environments array
-    m_particle_environments.prepare({Np, motif_size});
+    // reallocate the m_point_environments array
+    m_point_environments.prepare({Np, motif_size});
 
     // create the environment characterized by motif. Index it as 0.
     // set the IGNORE flag to true, since this is not an environment we have
@@ -734,7 +734,7 @@ void EnvironmentMotifMatch::compute(const freud::locality::NeighborQuery* nq, co
 
         for (unsigned int m = 0; m < part_vecs.size(); m++)
         {
-            m_particle_environments(i, m) = part_vecs[m];
+            m_point_environments(i, m) = part_vecs[m];
         }
     }
 }
@@ -756,8 +756,8 @@ void EnvironmentRMSDMinimizer::compute(const freud::locality::NeighborQuery* nq,
     EnvDisjointSet dj(Np + 1);
     dj.m_max_num_neigh = motif_size;
 
-    // reallocate the m_particle_environments array
-    m_particle_environments.prepare({Np, motif_size});
+    // reallocate the m_point_environments array
+    m_point_environments.prepare({Np, motif_size});
 
     // create the environment characterized by motif. Index it as 0.
     // set the IGNORE flag to true, since this is not an environment we
@@ -815,7 +815,7 @@ void EnvironmentRMSDMinimizer::compute(const freud::locality::NeighborQuery* nq,
 
         for (unsigned int m = 0; m < part_vecs.size(); m++)
         {
-            m_particle_environments(i, m) = part_vecs[m];
+            m_point_environments(i, m) = part_vecs[m];
         }
     }
 }

--- a/cpp/environment/MatchEnv.cc
+++ b/cpp/environment/MatchEnv.cc
@@ -528,12 +528,10 @@ unsigned int populateEnv(EnvDisjointSet dj, util::ManagedArray<unsigned int> &en
     return cur_set;
 }
 
+/**********************
+ * EnvironmentCluster *
+ **********************/
 
-
-
-/************
- * MatchEnv *
- ************/
 MatchEnv::MatchEnv(const box::Box& box, float r_max, unsigned int num_neighbors) : m_box(box), m_r_max(r_max), m_num_neighbors(num_neighbors)
 {
     m_Np = 0;
@@ -544,6 +542,11 @@ MatchEnv::MatchEnv(const box::Box& box, float r_max, unsigned int num_neighbors)
 }
 
 MatchEnv::~MatchEnv() {}
+
+/**********************
+ * EnvironmentCluster *
+ **********************/
+EnvironmentCluster::~EnvironmentCluster() {}
 
 Environment MatchEnv::buildEnv(const freud::locality::NeighborList* nlist, size_t num_bonds, size_t& bond,
                                const vec3<float>* points, unsigned int i, unsigned int env_ind)
@@ -567,7 +570,7 @@ Environment MatchEnv::buildEnv(const freud::locality::NeighborList* nlist, size_
     return ei;
 }
 
-void MatchEnv::cluster(const freud::locality::NeighborList* env_nlist,
+void EnvironmentCluster::cluster(const freud::locality::NeighborList* env_nlist,
                        const freud::locality::NeighborList* nlist, const vec3<float>* points, unsigned int Np,
                        float threshold, bool registration, bool global)
 {
@@ -656,7 +659,7 @@ void MatchEnv::cluster(const freud::locality::NeighborList* env_nlist,
     m_num_clusters = populateEnv(dj, m_env_index, m_env, m_tot_env, true);
 }
 
-void MatchEnv::matchMotif(const freud::locality::NeighborList* nlist, const vec3<float>* points,
+void EnvironmentMotifMatch::matchMotif(const freud::locality::NeighborList* nlist, const vec3<float>* points,
                           unsigned int Np, const vec3<float>* motif, unsigned int motif_size, float threshold,
                           bool registration)
 {
@@ -728,7 +731,7 @@ void MatchEnv::matchMotif(const freud::locality::NeighborList* nlist, const vec3
     m_num_clusters = populateEnv(dj, m_env_index, m_env, m_tot_env, false);
 }
 
-std::vector<float> MatchEnv::minRMSDMotif(const freud::locality::NeighborList* nlist,
+std::vector<float> EnvironmentMotifMatch::minRMSDMotif(const freud::locality::NeighborList* nlist,
                                           const vec3<float>* points, unsigned int Np,
                                           const vec3<float>* motif, unsigned int motif_size,
                                           bool registration)

--- a/cpp/environment/MatchEnv.cc
+++ b/cpp/environment/MatchEnv.cc
@@ -395,7 +395,7 @@ std::map<unsigned int, unsigned int> MatchEnv::isSimilar(const vec3<float>* refP
                                                          float threshold_sq, bool registration)
 {
     Environment e0, e1;
-    std::tie(e0, e1) = makeEnvironments(refPoints1, refPoints2, numRef);
+    std::tie(e0, e1) = makeEnvironments(m_box, refPoints1, refPoints2, numRef);
 
     // call isSimilar for e0 and e1
     std::pair<rotmat3<float>, BiMap<unsigned int, unsigned int>> mapping
@@ -413,8 +413,8 @@ std::map<unsigned int, unsigned int> MatchEnv::isSimilar(const vec3<float>* refP
     return vec_map.asMap();
 }
 
-std::pair<Environment, Environment> MatchEnv::makeEnvironments(const vec3<float>* refPoints1,
-                                                         vec3<float>* refPoints2, unsigned int numRef)
+std::pair<Environment, Environment> makeEnvironments(const box::Box &box, const vec3<float>* refPoints1,
+                                                     vec3<float>* refPoints2, unsigned int numRef)
 {
     // create the environment characterized by refPoints1. Index it as 0.
     // set the IGNORE flag to true, since this is not an environment we have
@@ -433,8 +433,8 @@ std::pair<Environment, Environment> MatchEnv::makeEnvironments(const vec3<float>
     // be wrapped into the box as well.
     for (unsigned int i = 0; i < numRef; i++)
     {
-        vec3<float> p0 = m_box.wrap(refPoints1[i]);
-        vec3<float> p1 = m_box.wrap(refPoints2[i]);
+        vec3<float> p0 = box.wrap(refPoints1[i]);
+        vec3<float> p1 = box.wrap(refPoints2[i]);
         e0.addVec(p0);
         e1.addVec(p1);
     }
@@ -443,7 +443,7 @@ std::pair<Environment, Environment> MatchEnv::makeEnvironments(const vec3<float>
 
 
 std::pair<rotmat3<float>, BiMap<unsigned int, unsigned int>>
-MatchEnv::minimizeRMSD(Environment& e1, Environment& e2, float& min_rmsd, bool registration)
+minimizeRMSD(Environment& e1, Environment& e2, float& min_rmsd, bool registration)
 {
     BiMap<unsigned int, unsigned int> vec_map;
     rotmat3<float> rotation = rotmat3<float>(); // this initializes to the identity matrix
@@ -492,12 +492,12 @@ MatchEnv::minimizeRMSD(Environment& e1, Environment& e2, float& min_rmsd, bool r
     return std::pair<rotmat3<float>, BiMap<unsigned int, unsigned int>>(rotation, vec_map);
 }
 
-std::map<unsigned int, unsigned int> MatchEnv::minimizeRMSD(const vec3<float>* refPoints1,
-                                                            vec3<float>* refPoints2, unsigned int numRef,
-                                                            float& min_rmsd, bool registration)
+std::map<unsigned int, unsigned int> minimizeRMSD(const box::Box &box, const vec3<float>* refPoints1,
+                                                  vec3<float>* refPoints2, unsigned int numRef,
+                                                  float& min_rmsd, bool registration)
 {
     Environment e0, e1;
-    std::tie(e0, e1) = makeEnvironments(refPoints1, refPoints2, numRef);
+    std::tie(e0, e1) = makeEnvironments(box, refPoints1, refPoints2, numRef);
 
     float tmp_min_rmsd = -1.0;
     std::pair<rotmat3<float>, BiMap<unsigned int, unsigned int>> mapping

--- a/cpp/environment/MatchEnv.cc
+++ b/cpp/environment/MatchEnv.cc
@@ -616,6 +616,7 @@ void EnvironmentCluster::compute(const freud::locality::NeighborList* env_nlist,
 unsigned int EnvironmentCluster::populateEnv(EnvDisjointSet dj)
 {
     std::map<unsigned int, unsigned int> label_map;
+    std::map<unsigned int, std::vector<vec3<float> > > cluster_env;
 
     // loop over all environments
     unsigned int label_ind;
@@ -637,7 +638,7 @@ unsigned int EnvironmentCluster::populateEnv(EnvDisjointSet dj)
                 label_map[c] = cur_set;
                 std::vector<vec3<float>> vecs = dj.getAvgEnv(c);
                 label_ind = label_map[c];
-                m_cluster_env[label_ind] = vecs;
+                cluster_env[label_ind] = vecs;
                 cur_set++;
             }
             else
@@ -653,6 +654,13 @@ unsigned int EnvironmentCluster::populateEnv(EnvDisjointSet dj)
             }
             particle_ind++;
         }
+    }
+
+    // Now update the vector of environments from the map.
+    m_cluster_environments.resize(cluster_env.size());
+    for (auto it = cluster_env.begin(); it != cluster_env.end(); ++it)
+    {
+        m_cluster_environments[it->first] = it->second;
     }
 
     // specify the number of cluster environments

--- a/cpp/environment/MatchEnv.cc
+++ b/cpp/environment/MatchEnv.cc
@@ -13,16 +13,11 @@
 
 namespace freud { namespace environment {
 
-// Constructor for EnvDisjointSet
-// Taken partially from Cluster.cc
+/*****************
+ * EnvDisjoinSet *
+ *****************/
 EnvDisjointSet::EnvDisjointSet(unsigned int Np) : rank(std::vector<unsigned int>(Np, 0)) {}
 
-// Merge the two sets that elements a and b belong to.
-// Taken partially from Cluster.cc
-// The vec_map must be a bimap of PROPERLY ORDERED vector indices where those
-// of set a are on the left and those of set b are on the right.
-// The rotation must take the set of PROPERLY ROTATED vectors b and rotate
-// them to match the set of PROPERLY ROTATED vectors a
 void EnvDisjointSet::merge(const unsigned int a, const unsigned int b,
                            BiMap<unsigned int, unsigned int> vec_map, rotmat3<float> rotation)
 {
@@ -147,8 +142,6 @@ void EnvDisjointSet::merge(const unsigned int a, const unsigned int b,
     }
 }
 
-// Return the set label that contains the element c
-// Taken mostly from Cluster.cc
 unsigned int EnvDisjointSet::find(const unsigned int c)
 {
     unsigned int r = c;
@@ -168,10 +161,6 @@ unsigned int EnvDisjointSet::find(const unsigned int c)
     return r;
 }
 
-// Return ALL nodes in the tree that correspond to the head index m.
-// Values returned: the actual locations of the nodes in s. (i.e. if i is
-// returned, the node is accessed by s[i]).
-// If environment m doesn't exist as a HEAD in the set, throw an error.
 std::vector<unsigned int> EnvDisjointSet::findSet(const unsigned int m)
 {
     bool invalid_ind = true;
@@ -200,9 +189,6 @@ std::vector<unsigned int> EnvDisjointSet::findSet(const unsigned int m)
     return m_set;
 }
 
-// Get the vectors corresponding to environment head index m. Vectors are
-// averaged over all members of the environment cluster.
-// If environment m doesn't exist as a HEAD in the set, throw an error.
 std::vector<vec3<float> > EnvDisjointSet::getAvgEnv(const unsigned int m)
 {
     bool invalid_ind = true;
@@ -253,8 +239,6 @@ std::vector<vec3<float> > EnvDisjointSet::getAvgEnv(const unsigned int m)
     return env;
 }
 
-// Get the vectors corresponding to index m in the dj set
-// If index m doesn't exist in the set, throw an error.
 std::vector<vec3<float>> EnvDisjointSet::getIndividualEnv(const unsigned int m)
 {
     if (m >= s.size())
@@ -281,6 +265,12 @@ std::vector<vec3<float>> EnvDisjointSet::getIndividualEnv(const unsigned int m)
     return env;
 }
 
+/*************************
+ * Convenience functions *
+ *************************/
+/************
+ * MatchEnv *
+ ************/
 MatchEnv::MatchEnv(const box::Box& box, float r_max, unsigned int num_neighbors) : m_box(box), m_r_max_sq(r_max*r_max), m_num_neighbors(num_neighbors)
 {
     m_Np = 0;
@@ -526,8 +516,6 @@ std::map<unsigned int, unsigned int> MatchEnv::minimizeRMSD(const vec3<float>* r
     return vec_map.asMap();
 }
 
-// Determine clusters of particles with matching environments
-// This is taken from Cluster.cc and SolLiq.cc and LocalQlNear.cc
 void MatchEnv::cluster(const freud::locality::NeighborList* env_nlist,
                        const freud::locality::NeighborList* nlist, const vec3<float>* points, unsigned int Np,
                        float threshold, bool registration, bool global)
@@ -617,8 +605,6 @@ void MatchEnv::cluster(const freud::locality::NeighborList* env_nlist,
     populateEnv(dj, true);
 }
 
-//! Determine whether particles match a given input motif, characterized by
-//  refPoints (of which there are numRef)
 void MatchEnv::matchMotif(const freud::locality::NeighborList* nlist, const vec3<float>* points,
                           unsigned int Np, const vec3<float>* refPoints, unsigned int numRef, float threshold,
                           bool registration)
@@ -691,16 +677,6 @@ void MatchEnv::matchMotif(const freud::locality::NeighborList* nlist, const vec3
     populateEnv(dj, false);
 }
 
-//! Rotate (if registration=True) and permute the environments of all particles
-//  to minimize their RMSD wrt a given input motif, characterized by refPoints
-//  (of which there are numRef).
-//  Returns a vector of minimal RMSD values, one value per particle.
-//  NOTE that this does not guarantee an absolutely minimal RMSD. It doesn't
-//  figure out the optimal permutation of BOTH sets of vectors to minimize the
-//  RMSD. Rather, it just figures out the optimal permutation of the second
-//  set, the vector set used in the argument below.
-//  To fully solve this, we need to use the Hungarian algorithm or some other
-//  way of solving the so-called assignment problem.
 std::vector<float> MatchEnv::minRMSDMotif(const freud::locality::NeighborList* nlist,
                                           const vec3<float>* points, unsigned int Np,
                                           const vec3<float>* refPoints, unsigned int numRef,

--- a/cpp/environment/MatchEnv.cc
+++ b/cpp/environment/MatchEnv.cc
@@ -518,12 +518,10 @@ Environment MatchEnv::buildEnv(const freud::locality::NeighborQuery* nq, const f
     return ei;
 }
 
-void EnvironmentCluster::compute(const freud::locality::NeighborQuery* nq, const freud::locality::NeighborList* env_nlist_arg,
-                       const freud::locality::NeighborList* nlist_arg, locality::QueryArgs qargs,
-                       float threshold, bool registration, bool global)
+void EnvironmentCluster::compute(const freud::locality::NeighborQuery* nq, const freud::locality::NeighborList* nlist_arg, locality::QueryArgs qargs, const freud::locality::NeighborList* env_nlist_arg, locality::QueryArgs env_qargs, float threshold, bool registration, bool global)
 {
     const locality::NeighborList nlist = locality::makeDefaultNlist(nq, nlist_arg, nq->getPoints(), nq->getNPoints(), qargs);
-    const locality::NeighborList env_nlist = locality::makeDefaultNlist(nq, env_nlist_arg, nq->getPoints(), nq->getNPoints(), qargs);
+    const locality::NeighborList env_nlist = locality::makeDefaultNlist(nq, env_nlist_arg, nq->getPoints(), nq->getNPoints(), env_qargs);
 
     unsigned int Np = nq->getNPoints();
     m_env_index.prepare(Np);

--- a/cpp/environment/MatchEnv.cc
+++ b/cpp/environment/MatchEnv.cc
@@ -607,7 +607,7 @@ void MatchEnv::cluster(const freud::locality::NeighborList* env_nlist,
 }
 
 void MatchEnv::matchMotif(const freud::locality::NeighborList* nlist, const vec3<float>* points,
-                          unsigned int Np, const vec3<float>* refPoints, unsigned int numRef, float threshold,
+                          unsigned int Np, const vec3<float>* motif, unsigned int motif_size, float threshold,
                           bool registration)
 {
     // reallocate the m_env_index array for safety
@@ -628,18 +628,18 @@ void MatchEnv::matchMotif(const freud::locality::NeighborList* nlist, const vec3
     // reallocate the m_tot_env array
     m_tot_env.prepare({Np, m_max_num_neighbors});
 
-    // create the environment characterized by refPoints. Index it as 0.
+    // create the environment characterized by motif. Index it as 0.
     // set the IGNORE flag to true, since this is not an environment we have
     // actually encountered in the simulation.
     Environment e0 = Environment(true);
 
-    // loop through all the vectors in refPoints and add them to the environment.
+    // loop through all the vectors in motif and add them to the environment.
     // wrap all the vectors back into the box. I think this is necessary since
     // all the vectors that will be added to actual particle environments will
     // be wrapped into the box as well.
-    for (unsigned int i = 0; i < numRef; i++)
+    for (unsigned int i = 0; i < motif_size; i++)
     {
-        vec3<float> p = m_box.wrap(refPoints[i]);
+        vec3<float> p = m_box.wrap(motif[i]);
         e0.addVec(p);
     }
 
@@ -680,7 +680,7 @@ void MatchEnv::matchMotif(const freud::locality::NeighborList* nlist, const vec3
 
 std::vector<float> MatchEnv::minRMSDMotif(const freud::locality::NeighborList* nlist,
                                           const vec3<float>* points, unsigned int Np,
-                                          const vec3<float>* refPoints, unsigned int numRef,
+                                          const vec3<float>* motif, unsigned int motif_size,
                                           bool registration)
 {
     // reallocate the m_env_index array for safety
@@ -701,18 +701,18 @@ std::vector<float> MatchEnv::minRMSDMotif(const freud::locality::NeighborList* n
     // reallocate the m_tot_env array
     m_tot_env.prepare({Np, m_max_num_neighbors});
 
-    // create the environment characterized by refPoints. Index it as 0.
+    // create the environment characterized by motif. Index it as 0.
     // set the IGNORE flag to true, since this is not an environment we
     // have actually encountered in the simulation.
     Environment e0 = Environment(true);
 
-    // loop through all the vectors in refPoints and add them to the environment.
+    // loop through all the vectors in motif and add them to the environment.
     // wrap all the vectors back into the box. I think this is necessary since
     // all the vectors that will be added to actual particle environments will
     // be wrapped into the box as well.
-    for (unsigned int i = 0; i < numRef; i++)
+    for (unsigned int i = 0; i < motif_size; i++)
     {
-        vec3<float> p = m_box.wrap(refPoints[i]);
+        vec3<float> p = m_box.wrap(motif[i]);
         e0.addVec(p);
     }
 

--- a/cpp/environment/MatchEnv.h
+++ b/cpp/environment/MatchEnv.h
@@ -258,12 +258,23 @@ public:
                  bool registration = false, bool global = false);
 
     //! Determine whether particles match a given input motif.
-    /*!
+    /*! Given a motif composed of vectors that represent the vectors connecting
+     * a point to the neighbors that are part of the motif, matchMotif looks at
+     * every point in points and checks if its neighbors may match this motif.
+     * Any point whose local environment matches the motif is marked as part of
+     * cluster 0 in the clusters array. All others are ignored. The
+     * tot_environments array is updated with the vectors composing the
+     * environment of every particle.
+     *
      * \param nlist A NeighborList instance.
      * \param points The points to test against the motif.
      * \param Np The number of points. 
-     * \param refPoints The points characterizing the motif.
-     * \param numRef The number of reference points. 
+     * \param motif The vectors characterizing the motif. Note that these are
+     *              vectors, so for instance given a square motif composed of
+     *              points at the corners of a square, the motif should not
+     *              include the point (0, 0) because what we are matching is
+     *              the vectors to the neighbors.
+     * \param motif_size The number of vectors characterizing the motif.
      * \param threshold A unitless number that is multiply by m_r_max. This
      *                  quantity is the maximum magnitude of the vector
      *                  difference between two vectors, below which you call
@@ -275,7 +286,7 @@ public:
      *                     minimizes the RMSD between the two sets
      */
     void matchMotif(const freud::locality::NeighborList* nlist, const vec3<float>* points, unsigned int Np,
-                    const vec3<float>* refPoints, unsigned int numRef, float threshold,
+                    const vec3<float>* motif, unsigned int motif_size, float threshold,
                     bool registration = false);
 
     //! Rotate (if registration=True) and permute the environments of all particles to minimize their RMSD wrt a given input motif.
@@ -290,8 +301,12 @@ public:
      * \param nlist A NeighborList instance.
      * \param points The points to test against the motif.
      * \param Np The number of points. 
-     * \param refPoints The points characterizing the motif.
-     * \param numRef The number of reference points. 
+     * \param motif The vectors characterizing the motif. Note that these are
+     *              vectors, so for instance given a square motif composed of
+     *              points at the corners of a square, the motif should not
+     *              include the point (0, 0) because what we are matching is
+     *              the vectors to the neighbors.
+     * \param motif_size The number of vectors characterizing the motif.
      * \param threshold A unitless number that is multiply by m_r_max. This
      *                  quantity is the maximum magnitude of the vector
      *                  difference between two vectors, below which you call
@@ -303,7 +318,7 @@ public:
      *                     minimizes the RMSD between the two sets
      */
     std::vector<float> minRMSDMotif(const freud::locality::NeighborList* nlist, const vec3<float>* points,
-                                    unsigned int Np, const vec3<float>* refPoints, unsigned int numRef,
+                                    unsigned int Np, const vec3<float>* motif, unsigned int motif_size,
                                     bool registration = false);
 
     //! Get a reference to the particles, indexed into clusters according to their matching local environments

--- a/cpp/environment/MatchEnv.h
+++ b/cpp/environment/MatchEnv.h
@@ -103,97 +103,112 @@ std::pair<Environment, Environment> makeEnvironments(const box::Box &box, const 
 
 // Get the somewhat-optimal RMSD between the (PROPERLY REGISTERED) environment e1 and the (PROPERLY REGISTERED) environment e2.
 /*! This function returns an std::pair of the rotation matrix that takes
-	* the vectors of e2 to the vectors of e1 AND the mapping between the
-	* properly indexed vectors of the environments that gives this RMSD.  NOTE
-	* that this does not guarantee an absolutely minimal RMSD. It doesn't
-	* figure out the optimal permutation of BOTH sets of vectors to minimize
-	* the RMSD. Rather, it just figures out the optimal permutation of the
-	* second set, the vector set used in the argument below. To fully solve
-	* this, we need to use the Hungarian algorithm or some other way of
-	* solving the so-called assignment problem.
-	*
-	* \param e1 First environment.
-	* \param e2 First environment.
-	* \param min_rmsd The value of the minimum RMSD (updated by reference).
-	* \param registration Controls whether we first use brute force registration to 
-	*                     orient the second set of vectors such that it
-	*                     minimizes the RMSD between the two sets
-	*/
+ * the vectors of e2 to the vectors of e1 AND the mapping between the
+ * properly indexed vectors of the environments that gives this RMSD.  NOTE
+ * that this does not guarantee an absolutely minimal RMSD. It doesn't
+ * figure out the optimal permutation of BOTH sets of vectors to minimize
+ * the RMSD. Rather, it just figures out the optimal permutation of the
+ * second set, the vector set used in the argument below. To fully solve
+ * this, we need to use the Hungarian algorithm or some other way of
+ * solving the so-called assignment problem.
+ *
+ * \param e1 First environment.
+ * \param e2 First environment.
+ * \param min_rmsd The value of the minimum RMSD (updated by reference).
+ * \param registration Controls whether we first use brute force registration to 
+ *                     orient the second set of vectors such that it
+ *                     minimizes the RMSD between the two sets
+ */
 std::pair<rotmat3<float>, BiMap<unsigned int, unsigned int> >
 minimizeRMSD(Environment& e1, Environment& e2, float& min_rmsd, bool registration);
 
 //! Overload of the above minimizeRMSD function that provides an easier interface to Python.
 /*! Construct the environments accordingly, and utilize minimizeRMSD() as
-	* above. Arguments are pointers to interface directly with python. Return
-	* a std::map (for ease of use) with the mapping between vectors refPoints1
-	* and refPoints2 that gives this RMSD. 
-	*
-	* WARNING: If registration=True, then refPoints2 is CHANGED by this function.
-	*
-	* \param refPoints1 Points composing first environment.
-	* \param refPoints2 Points composing second environment.
-	* \param numRef Number of points.
-	* \param threshold A unitless number that is multiply by m_r_max. This
-	*                  quantity is the maximum magnitude of the vector
-	*                  difference between two vectors, below which you call
-	*                  them matching.  Note that ONLY values of (threshold < 2)
-	*                  make any sense, since 2*r_max is the absolute
-	*                  maximum difference between any two environment vectors. 
-	* \param registration Controls whether we first use brute force registration to 
-	*                     orient the second set of vectors such that it
-	*                     minimizes the RMSD between the two sets
-	*/
+ * above. Arguments are pointers to interface directly with python. Return
+ * a std::map (for ease of use) with the mapping between vectors refPoints1
+ * and refPoints2 that gives this RMSD. 
+ *
+ * WARNING: If registration=True, then refPoints2 is CHANGED by this function.
+ *
+ * \param refPoints1 Points composing first environment.
+ * \param refPoints2 Points composing second environment.
+ * \param numRef Number of points.
+ * \param threshold A unitless number that is multiply by m_r_max. This
+ *                  quantity is the maximum magnitude of the vector
+ *                  difference between two vectors, below which you call
+ *                  them matching.  Note that ONLY values of (threshold < 2)
+ *                  make any sense, since 2*r_max is the absolute
+ *                  maximum difference between any two environment vectors. 
+ * \param registration Controls whether we first use brute force registration to 
+ *                     orient the second set of vectors such that it
+ *                     minimizes the RMSD between the two sets
+ */
 std::map<unsigned int, unsigned int> minimizeRMSD(
     const box::Box &box, const vec3<float>* refPoints1, vec3<float>*
     refPoints2, unsigned int numRef, float& min_rmsd, bool registration);
 
 //! Finds a rotation matrix and the appropriate index correspondence between two environments if it exists.
 /*! If the two environments correspond, returns a std::pair of the rotation matrix that takes the
-    * vectors of e2 to the vectors of e1 AND the mapping between the properly
-    * indexed vectors of the environments that will make them correspond to
-    * each other. If not, return a std::pair of the identity matrix AND an
-    * empty map.
-    *
-    * \param e1 First environment.
-    * \param e2 First environment.
-    * \param threshold A unitless number that is multiply by m_r_max. This
-    *                  quantity is the maximum magnitude of the vector
-    *                  difference between two vectors, below which you call
-    *                  them matching.  Note that ONLY values of (threshold < 2)
-    *                  make any sense, since 2*r_max is the absolute
-    *                  maximum difference between any two environment vectors. 
-    * \param registration Controls whether we first use brute force registration to 
-    *                     orient the second set of vectors such that it
-    *                     minimizes the RMSD between the two sets
-    */
+ * vectors of e2 to the vectors of e1 AND the mapping between the properly
+ * indexed vectors of the environments that will make them correspond to
+ * each other. If not, return a std::pair of the identity matrix AND an
+ * empty map.
+ *
+ * \param e1 First environment.
+ * \param e2 First environment.
+ * \param threshold A unitless number that is multiply by m_r_max. This
+ *                  quantity is the maximum magnitude of the vector
+ *                  difference between two vectors, below which you call
+ *                  them matching.  Note that ONLY values of (threshold < 2)
+ *                  make any sense, since 2*r_max is the absolute
+ *                  maximum difference between any two environment vectors. 
+ * \param registration Controls whether we first use brute force registration to 
+ *                     orient the second set of vectors such that it
+ *                     minimizes the RMSD between the two sets
+ */
 std::pair<rotmat3<float>, BiMap<unsigned int, unsigned int>>
 isSimilar(Environment& e1, Environment& e2, float r_max, float threshold_sq, bool registration);
 
 //! Overload of the above isSimilar function that provides an easier interface to Python.
 /*! If the two environments correspond, returns a std::pair of the rotation matrix that takes the
-    * vectors of e2 to the vectors of e1 AND the mapping between the properly
-    * indexed vectors of the environments that will make them correspond to
-    * each other. If not, return a std::pair of the identity matrix AND an
-    * empty map.
-    *
-    * WARNING: If registration=True, then refPoints2 is CHANGED by this function.
-    *
-    * \param refPoints1 Points composing first environment.
-    * \param refPoints2 Points composing second environment.
-    * \param numRef Number of points.
-    * \param threshold A unitless number that is multiply by m_r_max. This
-    *                  quantity is the maximum magnitude of the vector
-    *                  difference between two vectors, below which you call
-    *                  them matching.  Note that ONLY values of (threshold < 2)
-    *                  make any sense, since 2*r_max is the absolute
-    *                  maximum difference between any two environment vectors. 
-    * \param registration Controls whether we first use brute force registration to 
-    *                     orient the second set of vectors such that it
-    *                     minimizes the RMSD between the two sets
-    */
+ * vectors of e2 to the vectors of e1 AND the mapping between the properly
+ * indexed vectors of the environments that will make them correspond to
+ * each other. If not, return a std::pair of the identity matrix AND an
+ * empty map.
+ *
+ * WARNING: If registration=True, then refPoints2 is CHANGED by this function.
+ *
+ * \param refPoints1 Points composing first environment.
+ * \param refPoints2 Points composing second environment.
+ * \param numRef Number of points.
+ * \param threshold A unitless number that is multiply by m_r_max. This
+ *                  quantity is the maximum magnitude of the vector
+ *                  difference between two vectors, below which you call
+ *                  them matching.  Note that ONLY values of (threshold < 2)
+ *                  make any sense, since 2*r_max is the absolute
+ *                  maximum difference between any two environment vectors. 
+ * \param registration Controls whether we first use brute force registration to 
+ *                     orient the second set of vectors such that it
+ *                     minimizes the RMSD between the two sets
+ */
 std::map<unsigned int, unsigned int> isSimilar(const box::Box &box, const vec3<float>* refPoints1, vec3<float>* refPoints2,
                                                 unsigned int numRef, float r_max, float threshold_sq,
                                                 bool registration);
+
+//! Populate the env_index, env and tot_env arrays (updated by reference) based on the contents of an EnvDisjointSet.
+/*! T
+ * \param dj The object encoding the set of clusters found.
+ * \param env_index An array indexed by point id indicating the cluster id for each point.
+ * \param env A mapping from cluster id to a list of vectors composing that cluster's environment.
+ * \param tot_env An array indexed by point id indicating the environment of each point.
+ * \param reLabel If true, the cluster ids are relabeled to ensur contiguous
+ *                ordering from 0 to the number of clusters. Otherwise, the
+ *                cluster ids will match the point id of the first point found
+ *                with that environment (which defines the cluster).
+ * \return The number of clusters found.
+*/
+unsigned int populateEnv(EnvDisjointSet dj, util::ManagedArray<unsigned int> &env_index, std::map<unsigned int, std::vector<vec3<float> > > &env, util::ManagedArray<vec3<float> > &tot_env, bool reLabel);
+
 
 //! Cluster particles with similar environments.
 /*! The environment matching method is defined according to the paper "Identity
@@ -360,11 +375,6 @@ public:
     }
 
 private:
-
-    //! Populate the m_env_index, m_env and m_tot_env arrays.
-    /*! Renumber the clusters in the disjoint set dj from zero to num_clusters-1.
-     */
-    void populateEnv(EnvDisjointSet dj, util::ManagedArray<unsigned int> &env_index, std::map<unsigned int, std::vector<vec3<float> > > &env, util::ManagedArray<vec3<float> > &tot_env, bool reLabel);
 
     box::Box m_box; //!< Simulation box
     float m_r_max; //!< Square of the maximum cutoff radius at which to determine local environment

--- a/cpp/environment/MatchEnv.h
+++ b/cpp/environment/MatchEnv.h
@@ -364,7 +364,7 @@ private:
     //! Populate the m_env_index, m_env and m_tot_env arrays.
     /*! Renumber the clusters in the disjoint set dj from zero to num_clusters-1.
      */
-    void populateEnv(EnvDisjointSet dj, bool reLabel = true);
+    void populateEnv(EnvDisjointSet dj, util::ManagedArray<unsigned int> &env_index, std::map<unsigned int, std::vector<vec3<float> > > &env, util::ManagedArray<vec3<float> > &tot_env, bool reLabel);
 
     box::Box m_box; //!< Simulation box
     float m_r_max; //!< Square of the maximum cutoff radius at which to determine local environment
@@ -377,8 +377,8 @@ private:
     unsigned int m_num_clusters; //!< Last number of local environments computed
 
     util::ManagedArray<unsigned int> m_env_index; //!< Cluster index determined for each particle
-    std::map<unsigned int, std::vector<vec3<float>>> m_env; //!< Dictionary of (cluster id, vectors) pairs
-    util::ManagedArray<vec3<float>>
+    std::map<unsigned int, std::vector<vec3<float> > > m_env; //!< Dictionary of (cluster id, vectors) pairs
+    util::ManagedArray<vec3<float> >
         m_tot_env; //!< m_NP by m_max_num_neighbors by 3 matrix of all environments for all particles
 };
 

--- a/cpp/environment/MatchEnv.h
+++ b/cpp/environment/MatchEnv.h
@@ -51,19 +51,38 @@ struct Environment
 //! General disjoint set class, taken mostly from Cluster.h
 struct EnvDisjointSet
 {
-    //! Constructor
+    //! Constructor (taken partially from Cluster.cc).
     EnvDisjointSet(unsigned int Np);
     //! Merge two sets
+    /*! Merge the two sets that elements a and b belong to. Taken partially
+     * from Cluster.cc. The vec_map must be a bimap of PROPERLY ORDERED vector
+     * indices where those of set a are on the left and those of set b are on
+     * the right. The rotation must take the set of PROPERLY ROTATED vectors b
+     * and rotate them to match the set of PROPERLY ROTATED vectors a
+     */
     void merge(const unsigned int a, const unsigned int b, BiMap<unsigned int, unsigned int> vec_map,
                rotmat3<float> rotation);
-    //! Find the set with a given element
+
+    //! Find the set with a given element (taken mostly from Cluster.cc).
     unsigned int find(const unsigned int c);
+
     //! Return ALL nodes in the tree that correspond to the head index m
+    /*! Return ALL nodes in the tree that correspond to the head index m.
+     * Values returned: the actual locations of the nodes in s. (i.e. if i is
+     * returned, the node is accessed by s[i]). If environment m doesn't exist
+     * as a HEAD in the set, throw an error.
+     */
     std::vector<unsigned int> findSet(const unsigned int m);
-    //! Get the vectors corresponding to environment head index m. Vectors are averaged over all members of
-    //! the environment cluster.
+
+    //! Get the vectors corresponding to environment head index m.
+    /*! Vectors are averaged over all members of the environment cluster. Get
+     * the vectors corresponding to environment head index m. Vectors are
+     * averaged over all members of the environment cluster. If environment m
+     * doesn't exist as a HEAD in the set, throw an error.
+     */
     std::vector<vec3<float> > getAvgEnv(const unsigned int m);
-    //! Get the vectors corresponding to index m in the dj set
+
+    //! Get the vectors corresponding to index m in the dj set (throw an error if it doesn't exist).
     std::vector<vec3<float>> getIndividualEnv(const unsigned int m);
 
     std::vector<Environment> s;     //!< The disjoint set data
@@ -71,6 +90,16 @@ struct EnvDisjointSet
     unsigned int m_max_num_neigh;   //!< The maximum number of neighbors in any environment in the set
 };
 
+//! Cluster particles with similar environments.
+/*! The environment matching method is defined according to the paper "Identity
+ * crisis in alchemical space drives the entropic colloidal glass transition"
+ * by Erin G. Teich (http://dx.doi.org/10.1038/s41467-018-07977-2). The core of
+ * the method is a brute force point set registration of the bonds betweena
+ * point and its nearest neighbors with the corresponding bonds of another
+ * point. By performing this sort of registration between various pairs of
+ * points, we identify regions where neighboring points share similar local
+ * environments.
+ */
 class MatchEnv
 {
 public:
@@ -100,6 +129,7 @@ public:
      * environments, unless global is set true. Otherwise, it performs a
      * pairwise comparison of all particle environments to perform the match.
      * WARNING: A global search can be extremely slow.
+     * This is taken from Cluster.cc and SolLiq.cc and LocalQlNear.cc
      *
      * \param env_nlist The NeighborList used to build the environment of every particle.
      * \param nlist The NeighborList used to determine the neighbors against which 

--- a/cpp/environment/MatchEnv.h
+++ b/cpp/environment/MatchEnv.h
@@ -265,7 +265,7 @@ public:
      *               simulation. If global is false, only compare the
      *               environments of neighboring particles.
      */
-    void compute(const freud::locality::NeighborQuery* nq, const freud::locality::NeighborList* env_nlist_arg, const freud::locality::NeighborList* nlist_arg, locality::QueryArgs qargs, float threshold,
+    void compute(const freud::locality::NeighborQuery* nq, const freud::locality::NeighborList* nlist_arg, locality::QueryArgs qargs, const freud::locality::NeighborList* env_nlist_arg, locality::QueryArgs env_qargs, float threshold,
                  bool registration = false, bool global = false);
 
     //! Get a reference to the particles, indexed into clusters according to their matching local environments

--- a/cpp/environment/MatchEnv.h
+++ b/cpp/environment/MatchEnv.h
@@ -265,7 +265,7 @@ public:
      *               simulation. If global is false, only compare the
      *               environments of neighboring particles.
      */
-    void compute(const freud::locality::NeighborQuery* nq, const freud::locality::NeighborList* env_nlist, const freud::locality::NeighborList* nlist, float threshold,
+    void compute(const freud::locality::NeighborQuery* nq, const freud::locality::NeighborList* env_nlist_arg, const freud::locality::NeighborList* nlist_arg, locality::QueryArgs qargs, float threshold,
                  bool registration = false, bool global = false);
 
     //! Get a reference to the particles, indexed into clusters according to their matching local environments
@@ -356,7 +356,7 @@ public:
      *                     orient the second set of vectors such that it
      *                     minimizes the RMSD between the two sets
      */
-    void compute(const freud::locality::NeighborQuery* nq, const freud::locality::NeighborList* nlist,
+    void compute(const freud::locality::NeighborQuery* nq, const freud::locality::NeighborList* nlist_arg, locality::QueryArgs qargs,
                     const vec3<float>* motif, unsigned int motif_size, float threshold,
                     bool registration = false);
 
@@ -416,7 +416,7 @@ public:
      *                     orient the second set of vectors such that it
      *                     minimizes the RMSD between the two sets
      */
-    void compute(const freud::locality::NeighborQuery* nq, const freud::locality::NeighborList* nlist, const vec3<float>* motif, unsigned int motif_size,
+    void compute(const freud::locality::NeighborQuery* nq, const freud::locality::NeighborList* nlist_arg, locality::QueryArgs qargs, const vec3<float>* motif, unsigned int motif_size,
                                     bool registration = false);
 
     //! Return the array indicating whether or not a successful mapping was found between each particle and the provided motif.

--- a/cpp/environment/MatchEnv.h
+++ b/cpp/environment/MatchEnv.h
@@ -293,23 +293,16 @@ public:
                  const vec3<float>* points, unsigned int Np, float threshold,
                  bool registration = false, bool global = false);
 
-    //! Returns the set of vectors defining the environment indexed by i (indices culled from m_env_index)
-    /*! The environments are averaged over all particles that are deemed to
-     * share the same environment. This invariant can always be checked by
-     * comparing the average of environments in m_particle_environments sharing some cluster
-     * index to the output of getEnvironment(i).
-     */
-    std::vector<vec3<float>> getEnvironment(unsigned int i)
-    {
-        std::map<unsigned int, std::vector<vec3<float>>>::iterator it = m_cluster_env.find(i);
-        std::vector<vec3<float>> vecs = it->second;
-        return vecs;
-    }
-
     //! Get a reference to the particles, indexed into clusters according to their matching local environments
     const util::ManagedArray<unsigned int> &getClusters()
     {
         return m_env_index;
+    }
+
+    //! Get a reference to the particles, indexed into clusters according to their matching local environments
+    std::vector<std::vector<vec3<float> > > getClusterEnvironments()
+    {
+        return m_cluster_environments;
     }
 
     unsigned int getNumClusters()
@@ -337,8 +330,8 @@ private:
     unsigned int populateEnv(EnvDisjointSet dj);
 
     unsigned int m_num_clusters; //!< Last number of local environments computed
-    std::map<unsigned int, std::vector<vec3<float> > > m_cluster_env; //!< Dictionary of (cluster id, vectors) pairs
     util::ManagedArray<unsigned int> m_env_index; //!< Cluster index determined for each particle
+    std::vector<std::vector<vec3<float> > > m_cluster_environments; //!< Dictionary of (cluster id, vectors) pairs
 };
 
 //! Match local point environments to a specific motif.
@@ -397,7 +390,6 @@ public:
 
 private:
     util::ManagedArray<bool> m_matches; //!< Boolean array indicating whether or not a particle's environment matches the motif.
-    std::vector<std::vector<vec3<float> > > m_cluster_env; //!< Dictionary of (cluster id, vectors) pairs
 };
 
 
@@ -457,7 +449,6 @@ public:
 
 private:
     util::ManagedArray<float> m_rmsds; //!< Boolean array indicating whether or not a particle's environment matches the motif.
-    std::vector<std::vector<vec3<float> > > m_cluster_env; //!< Dictionary of (cluster id, vectors) pairs
 };
 
 }; }; // end namespace freud::environment

--- a/cpp/environment/MatchEnv.h
+++ b/cpp/environment/MatchEnv.h
@@ -197,22 +197,13 @@ std::map<unsigned int, unsigned int> isSimilar(const box::Box &box, const vec3<f
 class MatchEnv
 {
 public:
-    MatchEnv(unsigned int num_neighbors);
+    MatchEnv();
 
     ~MatchEnv();
 
     //! Construct and return a local environment surrounding the particle indexed by i. Set the environment index to env_ind.
     Environment buildEnv(const box::Box &box, const freud::locality::NeighborList* nlist, size_t num_bonds, size_t& bond,
                          const vec3<float>* points, unsigned int i, unsigned int env_ind);
-
-    unsigned int getNumNeighbors()
-    {
-        return m_num_neighbors;
-    }
-    unsigned int getMaxNumNeighbors()
-    {
-        return m_max_num_neighbors;
-    }
 
     //! Returns the entire Np by m_num_neighbors by 3 matrix of all environments for all particles
     const util::ManagedArray<vec3<float>> &getParticleEnvironments()
@@ -221,12 +212,6 @@ public:
     }
 
 protected:
-    unsigned int m_num_neighbors;      //!< Default number of nearest neighbors used to determine which environments are compared
-               //!< during local environment clustering.
-    unsigned int m_max_num_neighbors; //!< Maximum number of neighbors in any particle's local environment. If
-                         //!< hard_r=false, m_max_num_neighbors = m_num_neighbors. In the cluster method it is also possible to provide
-                         //!< two separate neighborlists, one for environments and one for clustering.
-
     util::ManagedArray<vec3<float> >
         m_particle_environments; //!< m_NP by m_max_num_neighbors by 3 matrix of all environments for all particles
 };
@@ -250,7 +235,7 @@ public:
      * \param box The system box.
      * \param num_neighbors Number of nearest neighbors taken to define the local environment of any given particle.
      */
-    EnvironmentCluster(unsigned int num_neighbors);
+    EnvironmentCluster() : MatchEnv() {}
 
     //! Destructor
     ~EnvironmentCluster();
@@ -342,7 +327,7 @@ public:
      * \param box The system box.
      * \param num_neighbors Number of nearest neighbors taken to define the local environment of any given particle.
      */
-    EnvironmentMotifMatch(unsigned int num_neighbors) : MatchEnv(num_neighbors) {}
+    EnvironmentMotifMatch() : MatchEnv() {}
 
     //! Determine whether particles match a given input motif.
     /*! Given a motif composed of vectors that represent the vectors connecting
@@ -402,7 +387,7 @@ public:
     /*!
      * \param num_neighbors Number of nearest neighbors taken to define the local environment of any given particle.
      */
-    EnvironmentRMSDMinimizer(unsigned int num_neighbors) : MatchEnv(num_neighbors) {}
+    EnvironmentRMSDMinimizer() : MatchEnv() {}
 
     //! Rotate (if registration=True) and permute the environments of all particles to minimize their RMSD wrt a given input motif.
     /*! Returns a vector of minimal RMSD values, one value per particle. NOTE

--- a/cpp/environment/MatchEnv.h
+++ b/cpp/environment/MatchEnv.h
@@ -203,12 +203,12 @@ std::map<unsigned int, unsigned int> isSimilar(const box::Box &box, const vec3<f
 class MatchEnv
 {
 public:
-    MatchEnv(const box::Box& box, float r_max, unsigned int num_neighbors);
+    MatchEnv(float r_max, unsigned int num_neighbors);
 
     ~MatchEnv();
 
     //! Construct and return a local environment surrounding the particle indexed by i. Set the environment index to env_ind.
-    Environment buildEnv(const freud::locality::NeighborList* nlist, size_t num_bonds, size_t& bond,
+    Environment buildEnv(const box::Box &box, const freud::locality::NeighborList* nlist, size_t num_bonds, size_t& bond,
                          const vec3<float>* points, unsigned int i, unsigned int env_ind);
 
     unsigned int getNumNeighbors()
@@ -227,7 +227,6 @@ public:
     }
 
 protected:
-    box::Box m_box; //!< Simulation box
     float m_r_max; //!< Square of the maximum cutoff radius at which to determine local environment
     unsigned int m_num_neighbors;      //!< Default number of nearest neighbors used to determine which environments are compared
                //!< during local environment clustering.
@@ -259,7 +258,7 @@ public:
      * \param r_max Cutoff radius for cell list and clustering algorithm. Values near first minimum of the rdf are recommended.  
      * \param num_neighbors Number of nearest neighbors taken to define the local environment of any given particle.
      */
-    EnvironmentCluster(const box::Box& box, float r_max, unsigned int num_neighbors);
+    EnvironmentCluster(float r_max, unsigned int num_neighbors);
 
     //! Destructor
     ~EnvironmentCluster();
@@ -289,7 +288,7 @@ public:
      *               simulation. If global is false, only compare the
      *               environments of neighboring particles.
      */
-    void compute(const freud::locality::NeighborList* env_nlist, const freud::locality::NeighborList* nlist,
+    void compute(const box::Box& box, const freud::locality::NeighborList* env_nlist, const freud::locality::NeighborList* nlist,
                  const vec3<float>* points, unsigned int Np, float threshold,
                  bool registration = false, bool global = false);
 
@@ -353,7 +352,7 @@ public:
      * \param r_max Cutoff radius for cell list and clustering algorithm. Values near first minimum of the rdf are recommended.  
      * \param num_neighbors Number of nearest neighbors taken to define the local environment of any given particle.
      */
-    EnvironmentMotifMatch(const box::Box& box, float r_max, unsigned int num_neighbors) : MatchEnv(box, r_max, num_neighbors) {}
+    EnvironmentMotifMatch(float r_max, unsigned int num_neighbors) : MatchEnv(r_max, num_neighbors) {}
 
     //! Determine whether particles match a given input motif.
     /*! Given a motif composed of vectors that represent the vectors connecting
@@ -383,7 +382,7 @@ public:
      *                     orient the second set of vectors such that it
      *                     minimizes the RMSD between the two sets
      */
-    void compute(const freud::locality::NeighborList* nlist, const vec3<float>* points, unsigned int Np,
+    void compute(const box::Box& box, const freud::locality::NeighborList* nlist, const vec3<float>* points, unsigned int Np,
                     const vec3<float>* motif, unsigned int motif_size, float threshold,
                     bool registration = false);
 
@@ -416,7 +415,7 @@ public:
      * \param r_max Cutoff radius for cell list and clustering algorithm. Values near first minimum of the rdf are recommended.  
      * \param num_neighbors Number of nearest neighbors taken to define the local environment of any given particle.
      */
-    EnvironmentRMSDMinimizer(const box::Box& box, float r_max, unsigned int num_neighbors) : MatchEnv(box, r_max, num_neighbors) {}
+    EnvironmentRMSDMinimizer(float r_max, unsigned int num_neighbors) : MatchEnv(r_max, num_neighbors) {}
 
     //! Rotate (if registration=True) and permute the environments of all particles to minimize their RMSD wrt a given input motif.
     /*! Returns a vector of minimal RMSD values, one value per particle. NOTE
@@ -446,7 +445,7 @@ public:
      *                     orient the second set of vectors such that it
      *                     minimizes the RMSD between the two sets
      */
-    void compute(const freud::locality::NeighborList* nlist, const vec3<float>* points,
+    void compute(const box::Box& box, const freud::locality::NeighborList* nlist, const vec3<float>* points,
                                     unsigned int Np, const vec3<float>* motif, unsigned int motif_size,
                                     bool registration = false);
 

--- a/cpp/environment/MatchEnv.h
+++ b/cpp/environment/MatchEnv.h
@@ -337,7 +337,12 @@ private:
 //! Match local point environments to a specific motif.
 /*! The environment matching method is defined according to the paper "Identity
  * crisis in alchemical space drives the entropic colloidal glass transition"
- * by Erin G. Teich (http://dx.doi.org/10.1038/s41467-018-07977-2). This class is primarily provided as a companion to EnvironmentCluster that can be used to more closely analyze specific motifs. Rather than clustering all points in a system based on their local environments, this class provides more a more fine-grained computation to analyze which points match a specified motif.
+ * by Erin G. Teich (http://dx.doi.org/10.1038/s41467-018-07977-2). This class
+ * is primarily provided as a companion to EnvironmentCluster that can be used
+ * to more closely analyze specific motifs. Rather than clustering all points
+ * in a system based on their local environments, this class provides more a
+ * more fine-grained computation to analyze which points match a specified
+ * motif.
  */
 class EnvironmentMotifMatch : public MatchEnv
 {
@@ -396,7 +401,11 @@ private:
 //! Compute RMSDs of the local particle environments.
 /*! The environment matching method is defined according to the paper "Identity
  * crisis in alchemical space drives the entropic colloidal glass transition"
- * by Erin G. Teich (http://dx.doi.org/10.1038/s41467-018-07977-2). This class is primarily provided as a companion to EnvironmentCluster that can be used to more closely analyze specific motifs. Rather than clustering all points in a system based on their local environments, this class provides more a more fine-grained computation to analyze which points match a specified motif.
+ * by Erin G. Teich (http://dx.doi.org/10.1038/s41467-018-07977-2). Similar to
+ * EnvironmentMotifMatch, this class is primarily provided as a companion to
+ * EnvironmentCluster that can be used to more closely analyze specific motifs.
+ * The purpose of this class is to find the optimal transformation that maps a
+ * set of points onto a specified motif.
  */
 class EnvironmentRMSDMinimizer : public MatchEnv
 {
@@ -448,7 +457,7 @@ public:
     }
 
 private:
-    util::ManagedArray<float> m_rmsds; //!< Boolean array indicating whether or not a particle's environment matches the motif.
+    util::ManagedArray<float> m_rmsds;  //!< Boolean array indicating whether or not a particle's environment matches the motif.
 };
 
 }; }; // end namespace freud::environment

--- a/cpp/environment/MatchEnv.h
+++ b/cpp/environment/MatchEnv.h
@@ -10,6 +10,7 @@
 #include "BiMap.h"
 #include "Box.h"
 #include "ManagedArray.h"
+#include "NeighborQuery.h"
 #include "NeighborList.h"
 #include "VectorMath.h"
 #include "brute_force.h"
@@ -202,8 +203,8 @@ public:
     ~MatchEnv();
 
     //! Construct and return a local environment surrounding the particle indexed by i. Set the environment index to env_ind.
-    Environment buildEnv(const box::Box &box, const freud::locality::NeighborList* nlist, size_t num_bonds, size_t& bond,
-                         const vec3<float>* points, unsigned int i, unsigned int env_ind);
+    Environment buildEnv(const freud::locality::NeighborQuery* nq, const freud::locality::NeighborList* nlist, size_t num_bonds, size_t& bond,
+                         unsigned int i, unsigned int env_ind);
 
     //! Returns the entire Np by m_num_neighbors by 3 matrix of all environments for all particles
     const util::ManagedArray<vec3<float>> &getParticleEnvironments()
@@ -264,8 +265,7 @@ public:
      *               simulation. If global is false, only compare the
      *               environments of neighboring particles.
      */
-    void compute(const box::Box& box, const freud::locality::NeighborList* env_nlist, const freud::locality::NeighborList* nlist,
-                 const vec3<float>* points, unsigned int Np, float threshold,
+    void compute(const freud::locality::NeighborQuery* nq, const freud::locality::NeighborList* env_nlist, const freud::locality::NeighborList* nlist, float threshold,
                  bool registration = false, bool global = false);
 
     //! Get a reference to the particles, indexed into clusters according to their matching local environments
@@ -356,7 +356,7 @@ public:
      *                     orient the second set of vectors such that it
      *                     minimizes the RMSD between the two sets
      */
-    void compute(const box::Box& box, const freud::locality::NeighborList* nlist, const vec3<float>* points, unsigned int Np,
+    void compute(const freud::locality::NeighborQuery* nq, const freud::locality::NeighborList* nlist,
                     const vec3<float>* motif, unsigned int motif_size, float threshold,
                     bool registration = false);
 
@@ -416,8 +416,7 @@ public:
      *                     orient the second set of vectors such that it
      *                     minimizes the RMSD between the two sets
      */
-    void compute(const box::Box& box, const freud::locality::NeighborList* nlist, const vec3<float>* points,
-                                    unsigned int Np, const vec3<float>* motif, unsigned int motif_size,
+    void compute(const freud::locality::NeighborQuery* nq, const freud::locality::NeighborList* nlist, const vec3<float>* motif, unsigned int motif_size,
                                     bool registration = false);
 
     //! Return the array indicating whether or not a successful mapping was found between each particle and the provided motif.

--- a/cpp/environment/MatchEnv.h
+++ b/cpp/environment/MatchEnv.h
@@ -207,14 +207,14 @@ public:
                          unsigned int i, unsigned int env_ind);
 
     //! Returns the entire Np by m_num_neighbors by 3 matrix of all environments for all particles
-    const util::ManagedArray<vec3<float>> &getParticleEnvironments()
+    const util::ManagedArray<vec3<float>> &getPointEnvironments()
     {
-        return m_particle_environments;
+        return m_point_environments;
     }
 
 protected:
     util::ManagedArray<vec3<float> >
-        m_particle_environments; //!< m_NP by m_max_num_neighbors by 3 matrix of all environments for all particles
+        m_point_environments; //!< m_NP by m_max_num_neighbors by 3 matrix of all environments for all particles
 };
 
 

--- a/cpp/locality/LinkCell.cc
+++ b/cpp/locality/LinkCell.cc
@@ -213,9 +213,23 @@ LinkCell::LinkCell()
     : NeighborQuery(), m_n_points(0), m_cell_width(0), m_celldim(0, 0, 0)
 {}
 
-LinkCell::LinkCell(const box::Box& box, float cell_width, const vec3<float>* points, unsigned int n_points)
+LinkCell::LinkCell(const box::Box& box, const vec3<float>* points, unsigned int n_points, float cell_width)
     : NeighborQuery(box, points, n_points), m_n_points(0), m_cell_width(cell_width), m_celldim(0, 0, 0)
 {
+    // If no cell width is provided, we calculate the system density and
+    // estimate the number of cells that would lead to 10 particles per cell.
+    // Want n_points/num_cells = 10
+    if (cell_width == 0)
+    {
+        // This number is arbitrary because there is no way to determine an
+        // appropriate cell density for an arbitrary triclinic box.
+        const unsigned int num_particle_per_cell = 10;
+        vec3<float> L = box.getNearestPlaneDistance();
+        unsigned int desired_num_cells = std::max(n_points/num_particle_per_cell,
+                                                  static_cast<unsigned int>(1));
+        m_cell_width = std::cbrtf(float(L.x*L.y*L.z)/desired_num_cells);
+    }
+
     m_celldim = computeDimensions(box, m_cell_width);
 
     // Check if box is too small!

--- a/cpp/locality/LinkCell.cc
+++ b/cpp/locality/LinkCell.cc
@@ -224,10 +224,9 @@ LinkCell::LinkCell(const box::Box& box, const vec3<float>* points, unsigned int 
         // This number is arbitrary because there is no way to determine an
         // appropriate cell density for an arbitrary triclinic box.
         const unsigned int num_particle_per_cell = 10;
-        vec3<float> L = box.getNearestPlaneDistance();
         unsigned int desired_num_cells = std::max(n_points/num_particle_per_cell,
                                                   static_cast<unsigned int>(1));
-        m_cell_width = std::cbrtf(float(L.x*L.y*L.z)/desired_num_cells);
+        m_cell_width = std::cbrtf(box.getVolume()/desired_num_cells);
     }
 
     m_celldim = computeDimensions(box, m_cell_width);

--- a/cpp/locality/LinkCell.h
+++ b/cpp/locality/LinkCell.h
@@ -184,7 +184,7 @@ public:
     //! Null Constructor
     LinkCell();
 
-    //! New constructor
+    //! Constructor
     LinkCell(const box::Box& box, const vec3<float>* points, unsigned int n_points, float cell_width=0);
 
     //! Compute LinkCell dimensions

--- a/cpp/locality/LinkCell.h
+++ b/cpp/locality/LinkCell.h
@@ -184,11 +184,8 @@ public:
     //! Null Constructor
     LinkCell();
 
-    //! Old constructor
-    LinkCell(const box::Box& box, float cell_width);
-
     //! New constructor
-    LinkCell(const box::Box& box, float cell_width, const vec3<float>* points, unsigned int n_points);
+    LinkCell(const box::Box& box, const vec3<float>* points, unsigned int n_points, float cell_width=0);
 
     //! Compute LinkCell dimensions
     const vec3<unsigned int> computeDimensions(const box::Box& box, float cell_width) const;

--- a/cpp/locality/NeighborQuery.h
+++ b/cpp/locality/NeighborQuery.h
@@ -109,7 +109,7 @@ public:
      *  \param n_query_points The number of query points.
      *  \param qargs The query arguments that should be used to find neighbors.
      */
-    std::shared_ptr<NeighborQueryIterator> query(const vec3<float>* query_points, unsigned int n_query_points,
+    virtual std::shared_ptr<NeighborQueryIterator> query(const vec3<float>* query_points, unsigned int n_query_points,
                                                                  QueryArgs query_args) const
     {
         this->validateQueryArgs(query_args);

--- a/cpp/locality/RawPoints.h
+++ b/cpp/locality/RawPoints.h
@@ -61,7 +61,7 @@ public:
     {
         if (!aq)
         {
-            throw std::runtime_error("The underlying AAABBQuery object has not yet been initialized. This likely developer failure.");
+            throw std::runtime_error("The underlying AABBQuery object has not yet been initialized. This likely developer failure.");
         }
 
         return aq->querySingle(query_point, query_point_idx, qargs);

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -322,6 +322,7 @@ nitpick_ignore = [("py:obj", "numpy.dtype"),
 napoleon_use_ivar = True
 
 
+# Don't document properties (we document them as class attributes).
 def autodoc_skip_member(app, what, name, obj, skip, options):
     return skip or isinstance(obj, property)
 

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -304,6 +304,10 @@ intersphinx_mapping = {'python': ('https://docs.python.org/3', None),
 
 autodoc_mock_import = ["numpy"]
 
+autodoc_default_options = {
+    'inherited-members': True
+}
+
 nitpick_ignore = [("py:obj", "numpy.dtype"),
                   ("py:class", "numpy.ndarray"),
                   ("py:class", "numpy.uint32"),
@@ -316,3 +320,11 @@ nitpick_ignore = [("py:obj", "numpy.dtype"),
 
 # Make class attributes show on single line
 napoleon_use_ivar = True
+
+
+def autodoc_skip_member(app, what, name, obj, skip, options):
+    return skip or isinstance(obj, property)
+
+
+def setup(app):
+    app.connect('autodoc-skip-member', autodoc_skip_member)

--- a/doc/source/credits.rst
+++ b/doc/source/credits.rst
@@ -90,6 +90,7 @@ Vyas Ramasubramani - **Lead developer**
 * Standardized vector directionality in computes.
 * Enabled usage of quaternions in place of angles for orientations in 2D PMFT calculations.
 * Wrote new freud 2.0 compute APIs based on neighbor\_query objects and neighbors as either dictionaries or NeighborLists.
+* Rewrote MatchEnv code to fit freud 2.0 API, splitting it into 3 separate calculations and rewriting internals using NeighborQuery objects.
 
 Bradley Dice - **Lead developer**
 

--- a/doc/source/environment.rst
+++ b/doc/source/environment.rst
@@ -11,7 +11,8 @@ Environment Module
 
     freud.environment.BondOrder
     freud.environment.LocalDescriptors
-    freud.environment.MatchEnv
+    freud.environment.EnvironmentCluster
+    freud.environment.EnvironmentMotifMatch
     freud.environment.AngularSeparationGlobal
     freud.environment.AngularSeparationNeighbor
     freud.environment.LocalBondProjection

--- a/freud/_environment.pxd
+++ b/freud/_environment.pxd
@@ -71,14 +71,18 @@ cdef extern from "MatchEnv.h" namespace "freud::environment":
 
     cdef cppclass MatchEnv:
         MatchEnv(const freud._box.Box &, float, unsigned int) except +
-        void setBox(const freud._box.Box)
-        void cluster(const freud._locality.NeighborList*,
-                     const freud._locality.NeighborList*,
-                     const vec3[float]*,
-                     unsigned int,
-                     float,
-                     bool,
-                     bool) except +
+        const freud.util.ManagedArray[unsigned int] &getClusters()
+        vector[vec3[float]] getEnvironment(unsigned int)
+        const freud.util.ManagedArray[vec3[float]] &getTotEnvironment()
+        unsigned int getNP()
+        unsigned int getNumClusters()
+        unsigned int getNumNeighbors()
+        unsigned int getMaxNumNeighbors()
+
+    cdef cppclass EnvironmentMotifMatch(MatchEnv):
+        EnvironmentMotifMatch(const freud._box.Box &,
+                              float,
+                              unsigned int) except +
         void matchMotif(const freud._locality.NeighborList*,
                         const vec3[float]*,
                         unsigned int,
@@ -93,13 +97,18 @@ cdef extern from "MatchEnv.h" namespace "freud::environment":
             const vec3[float]*,
             unsigned int,
             bool) except +
-        const freud.util.ManagedArray[unsigned int] &getClusters()
-        vector[vec3[float]] getEnvironment(unsigned int)
-        const freud.util.ManagedArray[vec3[float]] &getTotEnvironment()
-        unsigned int getNP()
-        unsigned int getNumClusters()
-        unsigned int getNumNeighbors()
-        unsigned int getMaxNumNeighbors()
+
+    cdef cppclass EnvironmentCluster(MatchEnv):
+        EnvironmentCluster(const freud._box.Box &,
+                           float,
+                           unsigned int) except +
+        void cluster(const freud._locality.NeighborList*,
+                     const freud._locality.NeighborList*,
+                     const vec3[float]*,
+                     unsigned int,
+                     float,
+                     bool,
+                     bool) except +
 
 cdef extern from "AngularSeparation.h" namespace "freud::environment":
     cdef cppclass AngularSeparationGlobal:

--- a/freud/_environment.pxd
+++ b/freud/_environment.pxd
@@ -74,47 +74,35 @@ cdef extern from "MatchEnv.h" namespace "freud::environment":
 
     cdef cppclass EnvironmentMotifMatch(MatchEnv):
         EnvironmentMotifMatch() except +
-        void compute(const freud._box.Box &,
+        void compute(const freud._locality.NeighborQuery*,
                      const freud._locality.NeighborList*,
-                     const vec3[float]*,
-                     unsigned int,
                      const vec3[float]*,
                      unsigned int,
                      float,
                      bool) except +
         const freud.util.ManagedArray[bool] &getMatches()
-        unsigned int getNumNeighbors()
-        unsigned int getMaxNumNeighbors()
 
     cdef cppclass EnvironmentRMSDMinimizer(MatchEnv):
         EnvironmentRMSDMinimizer() except +
         void compute(
-            const freud._box.Box &,
+            const freud._locality.NeighborQuery*,
             const freud._locality.NeighborList*,
-            const vec3[float]*,
-            unsigned int,
             const vec3[float]*,
             unsigned int,
             bool) except +
         const freud.util.ManagedArray[float] &getRMSDs()
-        unsigned int getNumNeighbors()
-        unsigned int getMaxNumNeighbors()
 
     cdef cppclass EnvironmentCluster(MatchEnv):
         EnvironmentCluster() except +
-        void compute(const freud._box.Box &,
+        void compute(const freud._locality.NeighborQuery*,
                      const freud._locality.NeighborList*,
                      const freud._locality.NeighborList*,
-                     const vec3[float]*,
-                     unsigned int,
                      float,
                      bool,
                      bool) except +
         unsigned int getNumClusters()
         const freud.util.ManagedArray[unsigned int] &getClusters()
         vector[vector[vec3[float]]] &getClusterEnvironments()
-        unsigned int getNumNeighbors()
-        unsigned int getMaxNumNeighbors()
 
 cdef extern from "AngularSeparation.h" namespace "freud::environment":
     cdef cppclass AngularSeparationGlobal:

--- a/freud/_environment.pxd
+++ b/freud/_environment.pxd
@@ -112,9 +112,9 @@ cdef extern from "MatchEnv.h" namespace "freud::environment":
                      float,
                      bool,
                      bool) except +
-        vector[vec3[float]] getEnvironment(unsigned int)
         unsigned int getNumClusters()
         const freud.util.ManagedArray[unsigned int] &getClusters()
+        vector[vector[vec3[float]]] &getClusterEnvironments()
 
 cdef extern from "AngularSeparation.h" namespace "freud::environment":
     cdef cppclass AngularSeparationGlobal:

--- a/freud/_environment.pxd
+++ b/freud/_environment.pxd
@@ -76,10 +76,10 @@ cdef extern from "MatchEnv.h" namespace "freud::environment":
         const freud.util.ManagedArray[vec3[float]] &getParticleEnvironments()
 
     cdef cppclass EnvironmentMotifMatch(MatchEnv):
-        EnvironmentMotifMatch(const freud._box.Box &,
-                              float,
+        EnvironmentMotifMatch(float,
                               unsigned int) except +
-        void compute(const freud._locality.NeighborList*,
+        void compute(const freud._box.Box &,
+                     const freud._locality.NeighborList*,
                      const vec3[float]*,
                      unsigned int,
                      const vec3[float]*,
@@ -89,10 +89,10 @@ cdef extern from "MatchEnv.h" namespace "freud::environment":
         const freud.util.ManagedArray[bool] &getMatches()
 
     cdef cppclass EnvironmentRMSDMinimizer(MatchEnv):
-        EnvironmentRMSDMinimizer(const freud._box.Box &,
-                                 float,
+        EnvironmentRMSDMinimizer(float,
                                  unsigned int) except +
         void compute(
+            const freud._box.Box &,
             const freud._locality.NeighborList*,
             const vec3[float]*,
             unsigned int,
@@ -102,10 +102,10 @@ cdef extern from "MatchEnv.h" namespace "freud::environment":
         const freud.util.ManagedArray[float] &getRMSDs()
 
     cdef cppclass EnvironmentCluster(MatchEnv):
-        EnvironmentCluster(const freud._box.Box &,
-                           float,
+        EnvironmentCluster(float,
                            unsigned int) except +
-        void compute(const freud._locality.NeighborList*,
+        void compute(const freud._box.Box &,
+                     const freud._locality.NeighborList*,
                      const freud._locality.NeighborList*,
                      const vec3[float]*,
                      unsigned int,

--- a/freud/_environment.pxd
+++ b/freud/_environment.pxd
@@ -61,6 +61,14 @@ cdef extern from "MatchEnv.h" namespace "freud::environment":
         const freud._box.Box &, const vec3[float]*, vec3[float]*, unsigned int,
         float &, bool) except +
 
+    map[unsigned int, unsigned int] isSimilar(const freud._box.Box &,
+                                              const vec3[float]*,
+                                              vec3[float]*,
+                                              unsigned int,
+                                              float,
+                                              float,
+                                              bool) except +
+
     cdef cppclass MatchEnv:
         MatchEnv(const freud._box.Box &, float, unsigned int) except +
         void setBox(const freud._box.Box)
@@ -85,11 +93,6 @@ cdef extern from "MatchEnv.h" namespace "freud::environment":
             const vec3[float]*,
             unsigned int,
             bool) except +
-        map[unsigned int, unsigned int] isSimilar(const vec3[float]*,
-                                                  vec3[float]*,
-                                                  unsigned int,
-                                                  float,
-                                                  bool) except +
         const freud.util.ManagedArray[unsigned int] &getClusters()
         vector[vec3[float]] getEnvironment(unsigned int)
         const freud.util.ManagedArray[vec3[float]] &getTotEnvironment()

--- a/freud/_environment.pxd
+++ b/freud/_environment.pxd
@@ -71,29 +71,28 @@ cdef extern from "MatchEnv.h" namespace "freud::environment":
 
     cdef cppclass MatchEnv:
         MatchEnv(const freud._box.Box &, float, unsigned int) except +
-        const freud.util.ManagedArray[unsigned int] &getClusters()
-        const freud.util.ManagedArray[vec3[float]] &getTotEnvironment()
         unsigned int getNumNeighbors()
         unsigned int getMaxNumNeighbors()
+        const freud.util.ManagedArray[vec3[float]] &getParticleEnvironments()
 
     cdef cppclass EnvironmentMotifMatch(MatchEnv):
         EnvironmentMotifMatch(const freud._box.Box &,
                               float,
                               unsigned int) except +
-        void matchMotif(const freud._locality.NeighborList*,
-                        const vec3[float]*,
-                        unsigned int,
-                        const vec3[float]*,
-                        unsigned int,
-                        float,
-                        bool) except +
+        void compute(const freud._locality.NeighborList*,
+                     const vec3[float]*,
+                     unsigned int,
+                     const vec3[float]*,
+                     unsigned int,
+                     float,
+                     bool) except +
         const freud.util.ManagedArray[bool] &getMatches()
 
     cdef cppclass EnvironmentRMSDMinimizer(MatchEnv):
         EnvironmentRMSDMinimizer(const freud._box.Box &,
                                  float,
                                  unsigned int) except +
-        void minRMSDMotif(
+        void compute(
             const freud._locality.NeighborList*,
             const vec3[float]*,
             unsigned int,
@@ -106,7 +105,7 @@ cdef extern from "MatchEnv.h" namespace "freud::environment":
         EnvironmentCluster(const freud._box.Box &,
                            float,
                            unsigned int) except +
-        void cluster(const freud._locality.NeighborList*,
+        void compute(const freud._locality.NeighborList*,
                      const freud._locality.NeighborList*,
                      const vec3[float]*,
                      unsigned int,
@@ -115,6 +114,7 @@ cdef extern from "MatchEnv.h" namespace "freud::environment":
                      bool) except +
         vector[vec3[float]] getEnvironment(unsigned int)
         unsigned int getNumClusters()
+        const freud.util.ManagedArray[unsigned int] &getClusters()
 
 cdef extern from "AngularSeparation.h" namespace "freud::environment":
     cdef cppclass AngularSeparationGlobal:

--- a/freud/_environment.pxd
+++ b/freud/_environment.pxd
@@ -70,7 +70,7 @@ cdef extern from "MatchEnv.h" namespace "freud::environment":
 
     cdef cppclass MatchEnv:
         MatchEnv() except +
-        const freud.util.ManagedArray[vec3[float]] &getParticleEnvironments()
+        const freud.util.ManagedArray[vec3[float]] &getPointEnvironments()
 
     cdef cppclass EnvironmentMotifMatch(MatchEnv):
         EnvironmentMotifMatch() except +

--- a/freud/_environment.pxd
+++ b/freud/_environment.pxd
@@ -72,9 +72,7 @@ cdef extern from "MatchEnv.h" namespace "freud::environment":
     cdef cppclass MatchEnv:
         MatchEnv(const freud._box.Box &, float, unsigned int) except +
         const freud.util.ManagedArray[unsigned int] &getClusters()
-        vector[vec3[float]] getEnvironment(unsigned int)
         const freud.util.ManagedArray[vec3[float]] &getTotEnvironment()
-        unsigned int getNP()
         unsigned int getNumClusters()
         unsigned int getNumNeighbors()
         unsigned int getMaxNumNeighbors()
@@ -109,6 +107,7 @@ cdef extern from "MatchEnv.h" namespace "freud::environment":
                      float,
                      bool,
                      bool) except +
+        vector[vec3[float]] getEnvironment(unsigned int)
 
 cdef extern from "AngularSeparation.h" namespace "freud::environment":
     cdef cppclass AngularSeparationGlobal:

--- a/freud/_environment.pxd
+++ b/freud/_environment.pxd
@@ -98,6 +98,7 @@ cdef extern from "MatchEnv.h" namespace "freud::environment":
         EnvironmentCluster() except +
         void compute(const freud._locality.NeighborQuery*,
                      const freud._locality.NeighborList*,
+                     freud._locality.QueryArgs,
                      const freud._locality.NeighborList*,
                      freud._locality.QueryArgs,
                      float,

--- a/freud/_environment.pxd
+++ b/freud/_environment.pxd
@@ -73,7 +73,6 @@ cdef extern from "MatchEnv.h" namespace "freud::environment":
         MatchEnv(const freud._box.Box &, float, unsigned int) except +
         const freud.util.ManagedArray[unsigned int] &getClusters()
         const freud.util.ManagedArray[vec3[float]] &getTotEnvironment()
-        unsigned int getNumClusters()
         unsigned int getNumNeighbors()
         unsigned int getMaxNumNeighbors()
 
@@ -88,13 +87,20 @@ cdef extern from "MatchEnv.h" namespace "freud::environment":
                         unsigned int,
                         float,
                         bool) except +
-        vector[float] minRMSDMotif(
+        const freud.util.ManagedArray[bool] &getMatches()
+
+    cdef cppclass EnvironmentRMSDMinimizer(MatchEnv):
+        EnvironmentRMSDMinimizer(const freud._box.Box &,
+                                 float,
+                                 unsigned int) except +
+        void minRMSDMotif(
             const freud._locality.NeighborList*,
             const vec3[float]*,
             unsigned int,
             const vec3[float]*,
             unsigned int,
             bool) except +
+        const freud.util.ManagedArray[float] &getRMSDs()
 
     cdef cppclass EnvironmentCluster(MatchEnv):
         EnvironmentCluster(const freud._box.Box &,
@@ -108,6 +114,7 @@ cdef extern from "MatchEnv.h" namespace "freud::environment":
                      bool,
                      bool) except +
         vector[vec3[float]] getEnvironment(unsigned int)
+        unsigned int getNumClusters()
 
 cdef extern from "AngularSeparation.h" namespace "freud::environment":
     cdef cppclass AngularSeparationGlobal:

--- a/freud/_environment.pxd
+++ b/freud/_environment.pxd
@@ -57,6 +57,10 @@ cdef extern from "LocalDescriptors.h" namespace "freud::environment":
         bool getNegativeM() const
 
 cdef extern from "MatchEnv.h" namespace "freud::environment":
+    map[unsigned int, unsigned int] minimizeRMSD(
+        const freud._box.Box &, const vec3[float]*, vec3[float]*, unsigned int,
+        float &, bool) except +
+
     cdef cppclass MatchEnv:
         MatchEnv(const freud._box.Box &, float, unsigned int) except +
         void setBox(const freud._box.Box)
@@ -86,11 +90,6 @@ cdef extern from "MatchEnv.h" namespace "freud::environment":
                                                   unsigned int,
                                                   float,
                                                   bool) except +
-        map[unsigned int, unsigned int] minimizeRMSD(const vec3[float]*,
-                                                     vec3[float]*,
-                                                     unsigned int,
-                                                     float &,
-                                                     bool) except +
         const freud.util.ManagedArray[unsigned int] &getClusters()
         vector[vec3[float]] getEnvironment(unsigned int)
         const freud.util.ManagedArray[vec3[float]] &getTotEnvironment()

--- a/freud/_environment.pxd
+++ b/freud/_environment.pxd
@@ -66,18 +66,16 @@ cdef extern from "MatchEnv.h" namespace "freud::environment":
                                               vec3[float]*,
                                               unsigned int,
                                               float,
-                                              float,
                                               bool) except +
 
     cdef cppclass MatchEnv:
-        MatchEnv(const freud._box.Box &, float, unsigned int) except +
+        MatchEnv(unsigned int) except +
         unsigned int getNumNeighbors()
         unsigned int getMaxNumNeighbors()
         const freud.util.ManagedArray[vec3[float]] &getParticleEnvironments()
 
     cdef cppclass EnvironmentMotifMatch(MatchEnv):
-        EnvironmentMotifMatch(float,
-                              unsigned int) except +
+        EnvironmentMotifMatch(unsigned int) except +
         void compute(const freud._box.Box &,
                      const freud._locality.NeighborList*,
                      const vec3[float]*,
@@ -89,8 +87,7 @@ cdef extern from "MatchEnv.h" namespace "freud::environment":
         const freud.util.ManagedArray[bool] &getMatches()
 
     cdef cppclass EnvironmentRMSDMinimizer(MatchEnv):
-        EnvironmentRMSDMinimizer(float,
-                                 unsigned int) except +
+        EnvironmentRMSDMinimizer(unsigned int) except +
         void compute(
             const freud._box.Box &,
             const freud._locality.NeighborList*,
@@ -102,8 +99,7 @@ cdef extern from "MatchEnv.h" namespace "freud::environment":
         const freud.util.ManagedArray[float] &getRMSDs()
 
     cdef cppclass EnvironmentCluster(MatchEnv):
-        EnvironmentCluster(float,
-                           unsigned int) except +
+        EnvironmentCluster(unsigned int) except +
         void compute(const freud._box.Box &,
                      const freud._locality.NeighborList*,
                      const freud._locality.NeighborList*,

--- a/freud/_environment.pxd
+++ b/freud/_environment.pxd
@@ -69,13 +69,11 @@ cdef extern from "MatchEnv.h" namespace "freud::environment":
                                               bool) except +
 
     cdef cppclass MatchEnv:
-        MatchEnv(unsigned int) except +
-        unsigned int getNumNeighbors()
-        unsigned int getMaxNumNeighbors()
+        MatchEnv() except +
         const freud.util.ManagedArray[vec3[float]] &getParticleEnvironments()
 
     cdef cppclass EnvironmentMotifMatch(MatchEnv):
-        EnvironmentMotifMatch(unsigned int) except +
+        EnvironmentMotifMatch() except +
         void compute(const freud._box.Box &,
                      const freud._locality.NeighborList*,
                      const vec3[float]*,
@@ -85,9 +83,11 @@ cdef extern from "MatchEnv.h" namespace "freud::environment":
                      float,
                      bool) except +
         const freud.util.ManagedArray[bool] &getMatches()
+        unsigned int getNumNeighbors()
+        unsigned int getMaxNumNeighbors()
 
     cdef cppclass EnvironmentRMSDMinimizer(MatchEnv):
-        EnvironmentRMSDMinimizer(unsigned int) except +
+        EnvironmentRMSDMinimizer() except +
         void compute(
             const freud._box.Box &,
             const freud._locality.NeighborList*,
@@ -97,9 +97,11 @@ cdef extern from "MatchEnv.h" namespace "freud::environment":
             unsigned int,
             bool) except +
         const freud.util.ManagedArray[float] &getRMSDs()
+        unsigned int getNumNeighbors()
+        unsigned int getMaxNumNeighbors()
 
     cdef cppclass EnvironmentCluster(MatchEnv):
-        EnvironmentCluster(unsigned int) except +
+        EnvironmentCluster() except +
         void compute(const freud._box.Box &,
                      const freud._locality.NeighborList*,
                      const freud._locality.NeighborList*,
@@ -111,6 +113,8 @@ cdef extern from "MatchEnv.h" namespace "freud::environment":
         unsigned int getNumClusters()
         const freud.util.ManagedArray[unsigned int] &getClusters()
         vector[vector[vec3[float]]] &getClusterEnvironments()
+        unsigned int getNumNeighbors()
+        unsigned int getMaxNumNeighbors()
 
 cdef extern from "AngularSeparation.h" namespace "freud::environment":
     cdef cppclass AngularSeparationGlobal:

--- a/freud/_environment.pxd
+++ b/freud/_environment.pxd
@@ -76,6 +76,7 @@ cdef extern from "MatchEnv.h" namespace "freud::environment":
         EnvironmentMotifMatch() except +
         void compute(const freud._locality.NeighborQuery*,
                      const freud._locality.NeighborList*,
+                     freud._locality.QueryArgs,
                      const vec3[float]*,
                      unsigned int,
                      float,
@@ -87,6 +88,7 @@ cdef extern from "MatchEnv.h" namespace "freud::environment":
         void compute(
             const freud._locality.NeighborQuery*,
             const freud._locality.NeighborList*,
+            freud._locality.QueryArgs,
             const vec3[float]*,
             unsigned int,
             bool) except +
@@ -97,6 +99,7 @@ cdef extern from "MatchEnv.h" namespace "freud::environment":
         void compute(const freud._locality.NeighborQuery*,
                      const freud._locality.NeighborList*,
                      const freud._locality.NeighborList*,
+                     freud._locality.QueryArgs,
                      float,
                      bool,
                      bool) except +

--- a/freud/_locality.pxd
+++ b/freud/_locality.pxd
@@ -108,9 +108,9 @@ cdef extern from "LinkCell.h" namespace "freud::locality":
     cdef cppclass LinkCell(NeighborQuery):
         LinkCell() except +
         LinkCell(const freud._box.Box &,
-                 float,
                  const vec3[float]*,
-                 unsigned int) except +
+                 unsigned int,
+                 float) except +
         const vec3[unsigned int] computeDimensions(
             const freud._box.Box &,
             float) const

--- a/freud/cluster.pyx
+++ b/freud/cluster.pyx
@@ -66,7 +66,6 @@ cdef class Cluster(PairCompute):
     def __dealloc__(self):
         del self.thisptr
 
-    @Compute._compute
     def compute(self, neighbor_query, keys=None, neighbors=None):
         R"""Compute the clusters for the given set of points.
 
@@ -182,7 +181,6 @@ cdef class ClusterProperties(Compute):
     def __dealloc__(self):
         del self.thisptr
 
-    @Compute._compute
     def compute(self, box, points, cluster_idx):
         R"""Compute properties of the point clusters.
         Loops over all points in the given array and determines the center of

--- a/freud/cluster.pyx
+++ b/freud/cluster.pyx
@@ -121,7 +121,6 @@ cdef class Cluster(PairCompute):
     def __repr__(self):
         return "freud.cluster.{cls}()".format(cls=type(self).__name__)
 
-    @Compute._computed_method
     def plot(self, ax=None):
         """Plot cluster distribution.
 

--- a/freud/cluster.pyx
+++ b/freud/cluster.pyx
@@ -87,7 +87,7 @@ cdef class Cluster(PairCompute):
             unsigned int num_query_points
 
         nq, nlist, qargs, l_query_points, num_query_points = \
-            self.preprocess_arguments(neighbor_query, neighbors=neighbors)
+            self._preprocess_arguments(neighbor_query, neighbors=neighbors)
 
         cdef unsigned int* l_keys_ptr = NULL
         cdef unsigned int[::1] l_keys

--- a/freud/cluster.pyx
+++ b/freud/cluster.pyx
@@ -66,7 +66,7 @@ cdef class Cluster(PairCompute):
     def __dealloc__(self):
         del self.thisptr
 
-    @Compute._compute()
+    @Compute._compute
     def compute(self, neighbor_query, keys=None, neighbors=None):
         R"""Compute the clusters for the given set of points.
 
@@ -104,17 +104,17 @@ cdef class Cluster(PairCompute):
             l_keys_ptr)
         return self
 
-    @Compute._computed_property()
+    @Compute._computed_property
     def num_clusters(self):
         return self.thisptr.getNumClusters()
 
-    @Compute._computed_property()
+    @Compute._computed_property
     def cluster_idx(self):
         return freud.util.make_managed_numpy_array(
             &self.thisptr.getClusterIdx(),
             freud.util.arr_type_t.UNSIGNED_INT)
 
-    @Compute._computed_property()
+    @Compute._computed_property
     def cluster_keys(self):
         cluster_keys = self.thisptr.getClusterKeys()
         return cluster_keys
@@ -122,7 +122,7 @@ cdef class Cluster(PairCompute):
     def __repr__(self):
         return "freud.cluster.{cls}()".format(cls=type(self).__name__)
 
-    @Compute._computed_method()
+    @Compute._computed_method
     def plot(self, ax=None):
         """Plot cluster distribution.
 
@@ -182,7 +182,7 @@ cdef class ClusterProperties(Compute):
     def __dealloc__(self):
         del self.thisptr
 
-    @Compute._compute()
+    @Compute._compute
     def compute(self, box, points, cluster_idx):
         R"""Compute properties of the point clusters.
         Loops over all points in the given array and determines the center of
@@ -213,19 +213,19 @@ cdef class ClusterProperties(Compute):
             Np)
         return self
 
-    @Compute._computed_property()
+    @Compute._computed_property
     def centers(self):
         return freud.util.make_managed_numpy_array(
             &self.thisptr.getClusterCenters(),
             freud.util.arr_type_t.FLOAT, 3)
 
-    @Compute._computed_property()
+    @Compute._computed_property
     def gyrations(self):
         return freud.util.make_managed_numpy_array(
             &self.thisptr.getClusterGyrations(),
             freud.util.arr_type_t.FLOAT)
 
-    @Compute._computed_property()
+    @Compute._computed_property
     def sizes(self):
         return freud.util.make_managed_numpy_array(
             &self.thisptr.getClusterSizes(),

--- a/freud/common.pyx
+++ b/freud/common.pyx
@@ -24,11 +24,11 @@ cdef class Compute:
     .. code-block:: python
         class Cluster(Compute):
 
-            @Compute._compute()
+            @Compute._compute
             def compute(...)
                 ...
 
-            @Compute._computed_property()
+            @Compute._computed_property
             def cluster_idx(self):
                 return ...
 
@@ -45,67 +45,61 @@ cdef class Compute:
         self._called_compute = False
 
     @staticmethod
-    def _compute():
+    def _compute(func):
         R"""Decorator that sets compute flag to be true.
 
         Args:
-            key (str): Name of compute flag.
+            func (callable): The compute function.
 
         Returns:
             Decorator decorating appropriate compute method.
         """
 
-        def _compute_with_key(func):
-            @wraps(func)
-            def wrapper(self, *args, **kwargs):
-                retval = func(self, *args, **kwargs)
-                self._called_compute = True
-                return retval
-            return wrapper
-        return _compute_with_key
+        @wraps(func)
+        def wrapper(self, *args, **kwargs):
+            retval = func(self, *args, **kwargs)
+            self._called_compute = True
+            return retval
+        return wrapper
 
     @staticmethod
-    def _computed_property():
+    def _computed_property(prop):
         R"""Decorator that makes a class method to be a property with limited access.
 
         Args:
-            key (str): Name of compute flag.
+            prop (callable): The property function.
 
         Returns:
             Decorator decorating appropriate property method.
         """
 
-        def _computed_property_with_key(func):
-            @property
-            @wraps(func)
-            def wrapper(self, *args, **kwargs):
-                if not self._called_compute:
-                    raise AttributeError(
-                        "Property not computed. Call compute first.")
-                return func(self, *args, **kwargs)
-            return wrapper
-        return _computed_property_with_key
+        @property
+        @wraps(prop)
+        def wrapper(self, *args, **kwargs):
+            if not self._called_compute:
+                raise AttributeError(
+                    "Property not computed. Call compute first.")
+            return prop(self, *args, **kwargs)
+        return wrapper
 
     @staticmethod
-    def _computed_method():
+    def _computed_method(meth):
         R"""Decorator that makes a class method to be a method with limited access.
 
         Args:
-            key (str): Name of compute flag.
+            meth (callable): The method that requires compute to be called.
 
         Returns:
-            Decorator decorating appropriate property method.
+            Decorator decorating appropriate method.
         """
 
-        def _computed_property_with_key(func):
-            @wraps(func)
-            def wrapper(self, *args, **kwargs):
-                if not self._called_compute:
-                    raise AttributeError(
-                        "Property not computed. Call compute first.")
-                return func(self, *args, **kwargs)
-            return wrapper
-        return _computed_property_with_key
+        @wraps(meth)
+        def wrapper(self, *args, **kwargs):
+            if not self._called_compute:
+                raise AttributeError(
+                    "Property not computed. Call compute first.")
+            return meth(self, *args, **kwargs)
+        return wrapper
 
     @staticmethod
     def _reset(func):

--- a/freud/common.pyx
+++ b/freud/common.pyx
@@ -76,25 +76,6 @@ cdef class Compute(object):
             return prop(self, *args, **kwargs)
         return wrapper
 
-    @staticmethod
-    def _computed_method(meth):
-        R"""Decorator that makes a class method to be a method with limited access.
-
-        Args:
-            meth (callable): The method that requires compute to be called.
-
-        Returns:
-            Decorator decorating appropriate method.
-        """
-
-        @wraps(meth)
-        def wrapper(self, *args, **kwargs):
-            if not self._called_compute:
-                raise AttributeError(
-                    "Property not computed. Call compute first.")
-            return meth(self, *args, **kwargs)
-        return wrapper
-
     def __str__(self):
         return repr(self)
 

--- a/freud/common.pyx
+++ b/freud/common.pyx
@@ -27,6 +27,7 @@ cdef class Compute(object):
             def compute(...)
                 ...
 
+            @Compute._computed_property()
             def cluster_idx(self):
                 return ...
 

--- a/freud/density.pyx
+++ b/freud/density.pyx
@@ -77,7 +77,6 @@ cdef class CorrelationFunction(SpatialHistogram1D):
     def __dealloc__(self):
         del self.thisptr
 
-    @Compute._compute
     def accumulate(self, neighbor_query, values, query_points=None,
                    query_values=None, neighbors=None):
         R"""Calculates the correlation function and adds to the current
@@ -144,13 +143,11 @@ cdef class CorrelationFunction(SpatialHistogram1D):
             freud.util.arr_type_t.COMPLEX_DOUBLE)
         return output if self.is_complex else np.real(output)
 
-    @Compute._reset
     def reset(self):
         # Overrides parent since resetting here requires additional logic.
         self.is_complex = False
         self.thisptr.reset()
 
-    @Compute._compute
     def compute(self, neighbor_query, values, query_points=None,
                 query_values=None, neighbors=None):
         R"""Calculates the correlation function for the given points. Will
@@ -261,7 +258,6 @@ cdef class GaussianDensity(Compute):
     def box(self):
         return freud.box.BoxFromCPP(self.thisptr.getBox())
 
-    @Compute._compute
     def compute(self, box, points):
         R"""Calculates the Gaussian blur for the specified points. Does not
         accumulate (will overwrite current image).
@@ -400,7 +396,6 @@ cdef class LocalDensity(PairCompute):
     def box(self):
         return freud.box.BoxFromCPP(self.thisptr.getBox())
 
-    @Compute._compute
     def compute(self, neighbor_query, query_points=None, neighbors=None):
         R"""Calculates the local density for the specified points. Does not
         accumulate (will overwrite current data).
@@ -514,7 +509,6 @@ cdef class RDF(SpatialHistogram1D):
         if type(self) == RDF:
             del self.thisptr
 
-    @Compute._compute
     def accumulate(self, neighbor_query, query_points=None, neighbors=None):
         R"""Calculates the RDF and adds to the current RDF histogram.
 
@@ -546,7 +540,6 @@ cdef class RDF(SpatialHistogram1D):
             dereference(qargs.thisptr))
         return self
 
-    @Compute._compute
     def compute(self, neighbor_query, query_points=None, neighbors=None):
         R"""Calculates the RDF for the specified points. Will overwrite the current
         histogram.

--- a/freud/density.pyx
+++ b/freud/density.pyx
@@ -109,7 +109,7 @@ cdef class CorrelationFunction(SpatialHistogram1D):
             unsigned int num_query_points
 
         nq, nlist, qargs, l_query_points, num_query_points = \
-            self.preprocess_arguments(neighbor_query, query_points, neighbors)
+            self._preprocess_arguments(neighbor_query, query_points, neighbors)
 
         # Save if any inputs have been complex so far.
         self.is_complex = self.is_complex or np.any(np.iscomplex(values)) or \
@@ -421,7 +421,7 @@ cdef class LocalDensity(PairCompute):
             unsigned int num_query_points
 
         nq, nlist, qargs, l_query_points, num_query_points = \
-            self.preprocess_arguments(neighbor_query, query_points, neighbors)
+            self._preprocess_arguments(neighbor_query, query_points, neighbors)
         self.thisptr.compute(
             nq.get_ptr(),
             <vec3[float]*> &l_query_points[0, 0],
@@ -531,7 +531,7 @@ cdef class RDF(SpatialHistogram1D):
             const float[:, ::1] l_query_points
             unsigned int num_query_points
         nq, nlist, qargs, l_query_points, num_query_points = \
-            self.preprocess_arguments(neighbor_query, query_points, neighbors)
+            self._preprocess_arguments(neighbor_query, query_points, neighbors)
 
         self.thisptr.accumulate(
             nq.get_ptr(),

--- a/freud/density.pyx
+++ b/freud/density.pyx
@@ -77,7 +77,7 @@ cdef class CorrelationFunction(SpatialHistogram1D):
     def __dealloc__(self):
         del self.thisptr
 
-    @Compute._compute()
+    @Compute._compute
     def accumulate(self, neighbor_query, values, query_points=None,
                    query_values=None, neighbors=None):
         R"""Calculates the correlation function and adds to the current
@@ -137,7 +137,7 @@ cdef class CorrelationFunction(SpatialHistogram1D):
             dereference(qargs.thisptr))
         return self
 
-    @Compute._computed_property()
+    @Compute._computed_property
     def correlation(self):
         output = freud.util.make_managed_numpy_array(
             &self.thisptr.getCorrelation(),
@@ -150,7 +150,7 @@ cdef class CorrelationFunction(SpatialHistogram1D):
         self.is_complex = False
         self.thisptr.reset()
 
-    @Compute._compute()
+    @Compute._compute
     def compute(self, neighbor_query, values, query_points=None,
                 query_values=None, neighbors=None):
         R"""Calculates the correlation function for the given points. Will
@@ -257,11 +257,11 @@ cdef class GaussianDensity(Compute):
     def __dealloc__(self):
         del self.thisptr
 
-    @Compute._computed_property()
+    @Compute._computed_property
     def box(self):
         return freud.box.BoxFromCPP(self.thisptr.getBox())
 
-    @Compute._compute()
+    @Compute._compute
     def compute(self, box, points):
         R"""Calculates the Gaussian blur for the specified points. Does not
         accumulate (will overwrite current image).
@@ -280,7 +280,7 @@ cdef class GaussianDensity(Compute):
                              <vec3[float]*> &l_points[0, 0], n_p)
         return self
 
-    @Compute._computed_property()
+    @Compute._computed_property
     def gaussian_density(self):
         if self.box.is2D:
             return np.squeeze(freud.util.make_managed_numpy_array(
@@ -309,7 +309,7 @@ cdef class GaussianDensity(Compute):
                                             r_max=self.r_max,
                                             sigma=self.sigma)
 
-    @Compute._computed_method()
+    @Compute._computed_method
     def plot(self, ax=None):
         """Plot Gaussian Density.
 
@@ -396,11 +396,11 @@ cdef class LocalDensity(PairCompute):
     def diameter(self):
         return self.thisptr.getDiameter()
 
-    @Compute._computed_property()
+    @Compute._computed_property
     def box(self):
         return freud.box.BoxFromCPP(self.thisptr.getBox())
 
-    @Compute._compute()
+    @Compute._compute
     def compute(self, neighbor_query, query_points=None, neighbors=None):
         R"""Calculates the local density for the specified points. Does not
         accumulate (will overwrite current data).
@@ -439,13 +439,13 @@ cdef class LocalDensity(PairCompute):
         return dict(mode="ball",
                     r_max=self.r_max + 0.5*self.diameter)
 
-    @Compute._computed_property()
+    @Compute._computed_property
     def density(self):
         return freud.util.make_managed_numpy_array(
             &self.thisptr.getDensity(),
             freud.util.arr_type_t.FLOAT)
 
-    @Compute._computed_property()
+    @Compute._computed_property
     def num_neighbors(self):
         return freud.util.make_managed_numpy_array(
             &self.thisptr.getNumNeighbors(),
@@ -514,7 +514,7 @@ cdef class RDF(SpatialHistogram1D):
         if type(self) == RDF:
             del self.thisptr
 
-    @Compute._compute()
+    @Compute._compute
     def accumulate(self, neighbor_query, query_points=None, neighbors=None):
         R"""Calculates the RDF and adds to the current RDF histogram.
 
@@ -546,7 +546,7 @@ cdef class RDF(SpatialHistogram1D):
             dereference(qargs.thisptr))
         return self
 
-    @Compute._compute()
+    @Compute._compute
     def compute(self, neighbor_query, query_points=None, neighbors=None):
         R"""Calculates the RDF for the specified points. Will overwrite the current
         histogram.
@@ -567,13 +567,13 @@ cdef class RDF(SpatialHistogram1D):
         self.accumulate(neighbor_query, query_points, neighbors)
         return self
 
-    @Compute._computed_property()
+    @Compute._computed_property
     def RDF(self):
         return freud.util.make_managed_numpy_array(
             &self.thisptr.getRDF(),
             freud.util.arr_type_t.FLOAT)
 
-    @Compute._computed_property()
+    @Compute._computed_property
     def n_r(self):
         return freud.util.make_managed_numpy_array(
             &self.thisptr.getNr(),
@@ -586,7 +586,7 @@ cdef class RDF(SpatialHistogram1D):
                                          r_max=self.bounds[1],
                                          r_min=self.bounds[0])
 
-    @Compute._computed_method()
+    @Compute._computed_method
     def plot(self, ax=None):
         """Plot radial distribution function.
 

--- a/freud/density.pyx
+++ b/freud/density.pyx
@@ -305,7 +305,6 @@ cdef class GaussianDensity(Compute):
                                             r_max=self.r_max,
                                             sigma=self.sigma)
 
-    @Compute._computed_method
     def plot(self, ax=None):
         """Plot Gaussian Density.
 
@@ -579,7 +578,6 @@ cdef class RDF(SpatialHistogram1D):
                                          r_max=self.bounds[1],
                                          r_min=self.bounds[0])
 
-    @Compute._computed_method
     def plot(self, ax=None):
         """Plot radial distribution function.
 

--- a/freud/environment.pyx
+++ b/freud/environment.pyx
@@ -599,7 +599,9 @@ cdef class EnvironmentCluster(_MatchEnv):
                 NeighborList to use to find neighbors of every particle, to
                 compare environments (Default value = :code:`None`).
         """
-        cdef freud.box.Box b = freud.common.convert_box(box)
+        cdef freud.locality.NeighborQuery nq = freud.locality._make_default_nq(
+            box, points)
+
         self.m_box = box
 
         points = freud.common.convert_array(points, shape=(None, 3))
@@ -616,8 +618,8 @@ cdef class EnvironmentCluster(_MatchEnv):
             self.m_box, points, None, query_args, env_nlist)
 
         self.thisptr.compute(
-            dereference(b.thisptr), env_nlist_.get_ptr(), nlist_.get_ptr(),
-            <vec3[float]*> &l_points[0, 0], nP, threshold, registration,
+            nq.get_ptr(), env_nlist_.get_ptr(), nlist_.get_ptr(),
+            threshold, registration,
             global_search)
         return self
 
@@ -723,7 +725,8 @@ cdef class EnvironmentMotifMatch(_MatchEnv):
                 NeighborList to use to find bonds (Default value =
                 :code:`None`).
         """
-        cdef freud.box.Box b = freud.common.convert_box(box)
+        cdef freud.locality.NeighborQuery nq = freud.locality._make_default_nq(
+            box, points)
         self.m_box = box
 
         points = freud.common.convert_array(points, shape=(None, 3))
@@ -740,8 +743,8 @@ cdef class EnvironmentMotifMatch(_MatchEnv):
             query_args, nlist)
 
         self.thisptr.compute(
-            dereference(b.thisptr), nlist_.get_ptr(), <vec3[float]*>
-            &l_points[0, 0], nP, <vec3[float]*> &l_motif[0, 0], nRef,
+            nq.get_ptr(), nlist_.get_ptr(), <vec3[float]*>
+            <vec3[float]*> &l_motif[0, 0], nRef,
             threshold, registration)
 
     @Compute._computed_property
@@ -817,7 +820,8 @@ cdef class _EnvironmentRMSDMinimizer(_MatchEnv):
                 Vector of minimal RMSD values, one value per particle.
 
         """
-        cdef freud.box.Box b = freud.common.convert_box(box)
+        cdef freud.locality.NeighborQuery nq = freud.locality._make_default_nq(
+            box, points)
         self.m_box = box
 
         points = freud.common.convert_array(points, shape=(None, 3))
@@ -834,8 +838,8 @@ cdef class _EnvironmentRMSDMinimizer(_MatchEnv):
             query_args, nlist)
 
         self.thisptr.compute(
-            dereference(b.thisptr), nlist_.get_ptr(), <vec3[float]*>
-            &l_points[0, 0], nP, <vec3[float]*> &l_motif[0, 0], nRef,
+            nq.get_ptr(), nlist_.get_ptr(), <vec3[float]*>
+            <vec3[float]*> &l_motif[0, 0], nRef,
             registration)
 
         return self

--- a/freud/environment.pyx
+++ b/freud/environment.pyx
@@ -515,10 +515,8 @@ cdef class _MatchEnv(Compute):
             of any given particle.
 
     Attributes:
-        tot_environment (:math:`\left(N_{particles}, N_{neighbors}, 3\right)` :class:`numpy.ndarray`):
+        particle_environments (:math:`\left(N_{particles}, N_{neighbors}, 3\right)` :class:`numpy.ndarray`):
             All environments for all particles.
-        num_particles (unsigned int):
-            The number of particles.
         num_clusters (unsigned int):
             The number of clusters.
         clusters (:math:`\left(N_{particles}\right)` :class:`numpy.ndarray`):
@@ -539,28 +537,11 @@ cdef class _MatchEnv(Compute):
             &self.matchptr.getClusters(),
             freud.util.arr_type_t.UNSIGNED_INT)
 
-    def getEnvironment(self, i):
-        R"""Returns the set of vectors defining the environment indexed by i.
-
-        Args:
-            i (unsigned int): Environment index.
-
-        Returns:
-            :math:`\left(N_{neighbors}, 3\right)` :class:`numpy.ndarray`:
-            The array of vectors.
-        """
-        env = self.matchptr.getEnvironment(i)
-        return np.asarray([[p.x, p.y, p.z] for p in env])
-
     @property
-    def tot_environment(self):
+    def particle_environments(self):
         return freud.util.make_managed_numpy_array(
             &self.matchptr.getTotEnvironment(),
             freud.util.arr_type_t.FLOAT, 3)
-
-    @property
-    def num_particles(self):
-        return self.matchptr.getNP()
 
     @property
     def num_clusters(self):
@@ -592,8 +573,6 @@ cdef class EnvironmentCluster(_MatchEnv):
             of any given particle.
 
     Attributes:
-        tot_environment (:math:`\left(N_{particles}, N_{neighbors}, 3\right)` :class:`numpy.ndarray`):
-            All environments for all particles.
         num_particles (unsigned int):
             The number of particles.
         num_clusters (unsigned int):
@@ -637,7 +616,7 @@ cdef class EnvironmentCluster(_MatchEnv):
                 it minimizes the RMSD between the two sets.
                 (Default value = :code:`False`)
             global_search (bool, optional):
-                If True, do an exhaustive search wherein the environments of
+                 If True, do an exhaustive search wherein the environments of
                 every single pair of particles in the simulation are compared.
                 If False, only compare the environments of neighboring
                 particles. (Default value = :code:`False`)
@@ -677,6 +656,19 @@ cdef class EnvironmentCluster(_MatchEnv):
             <vec3[float]*> &l_points[0, 0], nP, threshold,
             registration, global_search)
         return self
+
+    def getEnvironment(self, i):
+        R"""Returns the set of vectors defining the environment indexed by i.
+
+        Args:
+            i (unsigned int): Environment index.
+
+        Returns:
+            :math:`\left(N_{neighbors}, 3\right)` :class:`numpy.ndarray`:
+            The array of vectors.
+        """
+        env = self.thisptr.getEnvironment(i)
+        return np.asarray([[p.x, p.y, p.z] for p in env])
 
     def plot(self, ax=None):
         """Plot cluster distribution.
@@ -724,8 +716,6 @@ cdef class EnvironmentMotifMatch(_MatchEnv):
             of any given particle.
 
     Attributes:
-        tot_environment (:math:`\left(N_{particles}, N_{neighbors}, 3\right)` :class:`numpy.ndarray`):
-            All environments for all particles.
         num_particles (unsigned int):
             The number of particles.
         num_clusters (unsigned int):

--- a/freud/environment.pyx
+++ b/freud/environment.pyx
@@ -145,7 +145,7 @@ cdef class BondOrder(SpatialHistogram):
     def default_query_args(self):
         raise NotImplementedError('No default query arguments for BondOrder.')
 
-    @Compute._compute()
+    @Compute._compute
     def accumulate(self, neighbor_query, orientations, query_points=None,
                    query_orientations=None, neighbors=None):
         R"""Calculates the correlation function and adds to the current
@@ -199,13 +199,13 @@ cdef class BondOrder(SpatialHistogram):
             nlist.get_ptr(), dereference(qargs.thisptr))
         return self
 
-    @Compute._computed_property()
+    @Compute._computed_property
     def bond_order(self):
         return freud.util.make_managed_numpy_array(
             &self.thisptr.getBondOrder(),
             freud.util.arr_type_t.FLOAT)
 
-    @Compute._computed_property()
+    @Compute._computed_property
     def box(self):
         return freud.box.BoxFromCPP(self.thisptr.getBox())
 
@@ -214,7 +214,7 @@ cdef class BondOrder(SpatialHistogram):
         R"""Resets the values of the bond order in memory."""
         self.thisptr.reset()
 
-    @Compute._compute()
+    @Compute._compute
     def compute(self, neighbor_query, orientations, query_points=None,
                 query_orientations=None, neighbors=None):
         R"""Calculates the bond order histogram. Will overwrite the current
@@ -319,7 +319,7 @@ cdef class LocalDescriptors(PairCompute):
     def __dealloc__(self):
         del self.thisptr
 
-    @Compute._compute()
+    @Compute._compute
     def compute(self, neighbor_query, query_points=None, orientations=None,
                 neighbors=None):
         R"""Calculates the local descriptors of bonds from a set of source
@@ -373,17 +373,17 @@ cdef class LocalDescriptors(PairCompute):
             nlist.get_ptr(), dereference(qargs.thisptr))
         return self
 
-    @Compute._computed_property()
+    @Compute._computed_property
     def nlist(self):
         return freud.locality._nlist_from_cnlist(self.thisptr.getNList())
 
-    @Compute._computed_property()
+    @Compute._computed_property
     def sph(self):
         return freud.util.make_managed_numpy_array(
             &self.thisptr.getSph(),
             freud.util.arr_type_t.COMPLEX_FLOAT)
 
-    @Compute._computed_property()
+    @Compute._computed_property
     def num_sphs(self):
         return self.thisptr.getNSphs()
 
@@ -451,7 +451,7 @@ cdef class MatchEnv(Compute):
     def __dealloc__(self):
         del self.thisptr
 
-    @Compute._compute()
+    @Compute._compute
     def cluster(self, points, threshold, hard_r=False, registration=False,
                 global_search=False, env_nlist=None, nlist=None):
         R"""Determine clusters of particles with matching environments.
@@ -512,7 +512,7 @@ cdef class MatchEnv(Compute):
             registration, global_search)
         return self
 
-    @Compute._compute()
+    @Compute._compute
     def matchMotif(self, points, ref_points, threshold, registration=False,
                    nlist=None):
         R"""Determine clusters of particles that match the motif provided by
@@ -555,7 +555,7 @@ cdef class MatchEnv(Compute):
             <vec3[float]*> &l_ref_points[0], nRef, threshold,
             registration)
 
-    @Compute._compute()
+    @Compute._compute
     def minRMSDMotif(self, ref_points, points, registration=False, nlist=None):
         R"""Rotate (if registration=True) and permute the environments of all
         particles to minimize their RMSD with respect to the motif provided by
@@ -689,13 +689,13 @@ cdef class MatchEnv(Compute):
                 nRef1, min_rmsd, registration)
         return [min_rmsd, np.asarray(l_points), results_map]
 
-    @Compute._computed_property()
+    @Compute._computed_property
     def clusters(self):
         return freud.util.make_managed_numpy_array(
             &self.thisptr.getClusters(),
             freud.util.arr_type_t.UNSIGNED_INT)
 
-    @Compute._computed_method()
+    @Compute._computed_method
     def getEnvironment(self, i):
         R"""Returns the set of vectors defining the environment indexed by i.
 
@@ -709,17 +709,17 @@ cdef class MatchEnv(Compute):
         env = self.thisptr.getEnvironment(i)
         return np.asarray([[p.x, p.y, p.z] for p in env])
 
-    @Compute._computed_property()
+    @Compute._computed_property
     def tot_environment(self):
         return freud.util.make_managed_numpy_array(
             &self.thisptr.getTotEnvironment(),
             freud.util.arr_type_t.FLOAT, 3)
 
-    @Compute._computed_property()
+    @Compute._computed_property
     def num_particles(self):
         return self.thisptr.getNP()
 
-    @Compute._computed_property()
+    @Compute._computed_property
     def num_clusters(self):
         return self.thisptr.getNumClusters()
 
@@ -729,7 +729,7 @@ cdef class MatchEnv(Compute):
                     cls=type(self).__name__, box=self.m_box.__repr__(),
                     r_max=self.r_max, num_neighbors=self.num_neighbors)
 
-    @Compute._computed_method()
+    @Compute._computed_method
     def plot(self, ax=None):
         """Plot cluster distribution.
 
@@ -778,7 +778,7 @@ cdef class AngularSeparationNeighbor(PairCompute):
     def __dealloc__(self):
         del self.thisptr
 
-    @Compute._compute()
+    @Compute._compute
     def compute(self, neighbor_query, orientations, query_points=None,
                 query_orientations=None,
                 equiv_orientations=np.array([[1, 0, 0, 0]]),
@@ -850,7 +850,7 @@ cdef class AngularSeparationNeighbor(PairCompute):
             dereference(qargs.thisptr))
         return self
 
-    @Compute._computed_property()
+    @Compute._computed_property
     def angles(self):
         return freud.util.make_managed_numpy_array(
             &self.thisptr.getAngles(),
@@ -860,7 +860,7 @@ cdef class AngularSeparationNeighbor(PairCompute):
         return "freud.environment.{cls}()".format(
             cls=type(self).__name__)
 
-    @Compute._computed_property()
+    @Compute._computed_property
     def nlist(self):
         return freud.locality._nlist_from_cnlist(self.thisptr.getNList())
 
@@ -881,7 +881,7 @@ cdef class AngularSeparationGlobal(Compute):
     def __dealloc__(self):
         del self.thisptr
 
-    @Compute._compute()
+    @Compute._compute
     def compute(self, global_orientations,
                 orientations, equiv_orientations):
         R"""Calculates the minimum angles of separation between
@@ -924,7 +924,7 @@ cdef class AngularSeparationGlobal(Compute):
             n_equiv_orientations)
         return self
 
-    @Compute._computed_property()
+    @Compute._computed_property
     def angles(self):
         return freud.util.make_managed_numpy_array(
             &self.thisptr.getAngles(),
@@ -960,11 +960,11 @@ cdef class LocalBondProjection(PairCompute):
     def __dealloc__(self):
         del self.thisptr
 
-    @Compute._computed_property()
+    @Compute._computed_property
     def nlist(self):
         return freud.locality._nlist_from_cnlist(self.thisptr.getNList())
 
-    @Compute._compute()
+    @Compute._compute
     def compute(self, neighbor_query, orientations, proj_vecs,
                 query_points=None, equiv_orientations=np.array([[1, 0, 0, 0]]),
                 neighbors=None):
@@ -1035,13 +1035,13 @@ cdef class LocalBondProjection(PairCompute):
             nlist.get_ptr(), dereference(qargs.thisptr))
         return self
 
-    @Compute._computed_property()
+    @Compute._computed_property
     def projections(self):
         return freud.util.make_managed_numpy_array(
             &self.thisptr.getProjections(),
             freud.util.arr_type_t.FLOAT)
 
-    @Compute._computed_property()
+    @Compute._computed_property
     def normed_projections(self):
         return freud.util.make_managed_numpy_array(
             &self.thisptr.getNormedProjections(),

--- a/freud/environment.pyx
+++ b/freud/environment.pyx
@@ -568,9 +568,9 @@ cdef class EnvironmentCluster(_MatchEnv):
     def __dealloc__(self):
         del self.thisptr
 
-    def compute(self, box, points, threshold, hard_r=False, registration=False,
-                global_search=False, env_nlist=None, nlist=None, r_max=None,
-                num_neighbors=None):
+    def compute(self, box, points, threshold, registration=False,
+                global_search=False, env_nlist=None, nlist=None,
+                query_args=None):
         R"""Determine clusters of particles with matching environments.
 
         Args:
@@ -609,22 +609,11 @@ cdef class EnvironmentCluster(_MatchEnv):
 
         cdef freud.locality.NeighborList nlist_
         cdef freud.locality.NeighborList env_nlist_
-        if hard_r:
-            nlist_ = freud.locality._make_default_nlist(
-                self.m_box, points, None, dict(r_max=r_max), nlist)
+        nlist_ = freud.locality._make_default_nlist(
+            self.m_box, points, None, query_args, nlist)
 
-            env_nlist_ = freud.locality._make_default_nlist(
-                self.m_box, points, None, dict(r_max=r_max), env_nlist)
-        else:
-            nlist_ = freud.locality._make_default_nlist(
-                self.m_box, points, None,
-                dict(num_neighbors=num_neighbors, r_guess=r_max),
-                nlist)
-
-            env_nlist_ = freud.locality._make_default_nlist(
-                self.m_box, points, None,
-                dict(num_neighbors=num_neighbors, r_guess=r_max),
-                env_nlist)
+        env_nlist_ = freud.locality._make_default_nlist(
+            self.m_box, points, None, query_args, env_nlist)
 
         self.thisptr.compute(
             dereference(b.thisptr), env_nlist_.get_ptr(), nlist_.get_ptr(),
@@ -713,7 +702,7 @@ cdef class EnvironmentMotifMatch(_MatchEnv):
             new freud._environment.EnvironmentMotifMatch()
 
     def compute(self, box, motif, points, threshold, registration=False,
-                nlist=None, r_max=None, num_neighbors=None):
+                nlist=None, query_args=None):
         R"""Determine clusters of particles that match the motif provided by
         motif.
 
@@ -748,7 +737,7 @@ cdef class EnvironmentMotifMatch(_MatchEnv):
         cdef freud.locality.NeighborList nlist_
         nlist_ = freud.locality._make_default_nlist(
             self.m_box, points, None,
-            dict(num_neighbors=num_neighbors, r_guess=r_max), nlist)
+            query_args, nlist)
 
         self.thisptr.compute(
             dereference(b.thisptr), nlist_.get_ptr(), <vec3[float]*>
@@ -805,7 +794,7 @@ cdef class _EnvironmentRMSDMinimizer(_MatchEnv):
             freud.util.arr_type_t.FLOAT)
 
     def compute(self, box, motif, points, registration=False, nlist=None,
-                r_max=None, num_neighbors=None):
+                query_args=None):
         R"""Rotate (if registration=True) and permute the environments of all
         particles to minimize their RMSD with respect to the motif provided by
         motif.
@@ -842,7 +831,7 @@ cdef class _EnvironmentRMSDMinimizer(_MatchEnv):
         cdef freud.locality.NeighborList nlist_
         nlist_ = freud.locality._make_default_nlist(
             self.m_box, points, None,
-            dict(num_neighbors=num_neighbors, r_guess=r_max), nlist)
+            query_args, nlist)
 
         self.thisptr.compute(
             dereference(b.thisptr), nlist_.get_ptr(), <vec3[float]*>

--- a/freud/environment.pyx
+++ b/freud/environment.pyx
@@ -501,7 +501,7 @@ def _isSimilar(box, ref_points, points, threshold, registration=False):
     return [np.asarray(l_points), vec_map]
 
 
-cdef class _MatchEnv(Compute):
+cdef class _MatchEnv(PairCompute):
     R"""Parent for environment matching methods.
 
     Args:
@@ -601,6 +601,7 @@ cdef class EnvironmentCluster(_MatchEnv):
         """
         cdef freud.locality.NeighborQuery nq = freud.locality._make_default_nq(
             box, points)
+        cdef freud.locality._QueryArgs qa = freud.locality._QueryArgs()
 
         self.m_box = box
 
@@ -619,7 +620,7 @@ cdef class EnvironmentCluster(_MatchEnv):
 
         self.thisptr.compute(
             nq.get_ptr(), env_nlist_.get_ptr(), nlist_.get_ptr(),
-            threshold, registration,
+            dereference(qa.thisptr), threshold, registration,
             global_search)
         return self
 
@@ -727,6 +728,7 @@ cdef class EnvironmentMotifMatch(_MatchEnv):
         """
         cdef freud.locality.NeighborQuery nq = freud.locality._make_default_nq(
             box, points)
+        cdef freud.locality._QueryArgs qa = freud.locality._QueryArgs()
         self.m_box = box
 
         points = freud.common.convert_array(points, shape=(None, 3))
@@ -743,7 +745,8 @@ cdef class EnvironmentMotifMatch(_MatchEnv):
             query_args, nlist)
 
         self.thisptr.compute(
-            nq.get_ptr(), nlist_.get_ptr(), <vec3[float]*>
+            nq.get_ptr(), nlist_.get_ptr(), dereference(qa.thisptr),
+            <vec3[float]*>
             <vec3[float]*> &l_motif[0, 0], nRef,
             threshold, registration)
 
@@ -822,6 +825,7 @@ cdef class _EnvironmentRMSDMinimizer(_MatchEnv):
         """
         cdef freud.locality.NeighborQuery nq = freud.locality._make_default_nq(
             box, points)
+        cdef freud.locality._QueryArgs qa = freud.locality._QueryArgs()
         self.m_box = box
 
         points = freud.common.convert_array(points, shape=(None, 3))
@@ -838,7 +842,8 @@ cdef class _EnvironmentRMSDMinimizer(_MatchEnv):
             query_args, nlist)
 
         self.thisptr.compute(
-            nq.get_ptr(), nlist_.get_ptr(), <vec3[float]*>
+            nq.get_ptr(), nlist_.get_ptr(), dereference(qa.thisptr),
+            <vec3[float]*>
             <vec3[float]*> &l_motif[0, 0], nRef,
             registration)
 

--- a/freud/environment.pyx
+++ b/freud/environment.pyx
@@ -682,7 +682,7 @@ cdef class MatchEnv(Compute):
                 nRef1, min_rmsd, registration)
         return [min_rmsd, np.asarray(l_points), results_map]
 
-    @Compute._computed_property
+    @property
     def clusters(self):
         return freud.util.make_managed_numpy_array(
             &self.thisptr.getClusters(),
@@ -701,17 +701,17 @@ cdef class MatchEnv(Compute):
         env = self.thisptr.getEnvironment(i)
         return np.asarray([[p.x, p.y, p.z] for p in env])
 
-    @Compute._computed_property
+    @property
     def tot_environment(self):
         return freud.util.make_managed_numpy_array(
             &self.thisptr.getTotEnvironment(),
             freud.util.arr_type_t.FLOAT, 3)
 
-    @Compute._computed_property
+    @property
     def num_particles(self):
         return self.thisptr.getNP()
 
-    @Compute._computed_property
+    @property
     def num_clusters(self):
         return self.thisptr.getNumClusters()
 

--- a/freud/environment.pyx
+++ b/freud/environment.pyx
@@ -537,12 +537,6 @@ cdef class _MatchEnv(Compute):
             &self.matchptr.getParticleEnvironments(),
             freud.util.arr_type_t.FLOAT, 3)
 
-    def __repr__(self):
-        return ("freud.environment.{cls}("
-                "r_max={r_max}, num_neighbors={num_neighbors})").format(
-                    cls=type(self).__name__,
-                    r_max=self.r_max, num_neighbors=self.num_neighbors)
-
 
 cdef class EnvironmentCluster(_MatchEnv):
     R"""Clusters particles according to whether their local environments match
@@ -683,6 +677,12 @@ cdef class EnvironmentCluster(_MatchEnv):
             return freud.plot.clusters_plot(
                 values, counts, num_clusters_to_plot=10, ax=ax)
 
+    def __repr__(self):
+        return ("freud.environment.{cls}("
+                "r_max={r_max}, num_neighbors={num_neighbors})").format(
+                    cls=type(self).__name__,
+                    r_max=self.r_max, num_neighbors=self.num_neighbors)
+
     def _repr_png_(self):
         import freud.plot
         try:
@@ -776,6 +776,12 @@ cdef class EnvironmentMotifMatch(_MatchEnv):
             &self.thisptr.getMatches(),
             freud.util.arr_type_t.BOOL)
 
+    def __repr__(self):
+        return ("freud.environment.{cls}("
+                "r_max={r_max}, num_neighbors={num_neighbors})").format(
+                    cls=type(self).__name__,
+                    r_max=self.r_max, num_neighbors=self.num_neighbors)
+
 
 cdef class _EnvironmentRMSDMinimizer(_MatchEnv):
     R"""Find linear transformations that map the environments of points onto a motif.
@@ -864,6 +870,12 @@ cdef class _EnvironmentRMSDMinimizer(_MatchEnv):
             registration)
 
         return self
+
+    def __repr__(self):
+        return ("freud.environment.{cls}("
+                "r_max={r_max}, num_neighbors={num_neighbors})").format(
+                    cls=type(self).__name__,
+                    r_max=self.r_max, num_neighbors=self.num_neighbors)
 
 
 cdef class AngularSeparationNeighbor(PairCompute):

--- a/freud/environment.pyx
+++ b/freud/environment.pyx
@@ -688,7 +688,6 @@ cdef class MatchEnv(Compute):
             &self.thisptr.getClusters(),
             freud.util.arr_type_t.UNSIGNED_INT)
 
-    @Compute._computed_method
     def getEnvironment(self, i):
         R"""Returns the set of vectors defining the environment indexed by i.
 
@@ -722,7 +721,6 @@ cdef class MatchEnv(Compute):
                     cls=type(self).__name__, box=self.m_box.__repr__(),
                     r_max=self.r_max, num_neighbors=self.num_neighbors)
 
-    @Compute._computed_method
     def plot(self, ax=None):
         """Plot cluster distribution.
 

--- a/freud/environment.pyx
+++ b/freud/environment.pyx
@@ -563,8 +563,7 @@ cdef class EnvironmentCluster(_MatchEnv):
 
     def __cinit__(self, num_neighbors):
         self.thisptr = self.matchptr = \
-            new freud._environment.EnvironmentCluster(
-                num_neighbors)
+            new freud._environment.EnvironmentCluster()
 
         self.num_neighbors = num_neighbors
 
@@ -689,7 +688,12 @@ cdef class EnvironmentMotifMatch(_MatchEnv):
 
     In general, it is recommended to specify a number of neighbors rather than
     just a distance cutoff as part of your neighbor querying when performing
-    this computation since it can otherwise be very sensitive.
+    this computation since it can otherwise be very sensitive. Specifically, it
+    is highly recommended that you choose a number of neighbors that you
+    specify a number of neighbors query that requests at least as many
+    neighbors as the size of the motif you intend to test against. Otherwise,
+    you will struggle to match the motif. However, this is not currently
+    enforced (but we could add a warning to the compute...).
 
     Args:
         num_neighbors (unsigned int):
@@ -709,8 +713,7 @@ cdef class EnvironmentMotifMatch(_MatchEnv):
 
     def __cinit__(self, num_neighbors):
         self.thisptr = self.matchptr = \
-            new freud._environment.EnvironmentMotifMatch(
-                num_neighbors)
+            new freud._environment.EnvironmentMotifMatch()
 
         self.num_neighbors = num_neighbors
 
@@ -775,14 +778,14 @@ cdef class _EnvironmentRMSDMinimizer(_MatchEnv):
 
     In general, it is recommended to specify a number of neighbors rather than
     just a distance cutoff as part of your neighbor querying when performing
-    this computation since it can otherwise be very sensitive.
+    this computation since it can otherwise be very sensitive. Specifically, it
+    is highly recommended that you choose a number of neighbors that you
+    specify a number of neighbors query that requests at least as many
+    neighbors as the size of the motif you intend to test against. Otherwise,
+    you will struggle to match the motif. However, this is not currently
+    enforced (but we could add a warning to the compute...).
 
     Args:
-        box (:class:`freud.box.Box`):
-            Simulation box.
-        r_max (float):
-            Cutoff radius for cell list and clustering algorithm. Values near
-            the first minimum of the RDF are recommended.
         num_neighbors (unsigned int):
             Number of nearest neighbors taken to define the local environment
             of any given particle.
@@ -800,8 +803,7 @@ cdef class _EnvironmentRMSDMinimizer(_MatchEnv):
 
     def __cinit__(self, num_neighbors):
         self.thisptr = self.matchptr = \
-            new freud._environment.EnvironmentRMSDMinimizer(
-                num_neighbors)
+            new freud._environment.EnvironmentRMSDMinimizer()
 
         self.num_neighbors = num_neighbors
 

--- a/freud/environment.pyx
+++ b/freud/environment.pyx
@@ -603,13 +603,13 @@ cdef class MatchEnv(Compute):
             registration, global_search)
         return self
 
-    def matchMotif(self, points, ref_points, threshold, registration=False,
+    def matchMotif(self, motif, points, threshold, registration=False,
                    nlist=None):
         R"""Determine clusters of particles that match the motif provided by
-        ref_points.
+        motif.
 
         Args:
-            ref_points ((:math:`N_{particles}`, 3) :class:`numpy.ndarray`):
+            motif ((:math:`N_{particles}`, 3) :class:`numpy.ndarray`):
                 Vectors that make up the motif against which we are matching.
             points ((:math:`N_{particles}`, 3) :class:`numpy.ndarray`):
                 Particle positions.
@@ -626,12 +626,12 @@ cdef class MatchEnv(Compute):
                 :code:`None`).
         """
         points = freud.common.convert_array(points, shape=(None, 3))
-        ref_points = freud.common.convert_array(ref_points, shape=(None, 3))
+        motif = freud.common.convert_array(motif, shape=(None, 3))
 
         cdef const float[:, ::1] l_points = points
-        cdef const float[:, ::1] l_ref_points = ref_points
+        cdef const float[:, ::1] l_motif = motif
         cdef unsigned int nP = l_points.shape[0]
-        cdef unsigned int nRef = l_ref_points.shape[0]
+        cdef unsigned int nRef = l_motif.shape[0]
 
         cdef freud.locality.NeighborList nlist_
         nlist_ = freud.locality._make_default_nlist(
@@ -640,16 +640,16 @@ cdef class MatchEnv(Compute):
 
         self.thisptr.matchMotif(
             nlist_.get_ptr(), <vec3[float]*> &l_points[0, 0], nP,
-            <vec3[float]*> &l_ref_points[0, 0], nRef, threshold,
+            <vec3[float]*> &l_motif[0, 0], nRef, threshold,
             registration)
 
-    def minRMSDMotif(self, ref_points, points, registration=False, nlist=None):
+    def minRMSDMotif(self, motif, points, registration=False, nlist=None):
         R"""Rotate (if registration=True) and permute the environments of all
         particles to minimize their RMSD with respect to the motif provided by
-        ref_points.
+        motif.
 
         Args:
-            ref_points ((:math:`N_{particles}`, 3) :class:`numpy.ndarray`):
+            motif ((:math:`N_{particles}`, 3) :class:`numpy.ndarray`):
                 Vectors that make up the motif against which we are matching.
             points ((:math:`N_{particles}`, 3) :class:`numpy.ndarray`):
                 Particle positions.
@@ -667,14 +667,12 @@ cdef class MatchEnv(Compute):
 
         """
         points = freud.common.convert_array(points, shape=(None, 3))
-        ref_points = freud.common.convert_array(ref_points, shape=(None, 3))
+        motif = freud.common.convert_array(motif, shape=(None, 3))
 
-        cdef np.ndarray[float, ndim=1] l_points = np.ascontiguousarray(
-            points.flatten())
-        cdef np.ndarray[float, ndim=1] l_ref_points = np.ascontiguousarray(
-            ref_points.flatten())
+        cdef const float[:, ::1] l_points = points
+        cdef const float[:, ::1] l_motif = motif
         cdef unsigned int nP = l_points.shape[0]
-        cdef unsigned int nRef = l_ref_points.shape[0]
+        cdef unsigned int nRef = l_motif.shape[0]
 
         cdef freud.locality.NeighborList nlist_
         nlist_ = freud.locality._make_default_nlist(
@@ -682,8 +680,8 @@ cdef class MatchEnv(Compute):
             dict(num_neighbors=self.num_neighbors, r_guess=self.r_max), nlist)
 
         cdef vector[float] min_rmsd_vec = self.thisptr.minRMSDMotif(
-            nlist_.get_ptr(), <vec3[float]*> &l_points[0], nP,
-            <vec3[float]*> &l_ref_points[0], nRef, registration)
+            nlist_.get_ptr(), <vec3[float]*> &l_points[0, 0], nP,
+            <vec3[float]*> &l_motif[0, 0], nRef, registration)
 
         return min_rmsd_vec
 

--- a/freud/environment.pyx
+++ b/freud/environment.pyx
@@ -375,7 +375,7 @@ cdef class LocalDescriptors(PairCompute):
 
     @Compute._computed_property()
     def nlist(self):
-        return freud.locality.nlist_from_cnlist(self.thisptr.getNList())
+        return freud.locality._nlist_from_cnlist(self.thisptr.getNList())
 
     @Compute._computed_property()
     def sph(self):
@@ -490,18 +490,18 @@ cdef class MatchEnv(Compute):
         cdef freud.locality.NeighborList nlist_
         cdef freud.locality.NeighborList env_nlist_
         if hard_r:
-            nlist_ = freud.locality.make_default_nlist(
+            nlist_ = freud.locality._make_default_nlist(
                 self.m_box, points, None, dict(r_max=self.r_max), nlist)
 
-            env_nlist_ = freud.locality.make_default_nlist(
+            env_nlist_ = freud.locality._make_default_nlist(
                 self.m_box, points, None, dict(r_max=self.r_max), env_nlist)
         else:
-            nlist_ = freud.locality.make_default_nlist(
+            nlist_ = freud.locality._make_default_nlist(
                 self.m_box, points, None,
                 dict(num_neighbors=self.num_neighbors, r_guess=self.r_max),
                 nlist)
 
-            env_nlist_ = freud.locality.make_default_nlist(
+            env_nlist_ = freud.locality._make_default_nlist(
                 self.m_box, points, None,
                 dict(num_neighbors=self.num_neighbors, r_guess=self.r_max),
                 env_nlist)
@@ -546,7 +546,7 @@ cdef class MatchEnv(Compute):
         cdef unsigned int nRef = l_ref_points.shape[0]
 
         cdef freud.locality.NeighborList nlist_
-        nlist_ = freud.locality.make_default_nlist(
+        nlist_ = freud.locality._make_default_nlist(
             self.m_box, points, None,
             dict(num_neighbors=self.num_neighbors, r_guess=self.r_max), nlist)
 
@@ -590,7 +590,7 @@ cdef class MatchEnv(Compute):
         cdef unsigned int nRef = l_ref_points.shape[0]
 
         cdef freud.locality.NeighborList nlist_
-        nlist_ = freud.locality.make_default_nlist(
+        nlist_ = freud.locality._make_default_nlist(
             self.m_box, points, None,
             dict(num_neighbors=self.num_neighbors, r_guess=self.r_max), nlist)
 
@@ -862,7 +862,7 @@ cdef class AngularSeparationNeighbor(PairCompute):
 
     @Compute._computed_property()
     def nlist(self):
-        return freud.locality.nlist_from_cnlist(self.thisptr.getNList())
+        return freud.locality._nlist_from_cnlist(self.thisptr.getNList())
 
 
 cdef class AngularSeparationGlobal(Compute):
@@ -962,7 +962,7 @@ cdef class LocalBondProjection(PairCompute):
 
     @Compute._computed_property()
     def nlist(self):
-        return freud.locality.nlist_from_cnlist(self.thisptr.getNList())
+        return freud.locality._nlist_from_cnlist(self.thisptr.getNList())
 
     @Compute._compute()
     def compute(self, neighbor_query, orientations, proj_vecs,

--- a/freud/environment.pyx
+++ b/freud/environment.pyx
@@ -145,7 +145,6 @@ cdef class BondOrder(SpatialHistogram):
     def default_query_args(self):
         raise NotImplementedError('No default query arguments for BondOrder.')
 
-    @Compute._compute
     def accumulate(self, neighbor_query, orientations, query_points=None,
                    query_orientations=None, neighbors=None):
         R"""Calculates the correlation function and adds to the current
@@ -209,12 +208,10 @@ cdef class BondOrder(SpatialHistogram):
     def box(self):
         return freud.box.BoxFromCPP(self.thisptr.getBox())
 
-    @Compute._reset
     def reset(self):
         R"""Resets the values of the bond order in memory."""
         self.thisptr.reset()
 
-    @Compute._compute
     def compute(self, neighbor_query, orientations, query_points=None,
                 query_orientations=None, neighbors=None):
         R"""Calculates the bond order histogram. Will overwrite the current
@@ -319,7 +316,6 @@ cdef class LocalDescriptors(PairCompute):
     def __dealloc__(self):
         del self.thisptr
 
-    @Compute._compute
     def compute(self, neighbor_query, query_points=None, orientations=None,
                 neighbors=None):
         R"""Calculates the local descriptors of bonds from a set of source
@@ -451,7 +447,6 @@ cdef class MatchEnv(Compute):
     def __dealloc__(self):
         del self.thisptr
 
-    @Compute._compute
     def cluster(self, points, threshold, hard_r=False, registration=False,
                 global_search=False, env_nlist=None, nlist=None):
         R"""Determine clusters of particles with matching environments.
@@ -512,7 +507,6 @@ cdef class MatchEnv(Compute):
             registration, global_search)
         return self
 
-    @Compute._compute
     def matchMotif(self, points, ref_points, threshold, registration=False,
                    nlist=None):
         R"""Determine clusters of particles that match the motif provided by
@@ -555,7 +549,6 @@ cdef class MatchEnv(Compute):
             <vec3[float]*> &l_ref_points[0], nRef, threshold,
             registration)
 
-    @Compute._compute
     def minRMSDMotif(self, ref_points, points, registration=False, nlist=None):
         R"""Rotate (if registration=True) and permute the environments of all
         particles to minimize their RMSD with respect to the motif provided by
@@ -778,7 +771,6 @@ cdef class AngularSeparationNeighbor(PairCompute):
     def __dealloc__(self):
         del self.thisptr
 
-    @Compute._compute
     def compute(self, neighbor_query, orientations, query_points=None,
                 query_orientations=None,
                 equiv_orientations=np.array([[1, 0, 0, 0]]),
@@ -881,7 +873,6 @@ cdef class AngularSeparationGlobal(Compute):
     def __dealloc__(self):
         del self.thisptr
 
-    @Compute._compute
     def compute(self, global_orientations,
                 orientations, equiv_orientations):
         R"""Calculates the minimum angles of separation between
@@ -964,7 +955,6 @@ cdef class LocalBondProjection(PairCompute):
     def nlist(self):
         return freud.locality._nlist_from_cnlist(self.thisptr.getNList())
 
-    @Compute._compute
     def compute(self, neighbor_query, orientations, proj_vecs,
                 query_points=None, equiv_orientations=np.array([[1, 0, 0, 0]]),
                 neighbors=None):

--- a/freud/environment.pyx
+++ b/freud/environment.pyx
@@ -628,10 +628,8 @@ cdef class MatchEnv(Compute):
         points = freud.common.convert_array(points, shape=(None, 3))
         ref_points = freud.common.convert_array(ref_points, shape=(None, 3))
 
-        cdef np.ndarray[float, ndim=1] l_points = np.ascontiguousarray(
-            points.flatten())
-        cdef np.ndarray[float, ndim=1] l_ref_points = np.ascontiguousarray(
-            ref_points.flatten())
+        cdef const float[:, ::1] l_points = points
+        cdef const float[:, ::1] l_ref_points = ref_points
         cdef unsigned int nP = l_points.shape[0]
         cdef unsigned int nRef = l_ref_points.shape[0]
 
@@ -641,8 +639,8 @@ cdef class MatchEnv(Compute):
             dict(num_neighbors=self.num_neighbors, r_guess=self.r_max), nlist)
 
         self.thisptr.matchMotif(
-            nlist_.get_ptr(), <vec3[float]*> &l_points[0], nP,
-            <vec3[float]*> &l_ref_points[0], nRef, threshold,
+            nlist_.get_ptr(), <vec3[float]*> &l_points[0, 0], nP,
+            <vec3[float]*> &l_ref_points[0, 0], nRef, threshold,
             registration)
 
     def minRMSDMotif(self, ref_points, points, registration=False, nlist=None):

--- a/freud/environment.pyx
+++ b/freud/environment.pyx
@@ -405,7 +405,7 @@ cdef class LocalDescriptors(PairCompute):
                     negative_m=self.negative_m, mode=self.mode)
 
 
-def minimizeRMSD(box, ref_points, points, registration=False):
+def _minimizeRMSD(box, ref_points, points, registration=False):
     R"""Get the somewhat-optimal RMSD between the set of vectors ref_points
     and the set of vectors points.
 
@@ -451,7 +451,7 @@ def minimizeRMSD(box, ref_points, points, registration=False):
     return [min_rmsd, np.asarray(l_points), results_map]
 
 
-def isSimilar(box, ref_points, points, r_max, threshold, registration=False):
+def _isSimilar(box, ref_points, points, r_max, threshold, registration=False):
     R"""Test if the motif provided by ref_points is similar to the motif
     provided by points.
 
@@ -777,7 +777,7 @@ cdef class EnvironmentMotifMatch(_MatchEnv):
             freud.util.arr_type_t.BOOL)
 
 
-cdef class EnvironmentRMSDMinimizer(_MatchEnv):
+cdef class _EnvironmentRMSDMinimizer(_MatchEnv):
     R"""Find linear transformations that map the environments of points onto a motif.
 
     In general, it is recommended to specify a number of neighbors rather than

--- a/freud/environment.pyx
+++ b/freud/environment.pyx
@@ -561,17 +561,16 @@ cdef class EnvironmentCluster(_MatchEnv):
 
     cdef freud._environment.EnvironmentCluster * thisptr
 
-    def __cinit__(self, num_neighbors):
+    def __cinit__(self):
         self.thisptr = self.matchptr = \
             new freud._environment.EnvironmentCluster()
-
-        self.num_neighbors = num_neighbors
 
     def __dealloc__(self):
         del self.thisptr
 
     def compute(self, box, points, threshold, hard_r=False, registration=False,
-                global_search=False, env_nlist=None, nlist=None, r_max=None):
+                global_search=False, env_nlist=None, nlist=None, r_max=None,
+                num_neighbors=None):
         R"""Determine clusters of particles with matching environments.
 
         Args:
@@ -619,12 +618,12 @@ cdef class EnvironmentCluster(_MatchEnv):
         else:
             nlist_ = freud.locality._make_default_nlist(
                 self.m_box, points, None,
-                dict(num_neighbors=self.num_neighbors, r_guess=r_max),
+                dict(num_neighbors=num_neighbors, r_guess=r_max),
                 nlist)
 
             env_nlist_ = freud.locality._make_default_nlist(
                 self.m_box, points, None,
-                dict(num_neighbors=self.num_neighbors, r_guess=r_max),
+                dict(num_neighbors=num_neighbors, r_guess=r_max),
                 env_nlist)
 
         self.thisptr.compute(
@@ -670,10 +669,8 @@ cdef class EnvironmentCluster(_MatchEnv):
                 values, counts, num_clusters_to_plot=10, ax=ax)
 
     def __repr__(self):
-        return ("freud.environment.{cls}("
-                "num_neighbors={num_neighbors})").format(
-                    cls=type(self).__name__,
-                    num_neighbors=self.num_neighbors)
+        return ("freud.environment.{cls}()").format(
+            cls=type(self).__name__)
 
     def _repr_png_(self):
         import freud.plot
@@ -711,14 +708,12 @@ cdef class EnvironmentMotifMatch(_MatchEnv):
 
     cdef freud._environment.EnvironmentMotifMatch * thisptr
 
-    def __cinit__(self, num_neighbors):
+    def __cinit__(self):
         self.thisptr = self.matchptr = \
             new freud._environment.EnvironmentMotifMatch()
 
-        self.num_neighbors = num_neighbors
-
     def compute(self, box, motif, points, threshold, registration=False,
-                nlist=None, r_max=None):
+                nlist=None, r_max=None, num_neighbors=None):
         R"""Determine clusters of particles that match the motif provided by
         motif.
 
@@ -753,7 +748,7 @@ cdef class EnvironmentMotifMatch(_MatchEnv):
         cdef freud.locality.NeighborList nlist_
         nlist_ = freud.locality._make_default_nlist(
             self.m_box, points, None,
-            dict(num_neighbors=self.num_neighbors, r_guess=r_max), nlist)
+            dict(num_neighbors=num_neighbors, r_guess=r_max), nlist)
 
         self.thisptr.compute(
             dereference(b.thisptr), nlist_.get_ptr(), <vec3[float]*>
@@ -767,10 +762,8 @@ cdef class EnvironmentMotifMatch(_MatchEnv):
             freud.util.arr_type_t.BOOL)
 
     def __repr__(self):
-        return ("freud.environment.{cls}("
-                "num_neighbors={num_neighbors})").format(
-                    cls=type(self).__name__,
-                    num_neighbors=self.num_neighbors)
+        return ("freud.environment.{cls}()").format(
+            cls=type(self).__name__)
 
 
 cdef class _EnvironmentRMSDMinimizer(_MatchEnv):
@@ -801,11 +794,9 @@ cdef class _EnvironmentRMSDMinimizer(_MatchEnv):
 
     cdef freud._environment.EnvironmentRMSDMinimizer * thisptr
 
-    def __cinit__(self, num_neighbors):
+    def __cinit__(self):
         self.thisptr = self.matchptr = \
             new freud._environment.EnvironmentRMSDMinimizer()
-
-        self.num_neighbors = num_neighbors
 
     @Compute._computed_property
     def rmsds(self):
@@ -814,7 +805,7 @@ cdef class _EnvironmentRMSDMinimizer(_MatchEnv):
             freud.util.arr_type_t.FLOAT)
 
     def compute(self, box, motif, points, registration=False, nlist=None,
-                r_max=None):
+                r_max=None, num_neighbors=None):
         R"""Rotate (if registration=True) and permute the environments of all
         particles to minimize their RMSD with respect to the motif provided by
         motif.
@@ -851,7 +842,7 @@ cdef class _EnvironmentRMSDMinimizer(_MatchEnv):
         cdef freud.locality.NeighborList nlist_
         nlist_ = freud.locality._make_default_nlist(
             self.m_box, points, None,
-            dict(num_neighbors=self.num_neighbors, r_guess=r_max), nlist)
+            dict(num_neighbors=num_neighbors, r_guess=r_max), nlist)
 
         self.thisptr.compute(
             dereference(b.thisptr), nlist_.get_ptr(), <vec3[float]*>
@@ -861,10 +852,8 @@ cdef class _EnvironmentRMSDMinimizer(_MatchEnv):
         return self
 
     def __repr__(self):
-        return ("freud.environment.{cls}("
-                "num_neighbors={num_neighbors})").format(
-                    cls=type(self).__name__,
-                    num_neighbors=self.num_neighbors)
+        return ("freud.environment.{cls}()").format(
+            cls=type(self).__name__)
 
 
 cdef class AngularSeparationNeighbor(PairCompute):

--- a/freud/environment.pyx
+++ b/freud/environment.pyx
@@ -507,12 +507,8 @@ cdef class _MatchEnv(PairCompute):
     R"""Parent for environment matching methods.
 
     Attributes:
-        particle_environments (:math:`\left(N_{particles}, N_{neighbors}, 3\right)` :class:`numpy.ndarray`):
-            All environments for all particles.
-        num_clusters (unsigned int):
-            The number of clusters.
-        clusters (:math:`\left(N_{particles}\right)` :class:`numpy.ndarray`):
-            The per-particle index indicating cluster membership.
+        point_environments (:math:`\left(N_{points}, N_{neighbors}, 3\right)` :class:`numpy.ndarray`):
+            All environments for all points.
     """  # noqa: E501
     cdef freud._environment.MatchEnv * matchptr
 
@@ -521,9 +517,9 @@ cdef class _MatchEnv(PairCompute):
         pass
 
     @Compute._computed_property
-    def particle_environments(self):
+    def point_environments(self):
         return freud.util.make_managed_numpy_array(
-            &self.matchptr.getParticleEnvironments(),
+            &self.matchptr.getPointEnvironments(),
             freud.util.arr_type_t.FLOAT, 3)
 
     def __repr__(self):
@@ -536,8 +532,8 @@ cdef class EnvironmentCluster(_MatchEnv):
     or not, according to various shape matching metrics.
 
     Attributes:
-        particle_environments (:math:`\left(N_{particles}, N_{neighbors}, 3\right)` :class:`numpy.ndarray`):
-            All environments for all particles.
+        point_environments (:math:`\left(N_{points}, N_{neighbors}, 3\right)` :class:`numpy.ndarray`):
+            All environments for all points.
         num_clusters (unsigned int):
             The number of clusters.
         clusters (:math:`\left(N_{particles}\right)` :class:`numpy.ndarray`):
@@ -670,8 +666,8 @@ cdef class EnvironmentMotifMatch(_MatchEnv):
     Attributes:
         matches (:math:`(N_p, )` :class:`numpy.ndarray`):
             A boolean array indicating whether each point matches the motif.
-        particle_environments (:math:`\left(N_{points}, N_{neighbors}, 3\right)` :class:`numpy.ndarray`):
-            The environments for all points.
+        point_environments (:math:`\left(N_{points}, N_{neighbors}, 3\right)` :class:`numpy.ndarray`):
+            All environments for all points.
     """  # noqa: E501
 
     cdef freud._environment.EnvironmentMotifMatch * thisptr
@@ -746,8 +742,8 @@ cdef class _EnvironmentRMSDMinimizer(_MatchEnv):
     Attributes:
         rmsds (:math:`(N_p, )` :class:`numpy.ndarray`):
             A boolean array of the RMSDs found for each point's environment.
-        particle_environments (:math:`\left(N_{points}, N_{neighbors}, 3\right)` :class:`numpy.ndarray`):
-            The environments for all points.
+        point_environments (:math:`\left(N_{points}, N_{neighbors}, 3\right)` :class:`numpy.ndarray`):
+            All environments for all points.
     """  # noqa: E501
 
     cdef freud._environment.EnvironmentRMSDMinimizer * thisptr

--- a/freud/environment.pyx
+++ b/freud/environment.pyx
@@ -657,18 +657,11 @@ cdef class EnvironmentCluster(_MatchEnv):
     def num_clusters(self):
         return self.thisptr.getNumClusters()
 
-    def getEnvironment(self, i):
-        R"""Returns the set of vectors defining the environment indexed by i.
-
-        Args:
-            i (unsigned int): Environment index.
-
-        Returns:
-            :math:`\left(N_{neighbors}, 3\right)` :class:`numpy.ndarray`:
-            The array of vectors.
-        """
-        env = self.thisptr.getEnvironment(i)
-        return np.asarray([[p.x, p.y, p.z] for p in env])
+    @Compute._computed_property
+    def cluster_environments(self):
+        envs = self.thisptr.getClusterEnvironments()
+        return [np.asarray([[p.x, p.y, p.z] for p in env])
+                for env in envs]
 
     def plot(self, ax=None):
         """Plot cluster distribution.
@@ -870,6 +863,7 @@ cdef class EnvironmentRMSDMinimizer(_MatchEnv):
             <vec3[float]*> &l_motif[0, 0], nRef, registration)
 
         return self
+
 
 cdef class AngularSeparationNeighbor(PairCompute):
     R"""Calculates the minimum angles of separation between particles and

--- a/freud/environment.pyx
+++ b/freud/environment.pyx
@@ -177,7 +177,7 @@ cdef class BondOrder(SpatialHistogram):
             unsigned int num_query_points
 
         nq, nlist, qargs, l_query_points, num_query_points = \
-            self.preprocess_arguments(neighbor_query, query_points, neighbors)
+            self._preprocess_arguments(neighbor_query, query_points, neighbors)
         if query_orientations is None:
             query_orientations = orientations
 
@@ -345,7 +345,7 @@ cdef class LocalDescriptors(PairCompute):
             unsigned int num_query_points
 
         nq, nlist, qargs, l_query_points, num_query_points = \
-            self.preprocess_arguments(neighbor_query, query_points, neighbors)
+            self._preprocess_arguments(neighbor_query, query_points, neighbors)
 
         # The l_orientations_ptr is only used for 'particle_local' mode.
         cdef const float[:, ::1] l_orientations
@@ -811,7 +811,7 @@ cdef class AngularSeparationNeighbor(PairCompute):
             unsigned int num_query_points
 
         nq, nlist, qargs, l_query_points, num_query_points = \
-            self.preprocess_arguments(neighbor_query, query_points, neighbors)
+            self._preprocess_arguments(neighbor_query, query_points, neighbors)
 
         orientations = freud.common.convert_array(
             orientations, shape=(nq.points.shape[0], 4))
@@ -1000,7 +1000,7 @@ cdef class LocalBondProjection(PairCompute):
             unsigned int num_query_points
 
         nq, nlist, qargs, l_query_points, num_query_points = \
-            self.preprocess_arguments(neighbor_query, query_points, neighbors)
+            self._preprocess_arguments(neighbor_query, query_points, neighbors)
 
         orientations = freud.common.convert_array(
             orientations, shape=(None, 4))

--- a/freud/interface.pyx
+++ b/freud/interface.pyx
@@ -68,8 +68,8 @@ cdef class InterfaceMeasure(Compute):
             query_points, shape=(None, 3))
 
         if nlist is None:
-            lc = freud.locality.LinkCell(b, self.r_max, points)
-            nlist = lc.query(query_points,
+            aq = freud.locality.AABBQuery(b, points)
+            nlist = aq.query(query_points,
                              dict(r_max=self.r_max)).toNeighborList()
         else:
             nlist = nlist.copy().filter_r(self.r_max)

--- a/freud/interface.pyx
+++ b/freud/interface.pyx
@@ -49,7 +49,7 @@ cdef class InterfaceMeasure(Compute):
         self._point_ids = np.empty(0, dtype=np.uint32)
         self._query_point_ids = np.empty(0, dtype=np.uint32)
 
-    @Compute._compute()
+    @Compute._compute
     def compute(self, box, points, query_points, nlist=None):
         R"""Compute the particles at the interface between the two given sets of
         points.
@@ -78,19 +78,19 @@ cdef class InterfaceMeasure(Compute):
         self._query_point_ids = np.unique(nlist.query_point_indices)
         return self
 
-    @Compute._computed_property()
+    @Compute._computed_property
     def point_count(self):
         return len(self._point_ids)
 
-    @Compute._computed_property()
+    @Compute._computed_property
     def point_ids(self):
         return np.asarray(self._point_ids)
 
-    @Compute._computed_property()
+    @Compute._computed_property
     def query_point_count(self):
         return len(self._query_point_ids)
 
-    @Compute._computed_property()
+    @Compute._computed_property
     def query_point_ids(self):
         return np.asarray(self._query_point_ids)
 

--- a/freud/interface.pyx
+++ b/freud/interface.pyx
@@ -49,7 +49,6 @@ cdef class InterfaceMeasure(Compute):
         self._point_ids = np.empty(0, dtype=np.uint32)
         self._query_point_ids = np.empty(0, dtype=np.uint32)
 
-    @Compute._compute
     def compute(self, box, points, query_points, nlist=None):
         R"""Compute the particles at the interface between the two given sets of
         points.

--- a/freud/locality.pxd
+++ b/freud/locality.pxd
@@ -10,7 +10,7 @@ from freud.common cimport Compute
 cimport freud._locality
 cimport freud.box
 
-cdef NeighborList nlist_from_cnlist(freud._locality.NeighborList *c_nlist)
+cdef NeighborList _nlist_from_cnlist(freud._locality.NeighborList *c_nlist)
 
 cdef class NeighborQueryResult:
     cdef NeighborQuery nq

--- a/freud/locality.pyx
+++ b/freud/locality.pyx
@@ -1093,7 +1093,7 @@ cdef class _Voronoi:
     def __str__(self):
         return repr(self)
 
-    @Compute._computed_method()
+    @Compute._computed_method
     def plot(self, ax=None):
         """Plot Voronoi diagram.
 
@@ -1223,11 +1223,11 @@ cdef class SpatialHistogram(PairCompute):
     def default_query_args(self):
         return dict(mode="ball", r_max=self.r_max)
 
-    @Compute._computed_property()
+    @Compute._computed_property
     def box(self):
         return freud.box.BoxFromCPP(self.histptr.getBox())
 
-    @Compute._computed_property()
+    @Compute._computed_property
     def bin_counts(self):
         return freud.util.make_managed_numpy_array(
             &self.histptr.getBinCounts(),

--- a/freud/locality.pyx
+++ b/freud/locality.pyx
@@ -787,16 +787,16 @@ cdef class LinkCell(NeighborQuery):
        dens.compute(box, positions, nlist=lc.nlist)
     """
 
-    def __cinit__(self, box, cell_width, points):
+    def __cinit__(self, box, points, cell_width=0):
         self._box = freud.common.convert_box(box)
         cdef const float[:, ::1] l_points
         self.points = freud.common.convert_array(
             points, shape=(None, 3)).copy()
         l_points = self.points
         self.thisptr = self.nqptr = new freud._locality.LinkCell(
-            dereference(self._box.thisptr), float(cell_width),
+            dereference(self._box.thisptr),
             <vec3[float]*> &l_points[0, 0],
-            self.points.shape[0])
+            self.points.shape[0], cell_width)
 
     def __dealloc__(self):
         del self.thisptr

--- a/freud/locality.pyx
+++ b/freud/locality.pyx
@@ -1258,7 +1258,6 @@ cdef class SpatialHistogram(PairCompute):
     def nbins(self):
         return list(self.histptr.getAxisSizes())
 
-    @Compute._reset
     def reset(self):
         R"""Resets the values of RDF in memory."""
         self.histptr.reset()

--- a/freud/locality.pyx
+++ b/freud/locality.pyx
@@ -526,7 +526,7 @@ cdef class NeighborList:
         """  # noqa E501
         filt = np.ascontiguousarray(filt, dtype=np.bool)
         cdef np.ndarray[np.uint8_t, ndim=1, cast=True] filt_c = filt
-        cdef cbool * filt_ptr = <cbool*> filt_c.data
+        cdef cbool * filt_ptr = <cbool*> &filt_c[0]
         self.thisptr.filter(filt_ptr)
         return self
 

--- a/freud/locality.pyx
+++ b/freud/locality.pyx
@@ -1093,7 +1093,6 @@ cdef class _Voronoi:
     def __str__(self):
         return repr(self)
 
-    @Compute._computed_method
     def plot(self, ax=None):
         """Plot Voronoi diagram.
 

--- a/freud/locality.pyx
+++ b/freud/locality.pyx
@@ -1130,8 +1130,8 @@ cdef class PairCompute(Compute):
     well as dealing with boxes and query arguments.
     """
 
-    def preprocess_arguments(self, neighbor_query, query_points=None,
-                             neighbors=None, dimensions=None):
+    def _preprocess_arguments(self, neighbor_query, query_points=None,
+                              neighbors=None, dimensions=None):
         """Process standard compute arguments into freud's internal types by
         calling all the required internal functions.
 

--- a/freud/locality.pyx
+++ b/freud/locality.pyx
@@ -1176,6 +1176,18 @@ cdef class PairCompute(Compute):
         cdef NeighborList nlist
         cdef _QueryArgs qargs
 
+        nlist, qargs = self._resolve_neighbors(neighbors, query_points)
+
+        if query_points is None:
+            query_points = nq.points
+        else:
+            query_points = freud.common.convert_array(
+                query_points, shape=(None, 3))
+        cdef const float[:, ::1] l_query_points = query_points
+        cdef unsigned int num_query_points = l_query_points.shape[0]
+        return (nq, nlist, qargs, l_query_points, num_query_points)
+
+    def _resolve_neighbors(self, neighbors, query_points=None):
         if type(neighbors) == NeighborList:
             nlist = neighbors
             qargs = _QueryArgs()
@@ -1191,15 +1203,7 @@ cdef class PairCompute(Compute):
                 nlist = NeighborList(True)
             except NotImplementedError:
                 raise
-
-        if query_points is None:
-            query_points = nq.points
-        else:
-            query_points = freud.common.convert_array(
-                query_points, shape=(None, 3))
-        cdef const float[:, ::1] l_query_points = query_points
-        cdef unsigned int num_query_points = l_query_points.shape[0]
-        return (nq, nlist, qargs, l_query_points, num_query_points)
+        return nlist, qargs
 
     @property
     def default_query_args(self):

--- a/freud/locality.pyx
+++ b/freud/locality.pyx
@@ -232,7 +232,7 @@ cdef class NeighborQueryResult:
 
         cdef freud._locality.NeighborList *cnlist = dereference(
             iterator).toNeighborList()
-        cdef NeighborList nl = nlist_from_cnlist(cnlist)
+        cdef NeighborList nl = _nlist_from_cnlist(cnlist)
         # Explicitly manage a manually created nlist so that it will be
         # deleted when the Python object is.
         nl._managed = True
@@ -555,7 +555,7 @@ cdef class NeighborList:
         return self
 
 
-cdef NeighborList nlist_from_cnlist(freud._locality.NeighborList *c_nlist):
+cdef NeighborList _nlist_from_cnlist(freud._locality.NeighborList *c_nlist):
     """Create a Python NeighborList object that points to an existing C++
     NeighborList object.
 
@@ -574,7 +574,7 @@ cdef NeighborList nlist_from_cnlist(freud._locality.NeighborList *c_nlist):
     return result
 
 
-def make_default_nq(box, points):
+def _make_default_nq(box, points):
     R"""Helper function to return a NeighborQuery object.
 
     Currently the resolution for NeighborQuery objects is such that if Python
@@ -607,7 +607,7 @@ def make_default_nq(box, points):
     return rp
 
 
-def make_default_nlist(box, points, query_points, query_args, nlist=None):
+def _make_default_nlist(box, points, query_points, query_args, nlist=None):
     R"""Helper function to return a neighbor list object if is given, or to
     construct one using AABBQuery if it is not.
 
@@ -1007,7 +1007,7 @@ cdef class _Voronoi:
             <int*> &expanded_ids[0], <vec3[double]*> &expanded_points[0, 0],
             <int*> &ridge_vertex_indices[0])
 
-        self._nlist = nlist_from_cnlist(self.thisptr.getNeighborList())
+        self._nlist = _nlist_from_cnlist(self.thisptr.getNeighborList())
 
         # Construct a list of polytope vertices
         self._polytopes = list()

--- a/freud/msd.pyx
+++ b/freud/msd.pyx
@@ -164,7 +164,7 @@ cdef class MSD(Compute):
             raise ValueError("Invalid mode")
         self.mode = mode
 
-    @Compute._compute()
+    @Compute._compute
     def accumulate(self, positions, images=None):
         """Calculate the MSD for the positions provided and add to the existing
         per-particle data.
@@ -232,7 +232,7 @@ cdef class MSD(Compute):
     def box(self):
         return self._box
 
-    @Compute._computed_property()
+    @Compute._computed_property
     def msd(self):
         return np.concatenate(self.particle_msd, axis=1).mean(axis=-1)
 
@@ -242,7 +242,7 @@ cdef class MSD(Compute):
         the last call to compute)."""
         self.particle_msd = []
 
-    @Compute._compute()
+    @Compute._compute
     def compute(self, positions, images=None):
         """Calculate the MSD for the positions provided.
 
@@ -265,7 +265,7 @@ cdef class MSD(Compute):
         return "freud.msd.{cls}(box={box}, mode={mode})".format(
             cls=type(self).__name__, box=self._box, mode=repr(self.mode))
 
-    @Compute._computed_method()
+    @Compute._computed_method
     def plot(self, ax=None):
         """Plot MSD.
 

--- a/freud/msd.pyx
+++ b/freud/msd.pyx
@@ -262,7 +262,6 @@ cdef class MSD(Compute):
         return "freud.msd.{cls}(box={box}, mode={mode})".format(
             cls=type(self).__name__, box=self._box, mode=repr(self.mode))
 
-    @Compute._computed_method
     def plot(self, ax=None):
         """Plot MSD.
 

--- a/freud/msd.pyx
+++ b/freud/msd.pyx
@@ -164,7 +164,6 @@ cdef class MSD(Compute):
             raise ValueError("Invalid mode")
         self.mode = mode
 
-    @Compute._compute
     def accumulate(self, positions, images=None):
         """Calculate the MSD for the positions provided and add to the existing
         per-particle data.
@@ -236,13 +235,11 @@ cdef class MSD(Compute):
     def msd(self):
         return np.concatenate(self.particle_msd, axis=1).mean(axis=-1)
 
-    @Compute._reset
     def reset(self):
         R"""Clears the stored MSD values from previous calls to accumulate (or
         the last call to compute)."""
         self.particle_msd = []
 
-    @Compute._compute
     def compute(self, positions, images=None):
         """Calculate the MSD for the positions provided.
 

--- a/freud/order.pyx
+++ b/freud/order.pyx
@@ -322,7 +322,7 @@ cdef class Hexatic(PairCompute):
             unsigned int num_query_points
 
         nq, nlist, qargs, l_query_points, num_query_points = \
-            self.preprocess_arguments(neighbor_query, neighbors=neighbors)
+            self._preprocess_arguments(neighbor_query, neighbors=neighbors)
         self.thisptr.compute(nlist.get_ptr(),
                              nq.get_ptr(), dereference(qargs.thisptr))
         return self
@@ -389,7 +389,7 @@ cdef class Translational(PairCompute):
             unsigned int num_query_points
 
         nq, nlist, qargs, l_query_points, num_query_points = \
-            self.preprocess_arguments(neighbor_query, neighbors=neighbors)
+            self._preprocess_arguments(neighbor_query, neighbors=neighbors)
 
         self.thisptr.compute(nlist.get_ptr(),
                              nq.get_ptr(), dereference(qargs.thisptr))
@@ -534,7 +534,7 @@ cdef class Steinhardt(PairCompute):
             unsigned int num_query_points
 
         nq, nlist, qargs, l_query_points, num_query_points = \
-            self.preprocess_arguments(neighbor_query, neighbors=neighbors)
+            self._preprocess_arguments(neighbor_query, neighbors=neighbors)
 
         self.thisptr.compute(nlist.get_ptr(),
                              nq.get_ptr(),
@@ -673,7 +673,7 @@ cdef class SolidLiquid(PairCompute):
             unsigned int num_query_points
 
         nq, nlist, qargs, l_query_points, num_query_points = \
-            self.preprocess_arguments(neighbor_query, neighbors=neighbors)
+            self._preprocess_arguments(neighbor_query, neighbors=neighbors)
         self.thisptr.compute(nlist.get_ptr(),
                              nq.get_ptr(),
                              dereference(qargs.thisptr))

--- a/freud/order.pyx
+++ b/freud/order.pyx
@@ -550,7 +550,6 @@ cdef class Steinhardt(PairCompute):
                     Wl=self.Wl,
                     weighted=self.weighted)
 
-    @Compute._computed_method
     def plot(self, ax=None):
         """Plot order parameter distribution.
 
@@ -734,7 +733,6 @@ cdef class SolidLiquid(PairCompute):
                     S_threshold=self.S_threshold,
                     normalize_Q=self.normalize_Q)
 
-    @Compute._computed_method
     def plot(self, ax=None):
         """Plot solid-like cluster distribution.
 

--- a/freud/order.pyx
+++ b/freud/order.pyx
@@ -722,7 +722,7 @@ cdef class SolidLiquid(PairCompute):
 
     @Compute._computed_property()
     def nlist(self):
-        return freud.locality.nlist_from_cnlist(self.thisptr.getNList())
+        return freud.locality._nlist_from_cnlist(self.thisptr.getNList())
 
     @Compute._computed_property()
     def num_connections(self):

--- a/freud/order.pyx
+++ b/freud/order.pyx
@@ -104,7 +104,6 @@ cdef class Cubatic(Compute):
     def __dealloc__(self):
         del self.thisptr
 
-    @Compute._compute
     def compute(self, orientations):
         R"""Calculates the per-particle and global order parameter.
 
@@ -211,7 +210,6 @@ cdef class Nematic(Compute):
     def __dealloc__(self):
         del self.thisptr
 
-    @Compute._compute
     def compute(self, orientations):
         R"""Calculates the per-particle and global order parameter.
 
@@ -301,7 +299,6 @@ cdef class Hexatic(PairCompute):
     def __dealloc__(self):
         del self.thisptr
 
-    @Compute._compute
     def compute(self, neighbor_query, neighbors=None):
         R"""Calculates the correlation function and adds to the current
         histogram.
@@ -370,7 +367,6 @@ cdef class Translational(PairCompute):
     def __dealloc__(self):
         del self.thisptr
 
-    @Compute._compute
     def compute(self, neighbor_query, neighbors=None):
         R"""Calculates the local descriptors.
 
@@ -518,7 +514,6 @@ cdef class Steinhardt(PairCompute):
             &self.thisptr.getQl(),
             freud.util.arr_type_t.FLOAT)
 
-    @Compute._compute
     def compute(self, neighbor_query, neighbors=None):
         R"""Compute the order parameter.
 
@@ -658,7 +653,6 @@ cdef class SolidLiquid(PairCompute):
     def __dealloc__(self):
         del self.thisptr
 
-    @Compute._compute
     def compute(self, neighbor_query, neighbors=None):
         R"""Compute the order parameter.
 
@@ -808,7 +802,6 @@ cdef class RotationalAutocorrelation(Compute):
     def __dealloc__(self):
         del self.thisptr
 
-    @Compute._compute
     def compute(self, ref_orientations, orientations):
         """Calculates the rotational autocorrelation function for a single frame.
 

--- a/freud/order.pyx
+++ b/freud/order.pyx
@@ -104,7 +104,7 @@ cdef class Cubatic(Compute):
     def __dealloc__(self):
         del self.thisptr
 
-    @Compute._compute()
+    @Compute._compute
     def compute(self, orientations):
         R"""Calculates the per-particle and global order parameter.
 
@@ -138,28 +138,28 @@ cdef class Cubatic(Compute):
     def seed(self):
         return self.thisptr.getSeed()
 
-    @Compute._computed_property()
+    @Compute._computed_property
     def order(self):
         return self.thisptr.getCubaticOrderParameter()
 
-    @Compute._computed_property()
+    @Compute._computed_property
     def orientation(self):
         cdef quat[float] q = self.thisptr.getCubaticOrientation()
         return np.asarray([q.s, q.v.x, q.v.y, q.v.z], dtype=np.float32)
 
-    @Compute._computed_property()
+    @Compute._computed_property
     def particle_order(self):
         return freud.util.make_managed_numpy_array(
             &self.thisptr.getParticleOrderParameter(),
             freud.util.arr_type_t.FLOAT)
 
-    @Compute._computed_property()
+    @Compute._computed_property
     def global_tensor(self):
         return freud.util.make_managed_numpy_array(
             &self.thisptr.getGlobalTensor(),
             freud.util.arr_type_t.FLOAT)
 
-    @Compute._computed_property()
+    @Compute._computed_property
     def cubatic_tensor(self):
         return freud.util.make_managed_numpy_array(
             &self.thisptr.getCubaticTensor(),
@@ -211,7 +211,7 @@ cdef class Nematic(Compute):
     def __dealloc__(self):
         del self.thisptr
 
-    @Compute._compute()
+    @Compute._compute
     def compute(self, orientations):
         R"""Calculates the per-particle and global order parameter.
 
@@ -229,22 +229,22 @@ cdef class Nematic(Compute):
                              num_particles)
         return self
 
-    @Compute._computed_property()
+    @Compute._computed_property
     def order(self):
         return self.thisptr.getNematicOrderParameter()
 
-    @Compute._computed_property()
+    @Compute._computed_property
     def director(self):
         cdef vec3[float] n = self.thisptr.getNematicDirector()
         return np.asarray([n.x, n.y, n.z], dtype=np.float32)
 
-    @Compute._computed_property()
+    @Compute._computed_property
     def particle_tensor(self):
         return freud.util.make_managed_numpy_array(
             &self.thisptr.getParticleTensor(),
             freud.util.arr_type_t.FLOAT)
 
-    @Compute._computed_property()
+    @Compute._computed_property
     def nematic_tensor(self):
         return freud.util.make_managed_numpy_array(
             &self.thisptr.getNematicTensor(),
@@ -301,7 +301,7 @@ cdef class Hexatic(PairCompute):
     def __dealloc__(self):
         del self.thisptr
 
-    @Compute._compute()
+    @Compute._compute
     def compute(self, neighbor_query, neighbors=None):
         R"""Calculates the correlation function and adds to the current
         histogram.
@@ -334,7 +334,7 @@ cdef class Hexatic(PairCompute):
     def default_query_args(self):
         return dict(mode="nearest", num_neighbors=self.k)
 
-    @Compute._computed_property()
+    @Compute._computed_property
     def order(self):
         return freud.util.make_managed_numpy_array(
             &self.thisptr.getOrder(),
@@ -370,7 +370,7 @@ cdef class Translational(PairCompute):
     def __dealloc__(self):
         del self.thisptr
 
-    @Compute._compute()
+    @Compute._compute
     def compute(self, neighbor_query, neighbors=None):
         R"""Calculates the local descriptors.
 
@@ -403,7 +403,7 @@ cdef class Translational(PairCompute):
     def default_query_args(self):
         return dict(mode="nearest", num_neighbors=int(self.k))
 
-    @Compute._computed_property()
+    @Compute._computed_property
     def order(self):
         return freud.util.make_managed_numpy_array(
             &self.thisptr.getOrder(),
@@ -502,23 +502,23 @@ cdef class Steinhardt(PairCompute):
     def l(self):  # noqa: E743
         return self.thisptr.getL()
 
-    @Compute._computed_property()
+    @Compute._computed_property
     def norm(self):
         return self.thisptr.getNorm()
 
-    @Compute._computed_property()
+    @Compute._computed_property
     def order(self):
         return freud.util.make_managed_numpy_array(
             &self.thisptr.getOrder(),
             freud.util.arr_type_t.FLOAT)
 
-    @Compute._computed_property()
+    @Compute._computed_property
     def Ql(self):
         return freud.util.make_managed_numpy_array(
             &self.thisptr.getQl(),
             freud.util.arr_type_t.FLOAT)
 
-    @Compute._compute()
+    @Compute._compute
     def compute(self, neighbor_query, neighbors=None):
         R"""Compute the order parameter.
 
@@ -555,7 +555,7 @@ cdef class Steinhardt(PairCompute):
                     Wl=self.Wl,
                     weighted=self.weighted)
 
-    @Compute._computed_method()
+    @Compute._computed_method
     def plot(self, ax=None):
         """Plot order parameter distribution.
 
@@ -658,7 +658,7 @@ cdef class SolidLiquid(PairCompute):
     def __dealloc__(self):
         del self.thisptr
 
-    @Compute._compute()
+    @Compute._compute
     def compute(self, neighbor_query, neighbors=None):
         R"""Compute the order parameter.
 
@@ -700,31 +700,31 @@ cdef class SolidLiquid(PairCompute):
     def normalize_Q(self):
         return self.thisptr.getNormalizeQ()
 
-    @Compute._computed_property()
+    @Compute._computed_property
     def cluster_idx(self):
         return freud.util.make_managed_numpy_array(
             &self.thisptr.getClusterIdx(),
             freud.util.arr_type_t.UNSIGNED_INT)
 
-    @Compute._computed_property()
+    @Compute._computed_property
     def Ql_ij(self):
         return freud.util.make_managed_numpy_array(
             &self.thisptr.getQlij(),
             freud.util.arr_type_t.FLOAT)
 
-    @Compute._computed_property()
+    @Compute._computed_property
     def cluster_sizes(self):
         return np.asarray(self.thisptr.getClusterSizes())
 
-    @Compute._computed_property()
+    @Compute._computed_property
     def largest_cluster_size(self):
         return self.thisptr.getLargestClusterSize()
 
-    @Compute._computed_property()
+    @Compute._computed_property
     def nlist(self):
         return freud.locality._nlist_from_cnlist(self.thisptr.getNList())
 
-    @Compute._computed_property()
+    @Compute._computed_property
     def num_connections(self):
         return freud.util.make_managed_numpy_array(
             &self.thisptr.getNumberOfConnections(),
@@ -740,7 +740,7 @@ cdef class SolidLiquid(PairCompute):
                     S_threshold=self.S_threshold,
                     normalize_Q=self.normalize_Q)
 
-    @Compute._computed_method()
+    @Compute._computed_method
     def plot(self, ax=None):
         """Plot solid-like cluster distribution.
 
@@ -808,7 +808,7 @@ cdef class RotationalAutocorrelation(Compute):
     def __dealloc__(self):
         del self.thisptr
 
-    @Compute._compute()
+    @Compute._compute
     def compute(self, ref_orientations, orientations):
         """Calculates the rotational autocorrelation function for a single frame.
 
@@ -833,11 +833,11 @@ cdef class RotationalAutocorrelation(Compute):
             nP)
         return self
 
-    @Compute._computed_property()
+    @Compute._computed_property
     def order(self):
         return self.thisptr.getRotationalAutocorrelation()
 
-    @Compute._computed_property()
+    @Compute._computed_property
     def particle_order(self):
         return freud.util.make_managed_numpy_array(
             &self.thisptr.getRAArray(),

--- a/freud/pmft.pyx
+++ b/freud/pmft.pyx
@@ -116,14 +116,14 @@ cdef class _PMFT(SpatialHistogram):
         if type(self) is _PMFT:
             del self.pmftptr
 
-    @Compute._computed_property()
+    @Compute._computed_property
     def PMFT(self):
         with np.warnings.catch_warnings():
             np.warnings.filterwarnings('ignore')
             result = -np.log(np.copy(self.PCF))
         return result
 
-    @Compute._computed_property()
+    @Compute._computed_property
     def PCF(self):
         return freud.util.make_managed_numpy_array(
             &self.pmftptr.getPCF(),
@@ -172,7 +172,7 @@ cdef class PMFTR12(_PMFT):
         if type(self) is PMFTR12:
             del self.pmftr12ptr
 
-    @Compute._compute()
+    @Compute._compute
     def accumulate(self, neighbor_query, orientations, query_points=None,
                    query_orientations=None, neighbors=None):
         R"""Calculates the positional correlation function and adds to the
@@ -236,7 +236,7 @@ cdef class PMFTR12(_PMFT):
                                    dereference(qargs.thisptr))
         return self
 
-    @Compute._compute()
+    @Compute._compute
     def compute(self, neighbor_query, orientations, query_points=None,
                 query_orientations=None, neighbors=None):
         R"""Calculates the positional correlation function for the given points.
@@ -339,7 +339,7 @@ cdef class PMFTXYT(_PMFT):
         if type(self) is PMFTXYT:
             del self.pmftxytptr
 
-    @Compute._compute()
+    @Compute._compute
     def accumulate(self, neighbor_query, orientations, query_points=None,
                    query_orientations=None, neighbors=None):
         R"""Calculates the positional correlation function and adds to the
@@ -403,7 +403,7 @@ cdef class PMFTXYT(_PMFT):
                                    dereference(qargs.thisptr))
         return self
 
-    @Compute._compute()
+    @Compute._compute
     def compute(self, neighbor_query, orientations, query_points=None,
                 query_orientations=None, neighbors=None):
         R"""Calculates the positional correlation function for the given points.
@@ -505,7 +505,7 @@ cdef class PMFTXY2D(_PMFT):
         if type(self) is PMFTXY2D:
             del self.pmftxy2dptr
 
-    @Compute._compute()
+    @Compute._compute
     def accumulate(self, neighbor_query, orientations, query_points=None,
                    neighbors=None):
         R"""Calculates the positional correlation function and adds to the
@@ -553,7 +553,7 @@ cdef class PMFTXY2D(_PMFT):
                                     dereference(qargs.thisptr))
         return self
 
-    @Compute._compute()
+    @Compute._compute
     def compute(self, neighbor_query, orientations, query_points=None,
                 neighbors=None):
         R"""Calculates the positional correlation function for the given points.
@@ -583,14 +583,14 @@ cdef class PMFTXY2D(_PMFT):
         self.accumulate(neighbor_query, orientations, query_points, neighbors)
         return self
 
-    @Compute._computed_property()
+    @Compute._computed_property
     def bin_counts(self):
         # Currently this returns a 3D array that must be squeezed due to the
         # internal choices in the histogramming; this will be fixed in future
         # changes.
         return np.squeeze(super(PMFTXY2D, self).bin_counts)
 
-    @Compute._computed_property()
+    @Compute._computed_property
     def PCF(self):
         # Currently this returns a 3D array that must be squeezed due to the
         # internal choices in the histogramming; this will be fixed in future
@@ -613,7 +613,7 @@ cdef class PMFTXY2D(_PMFT):
         except AttributeError:
             return None
 
-    @Compute._computed_method()
+    @Compute._computed_method
     def plot(self, ax=None):
         """Plot PMFTXY2D.
 
@@ -694,7 +694,7 @@ cdef class PMFTXYZ(_PMFT):
         if type(self) is PMFTXYZ:
             del self.pmftxyzptr
 
-    @Compute._compute()
+    @Compute._compute
     def accumulate(self, neighbor_query, orientations, query_points=None,
                    face_orientations=None, neighbors=None):
         R"""Calculates the positional correlation function and adds to the
@@ -790,7 +790,7 @@ cdef class PMFTXYZ(_PMFT):
             num_faces, nlist.get_ptr(), dereference(qargs.thisptr))
         return self
 
-    @Compute._compute()
+    @Compute._compute
     def compute(self, neighbor_query, orientations, query_points=None,
                 face_orientations=None, neighbors=None):
         R"""Calculates the positional correlation function for the given points.

--- a/freud/pmft.pyx
+++ b/freud/pmft.pyx
@@ -214,7 +214,7 @@ cdef class PMFTR12(_PMFT):
             unsigned int num_query_points
 
         nq, nlist, qargs, l_query_points, num_query_points = \
-            self.preprocess_arguments(
+            self._preprocess_arguments(
                 neighbor_query, query_points, neighbors, dimensions=2)
 
         orientations = _gen_angle_array(
@@ -379,7 +379,7 @@ cdef class PMFTXYT(_PMFT):
             unsigned int num_query_points
 
         nq, nlist, qargs, l_query_points, num_query_points = \
-            self.preprocess_arguments(
+            self._preprocess_arguments(
                 neighbor_query, query_points, neighbors, dimensions=2)
 
         orientations = _gen_angle_array(
@@ -534,7 +534,7 @@ cdef class PMFTXY2D(_PMFT):
             unsigned int num_query_points
 
         nq, nlist, qargs, l_query_points, num_query_points = \
-            self.preprocess_arguments(
+            self._preprocess_arguments(
                 neighbor_query, query_points, neighbors, dimensions=2)
 
         orientations = _gen_angle_array(
@@ -722,7 +722,7 @@ cdef class PMFTXYZ(_PMFT):
             unsigned int num_query_points
 
         nq, nlist, qargs, l_query_points, num_query_points = \
-            self.preprocess_arguments(
+            self._preprocess_arguments(
                 neighbor_query, query_points, neighbors, dimensions=3)
         l_query_points = l_query_points - self.shiftvec.reshape(1, 3)
 

--- a/freud/pmft.pyx
+++ b/freud/pmft.pyx
@@ -172,7 +172,6 @@ cdef class PMFTR12(_PMFT):
         if type(self) is PMFTR12:
             del self.pmftr12ptr
 
-    @Compute._compute
     def accumulate(self, neighbor_query, orientations, query_points=None,
                    query_orientations=None, neighbors=None):
         R"""Calculates the positional correlation function and adds to the
@@ -236,7 +235,6 @@ cdef class PMFTR12(_PMFT):
                                    dereference(qargs.thisptr))
         return self
 
-    @Compute._compute
     def compute(self, neighbor_query, orientations, query_points=None,
                 query_orientations=None, neighbors=None):
         R"""Calculates the positional correlation function for the given points.
@@ -339,7 +337,6 @@ cdef class PMFTXYT(_PMFT):
         if type(self) is PMFTXYT:
             del self.pmftxytptr
 
-    @Compute._compute
     def accumulate(self, neighbor_query, orientations, query_points=None,
                    query_orientations=None, neighbors=None):
         R"""Calculates the positional correlation function and adds to the
@@ -403,7 +400,6 @@ cdef class PMFTXYT(_PMFT):
                                    dereference(qargs.thisptr))
         return self
 
-    @Compute._compute
     def compute(self, neighbor_query, orientations, query_points=None,
                 query_orientations=None, neighbors=None):
         R"""Calculates the positional correlation function for the given points.
@@ -505,7 +501,6 @@ cdef class PMFTXY2D(_PMFT):
         if type(self) is PMFTXY2D:
             del self.pmftxy2dptr
 
-    @Compute._compute
     def accumulate(self, neighbor_query, orientations, query_points=None,
                    neighbors=None):
         R"""Calculates the positional correlation function and adds to the
@@ -553,7 +548,6 @@ cdef class PMFTXY2D(_PMFT):
                                     dereference(qargs.thisptr))
         return self
 
-    @Compute._compute
     def compute(self, neighbor_query, orientations, query_points=None,
                 neighbors=None):
         R"""Calculates the positional correlation function for the given points.
@@ -694,7 +688,6 @@ cdef class PMFTXYZ(_PMFT):
         if type(self) is PMFTXYZ:
             del self.pmftxyzptr
 
-    @Compute._compute
     def accumulate(self, neighbor_query, orientations, query_points=None,
                    face_orientations=None, neighbors=None):
         R"""Calculates the positional correlation function and adds to the
@@ -790,7 +783,6 @@ cdef class PMFTXYZ(_PMFT):
             num_faces, nlist.get_ptr(), dereference(qargs.thisptr))
         return self
 
-    @Compute._compute
     def compute(self, neighbor_query, orientations, query_points=None,
                 face_orientations=None, neighbors=None):
         R"""Calculates the positional correlation function for the given points.

--- a/freud/pmft.pyx
+++ b/freud/pmft.pyx
@@ -607,7 +607,6 @@ cdef class PMFTXY2D(_PMFT):
         except AttributeError:
             return None
 
-    @Compute._computed_method
     def plot(self, ax=None):
         """Plot PMFTXY2D.
 

--- a/freud/util.pxd
+++ b/freud/util.pxd
@@ -11,6 +11,7 @@ from cpython cimport Py_INCREF
 from libcpp.complex cimport complex
 from cython.operator cimport dereference
 from libcpp.memory cimport shared_ptr
+from libcpp cimport bool
 
 cimport numpy as np
 
@@ -24,6 +25,7 @@ ctypedef enum arr_type_t:
     COMPLEX_FLOAT
     COMPLEX_DOUBLE
     UNSIGNED_INT
+    BOOL
 
 ctypedef union arr_ptr_t:
     const void *null_ptr
@@ -32,6 +34,7 @@ ctypedef union arr_ptr_t:
     const ManagedArray[float complex] *complex_float_ptr
     const ManagedArray[double complex] *complex_double_ptr
     const ManagedArray[uint] *uint_ptr
+    const ManagedArray[bool] *bool_ptr
 
 
 cdef class _ManagedArrayContainer:
@@ -73,6 +76,11 @@ cdef class _ManagedArrayContainer:
                                          element_size)
             obj.thisptr.uint_ptr = new const ManagedArray[uint](
                 dereference(<const ManagedArray[uint] *>array))
+        elif arr_type == arr_type_t.BOOL:
+            obj = _ManagedArrayContainer(arr_type, np.NPY_BOOL,
+                                         element_size)
+            obj.thisptr.bool_ptr = new const ManagedArray[bool](
+                dereference(<const ManagedArray[bool] *>array))
 
         return obj
 

--- a/freud/util.pyx
+++ b/freud/util.pyx
@@ -61,6 +61,8 @@ cdef class _ManagedArrayContainer:
             return tuple(self.thisptr.complex_float_ptr.shape())
         elif self.data_type == arr_type_t.COMPLEX_DOUBLE:
             return tuple(self.thisptr.complex_double_ptr.shape())
+        elif self.data_type == arr_type_t.BOOL:
+            return tuple(self.thisptr.bool_ptr.shape())
 
     @property
     def element_size(self):
@@ -77,6 +79,8 @@ cdef class _ManagedArrayContainer:
             del self.thisptr.complex_float_ptr
         elif self.data_type == arr_type_t.COMPLEX_DOUBLE:
             del self.thisptr.complex_double_ptr
+        elif self.data_type == arr_type_t.BOOL:
+            del self.thisptr.bool_ptr
 
     cdef void set_as_base(self, arr):
         """Sets the base of arr to be this object and increases the
@@ -96,6 +100,8 @@ cdef class _ManagedArrayContainer:
             return self.thisptr.complex_float_ptr.get()
         elif self.data_type == arr_type_t.COMPLEX_DOUBLE:
             return self.thisptr.complex_double_ptr.get()
+        elif self.data_type == arr_type_t.BOOL:
+            return self.thisptr.bool_ptr.get()
 
     def __array__(self):
         """Convert the underlying data array into a read-only numpy array.

--- a/setup.py
+++ b/setup.py
@@ -209,7 +209,10 @@ directives = {
     'embedsignature': True,
     'language_level': 3,
 }
-macros = []
+macros = [
+    ('NPY_NO_DEPRECATED_API', 'NPY_1_10_API_VERSION'),
+    ('VOROPP_VERBOSE', '1'),
+]
 
 # Decide whether or not to compile with coverage support
 if args.use_coverage:

--- a/tests/test_environment_LocalBondProjection.py
+++ b/tests/test_environment_LocalBondProjection.py
@@ -87,9 +87,10 @@ class TestLocalBondProjection(unittest.TestCase):
         ang = freud.environment.LocalBondProjection()
         ang.compute((box, points), ors, proj_vecs, neighbors=query_args)
 
-        dnlist = freud.locality.make_default_nlist(
-            box, points, None,
-            dict(num_neighbors=num_neighbors, r_guess=r_guess), None)
+        dnlist = freud.locality.AABBQuery(
+            box, points).query(
+                points, dict(num_neighbors=num_neighbors, r_guess=r_guess,
+                             exclude_ii=True))
         bonds = [(i[0], i[1]) for i in dnlist]
 
         # We will look at the bond between [1, 0, 0] as ref_point

--- a/tests/test_environment_MatchEnv.py
+++ b/tests/test_environment_MatchEnv.py
@@ -21,7 +21,7 @@ class TestCluster(unittest.TestCase):
         num_neighbors = 14
         threshold = 0.1
 
-        match = freud.environment.EnvironmentCluster(box, r_max, num_neighbors)
+        match = freud.environment.EnvironmentCluster(r_max, num_neighbors)
         with self.assertRaises(AttributeError):
             match.particle_environments
         with self.assertRaises(AttributeError):
@@ -33,7 +33,7 @@ class TestCluster(unittest.TestCase):
         with self.assertRaises(AttributeError):
             match.cluster_environments
 
-        match.compute(xyz, threshold)
+        match.compute(box, xyz, threshold)
 
         cluster_env = match.cluster_environments
 
@@ -70,8 +70,8 @@ class TestCluster(unittest.TestCase):
         num_neighbors = 6
         threshold = 0.1
 
-        match = freud.environment.EnvironmentCluster(box, r_max, num_neighbors)
-        match.compute(xyz, threshold)
+        match = freud.environment.EnvironmentCluster(r_max, num_neighbors)
+        match.compute(box, xyz, threshold)
 
         cluster_env = match.cluster_environments
 
@@ -111,8 +111,8 @@ class TestCluster(unittest.TestCase):
         num_neighbors = 14
         threshold = 0.1
 
-        match = freud.environment.EnvironmentCluster(box, r_max, num_neighbors)
-        match.compute(xyz, threshold, hard_r=False, registration=False)
+        match = freud.environment.EnvironmentCluster(r_max, num_neighbors)
+        match.compute(box, xyz, threshold, hard_r=False, registration=False)
 
         cluster_env = match.cluster_environments
 
@@ -150,8 +150,8 @@ class TestCluster(unittest.TestCase):
         num_neighbors = 14
         threshold = 0.1
 
-        match = freud.environment.EnvironmentCluster(box, r_max, num_neighbors)
-        match.compute(xyz, threshold, hard_r=True, registration=False)
+        match = freud.environment.EnvironmentCluster(r_max, num_neighbors)
+        match.compute(box, xyz, threshold, hard_r=True, registration=False)
         cluster_env = match.cluster_environments
 
         fn = os.path.join(self.test_folder, "bcc_env.npy")
@@ -200,8 +200,8 @@ class TestCluster(unittest.TestCase):
         L = np.max(xyz)*3.0
         box = freud.box.Box(L, L, L, 0, 0, 0)
 
-        match = freud.environment.EnvironmentCluster(box, r_max, num_neighbors)
-        match.compute(xyz, threshold, hard_r=False,
+        match = freud.environment.EnvironmentCluster(r_max, num_neighbors)
+        match.compute(box, xyz, threshold, hard_r=False,
                       registration=True, global_search=True)
         clusters = match.clusters
 
@@ -330,11 +330,9 @@ class TestCluster(unittest.TestCase):
             atol=1e-5)
 
     def test_repr(self):
-        L = 10
-        box = freud.box.Box.cube(L)
         r_max = 3.1
         num_neighbors = 14
-        match = freud.environment.EnvironmentCluster(box, r_max, num_neighbors)
+        match = freud.environment.EnvironmentCluster(r_max, num_neighbors)
         self.assertEqual(str(match), str(eval(repr(match))))
 
     def test_repr_png(self):
@@ -353,13 +351,13 @@ class TestCluster(unittest.TestCase):
         xyz = np.array(xyz, dtype=np.float32)
         xyz[:, 2] = 0
         xyz.flags['WRITEABLE'] = False
-        match = freud.environment.EnvironmentCluster(box, r_max, num_neighbors)
+        match = freud.environment.EnvironmentCluster(r_max, num_neighbors)
 
         with self.assertRaises(AttributeError):
             match.plot()
         self.assertEqual(match._repr_png_(), None)
 
-        match.compute(xyz, threshold)
+        match.compute(box, xyz, threshold)
         match._repr_png_()
 
 
@@ -373,8 +371,8 @@ class TestEnvironmentMotifMatch(unittest.TestCase):
 
         box = freud.box.Box.square(3)
         match = freud.environment.EnvironmentMotifMatch(
-            box, r_max, num_neighbors)
-        match.compute(motif, points, 0.1)
+            r_max, num_neighbors)
+        match.compute(box, motif, points, 0.1)
         matches = match.matches
 
         for i in range(len(motif)):

--- a/tests/test_environment_MatchEnv.py
+++ b/tests/test_environment_MatchEnv.py
@@ -35,7 +35,7 @@ class TestCluster(unittest.TestCase):
             match.cluster_environments
 
         query_args = dict(r_guess=r_max, num_neighbors=num_neighbors)
-        match.compute(box, xyz, threshold, query_args=query_args)
+        match.compute((box, xyz), threshold, neighbors=query_args)
 
         cluster_env = match.cluster_environments
 
@@ -75,7 +75,7 @@ class TestCluster(unittest.TestCase):
 
         match = freud.environment.EnvironmentCluster()
         query_args = dict(r_guess=r_max, num_neighbors=num_neighbors)
-        match.compute(box, xyz, threshold, query_args=query_args)
+        match.compute((box, xyz), threshold, neighbors=query_args)
 
         cluster_env = match.cluster_environments
 
@@ -118,8 +118,8 @@ class TestCluster(unittest.TestCase):
 
         match = freud.environment.EnvironmentCluster()
         query_args = dict(r_guess=r_max, num_neighbors=num_neighbors)
-        match.compute(box, xyz, threshold, registration=False,
-                      query_args=query_args)
+        match.compute((box, xyz), threshold, registration=False,
+                      neighbors=query_args)
 
         cluster_env = match.cluster_environments
 
@@ -160,8 +160,8 @@ class TestCluster(unittest.TestCase):
 
         match = freud.environment.EnvironmentCluster()
         query_args = dict(r_max=r_max, num_neighbors=num_neighbors)
-        match.compute(box, xyz, threshold, registration=False,
-                      query_args=query_args)
+        match.compute((box, xyz), threshold, registration=False,
+                      neighbors=query_args)
         cluster_env = match.cluster_environments
 
         fn = os.path.join(self.test_folder, "bcc_env.npy")
@@ -213,8 +213,8 @@ class TestCluster(unittest.TestCase):
 
         match = freud.environment.EnvironmentCluster()
         query_args = dict(r_guess=r_max, num_neighbors=num_neighbors)
-        match.compute(box, xyz, threshold, registration=True,
-                      global_search=True, query_args=query_args)
+        match.compute((box, xyz), threshold, registration=True,
+                      global_search=True, neighbors=query_args)
         clusters = match.clusters
 
         # Get environment for each particle
@@ -366,7 +366,7 @@ class TestCluster(unittest.TestCase):
         self.assertEqual(match._repr_png_(), None)
 
         query_args = dict(r_guess=r_max, num_neighbors=num_neighbors)
-        match.compute(box, xyz, threshold, query_args=query_args)
+        match.compute((box, xyz), threshold, neighbors=query_args)
         match._repr_png_()
 
 
@@ -382,7 +382,7 @@ class TestEnvironmentMotifMatch(unittest.TestCase):
         box = freud.box.Box.square(3)
         match = freud.environment.EnvironmentMotifMatch()
         query_args = dict(r_guess=r_max, num_neighbors=num_neighbors)
-        match.compute(box, motif, points, 0.1, query_args=query_args)
+        match.compute((box, points), motif, 0.1, neighbors=query_args)
         matches = match.matches
 
         for i in range(len(motif)):
@@ -402,7 +402,7 @@ class TestEnvironmentRMSDMinimizer(unittest.TestCase):
         box = freud.box.Box.square(3)
         match = freud.environment._EnvironmentRMSDMinimizer()
         query_args = dict(r_guess=r_max, num_neighbors=num_neighbors)
-        match.compute(box, motif, points, 0.1, query_args=query_args)
+        match.compute((box, points), motif, neighbors=query_args)
         self.assertTrue(np.all(match.rmsds[:-1] > 0))
         self.assertEqual(match.rmsds[-1], 0)
 

--- a/tests/test_environment_MatchEnv.py
+++ b/tests/test_environment_MatchEnv.py
@@ -31,16 +31,11 @@ class TestCluster(unittest.TestCase):
         with self.assertRaises(AttributeError):
             match.clusters
         with self.assertRaises(AttributeError):
-            match.getEnvironment(0)
+            match.cluster_environments
 
         match.compute(xyz, threshold)
-        clusters = match.clusters
 
-        cluster_env = {}
-        for cluster_ind in clusters:
-            if cluster_ind not in cluster_env:
-                cluster_env[cluster_ind] = np.copy(np.array(
-                    match.getEnvironment(cluster_ind)))
+        cluster_env = match.cluster_environments
 
         fn = os.path.join(self.test_folder, 'bcc_env.npy')
         bcc_env = np.load(fn)
@@ -51,9 +46,9 @@ class TestCluster(unittest.TestCase):
         # purposes of an element-by-element comparison.
         # np.lexsort() sorts by the columns you feed it, with the final fed
         # column being the "primary" sorting key.
-        # getEnvironment() might return the motif with its vectors sorted any
-        # old way, and if we compare against a saved numpy array then we have
-        # to order the two arrays in the same fashion.
+        # cluster_environments might provide the motif with its vectors sorted
+        # any old way, and if we compare against a saved numpy array then we
+        # have to order the two arrays in the same fashion.
         sorted_env_cluster = env_cluster[np.lexsort((env_cluster[:, 0],
                                                      env_cluster[:, 1],
                                                      env_cluster[:, 2]))]
@@ -77,13 +72,8 @@ class TestCluster(unittest.TestCase):
 
         match = freud.environment.EnvironmentCluster(box, r_max, num_neighbors)
         match.compute(xyz, threshold)
-        clusters = match.clusters
 
-        cluster_env = {}
-        for cluster_ind in clusters:
-            if cluster_ind not in cluster_env:
-                cluster_env[cluster_ind] = np.copy(np.array(
-                    match.getEnvironment(cluster_ind)))
+        cluster_env = match.cluster_environments
 
         fn = os.path.join(self.test_folder, "sc_env.npy")
         sc_env = np.load(fn)
@@ -95,9 +85,9 @@ class TestCluster(unittest.TestCase):
         # purposes of an element-by-element comparison.
         # np.lexsort() sorts by the columns you feed it, with the final fed
         # column being the "primary" sorting key.
-        # getEnvironment() might return the motif with its vectors sorted any
-        # old way, and if we compare against a saved numpy array then we have
-        # to order the two arrays in the same fashion.
+        # cluster_environments might provide the motif with its vectors sorted
+        # any old way, and if we compare against a saved numpy array then we
+        # have to order the two arrays in the same fashion.
         sorted_env_cluster = env_cluster[np.lexsort((env_cluster[:, 0],
                                                      env_cluster[:, 1],
                                                      env_cluster[:, 2]))]
@@ -123,13 +113,8 @@ class TestCluster(unittest.TestCase):
 
         match = freud.environment.EnvironmentCluster(box, r_max, num_neighbors)
         match.compute(xyz, threshold, hard_r=False, registration=False)
-        clusters = match.clusters
 
-        cluster_env = {}
-        for cluster_ind in clusters:
-            if cluster_ind not in cluster_env:
-                cluster_env[cluster_ind] = np.copy(np.array(
-                    match.getEnvironment(cluster_ind)))
+        cluster_env = match.cluster_environments
 
         fn = os.path.join(self.test_folder, "bcc_env.npy")
         bcc_env = np.load(fn)
@@ -140,9 +125,9 @@ class TestCluster(unittest.TestCase):
         # purposes of an element-by-element comparison.
         # np.lexsort() sorts by the columns you feed it, with the final fed
         # column being the "primary" sorting key.
-        # getEnvironment() might return the motif with its vectors sorted any
-        # old way, and if we compare against a saved numpy array then we have
-        # to order the two arrays in the same fashion.
+        # cluster_environments might provide the motif with its vectors sorted
+        # any old way, and if we compare against a saved numpy array then we
+        # have to order the two arrays in the same fashion.
         sorted_env_cluster = env_cluster[np.lexsort((env_cluster[:, 0],
                                                      env_cluster[:, 1],
                                                      env_cluster[:, 2]))]
@@ -167,13 +152,7 @@ class TestCluster(unittest.TestCase):
 
         match = freud.environment.EnvironmentCluster(box, r_max, num_neighbors)
         match.compute(xyz, threshold, hard_r=True, registration=False)
-        clusters = match.clusters
-
-        cluster_env = {}
-        for cluster_ind in clusters:
-            if cluster_ind not in cluster_env:
-                cluster_env[cluster_ind] = np.copy(np.array(
-                    match.getEnvironment(cluster_ind)))
+        cluster_env = match.cluster_environments
 
         fn = os.path.join(self.test_folder, "bcc_env.npy")
         bcc_env = np.load(fn)
@@ -184,9 +163,9 @@ class TestCluster(unittest.TestCase):
         # purposes of an element-by-element comparison.
         # np.lexsort() sorts by the columns you feed it, with the final fed
         # column being the "primary" sorting key.
-        # getEnvironment() might return the motif with its vectors sorted any
-        # old way, and if we compare against a saved numpy array then we have
-        # to order the two arrays in the same fashion.
+        # cluster_environments might provide the motif with its vectors sorted
+        # any old way, and if we compare against a saved numpy array then we
+        # have to order the two arrays in the same fashion.
         sorted_env_cluster = env_cluster[np.lexsort((env_cluster[:, 0],
                                                      env_cluster[:, 1],
                                                      env_cluster[:, 2]))]

--- a/tests/test_environment_MatchEnv.py
+++ b/tests/test_environment_MatchEnv.py
@@ -24,7 +24,7 @@ class TestCluster(unittest.TestCase):
 
         match = freud.environment.EnvironmentCluster()
         with self.assertRaises(AttributeError):
-            match.particle_environments
+            match.point_environments
         with self.assertRaises(AttributeError):
             match.num_particles
         with self.assertRaises(AttributeError):
@@ -218,7 +218,7 @@ class TestCluster(unittest.TestCase):
         clusters = match.clusters
 
         # Get environment for each particle
-        tot_env = match.particle_environments
+        tot_env = match.point_environments
 
         # Particles with index 22 and 31 have opposite y positions,
         # they should have the same local environment

--- a/tests/test_environment_MatchEnv.py
+++ b/tests/test_environment_MatchEnv.py
@@ -5,7 +5,6 @@ import unittest
 import os
 
 
-@unittest.skip
 class TestCluster(unittest.TestCase):
     # by Chrisy
     test_folder = os.path.join(os.path.dirname(__file__), 'numpy_test_files')

--- a/tests/test_environment_MatchEnv.py
+++ b/tests/test_environment_MatchEnv.py
@@ -290,8 +290,8 @@ class TestCluster(unittest.TestCase):
             e0, refPoints2[np.asarray(list(isSim_vec_map.values()))],
             atol=1e-6)
         # 4. Calculate the minimal RMSD.
-        [min_rmsd, refPoints2, minRMSD_vec_map] = match.minimizeRMSD(
-            e0, e1, registration=False)
+        [min_rmsd, refPoints2, minRMSD_vec_map] = \
+            freud.environment.minimizeRMSD(box, e0, e1, registration=False)
         # 5. Verify that the minimizeRMSD method finds 0 minimal RMSD
         #    (with no registration.)
         npt.assert_equal(0.0, min_rmsd)
@@ -318,8 +318,8 @@ class TestCluster(unittest.TestCase):
         analy_rmsd = np.sqrt(deltasum)
         # 9. Verify that minimizeRMSD gives this minimal RMSD
         #    (with no registration).
-        [min_rmsd, refPoints2, minRMSD_vec_map] = match.minimizeRMSD(
-            e0, e0_rot, registration=False)
+        [min_rmsd, refPoints2, minRMSD_vec_map] = \
+            freud.environment.minimizeRMSD(box, e0, e0_rot, registration=False)
         npt.assert_allclose(analy_rmsd, min_rmsd, atol=1e-5)
         npt.assert_allclose(
             e0_rot, refPoints2[np.asarray(list(minRMSD_vec_map.values()))],
@@ -329,15 +329,15 @@ class TestCluster(unittest.TestCase):
         np.random.shuffle(e1_rot)
         # 11. Verify that minimizeRMSD gives this minimal RMSD again
         #     (with no registration).
-        [min_rmsd, refPoints2, minRMSD_vec_map] = match.minimizeRMSD(
-            e0, e1_rot, registration=False)
+        [min_rmsd, refPoints2, minRMSD_vec_map] = \
+            freud.environment.minimizeRMSD(box, e0, e1_rot, registration=False)
         npt.assert_allclose(analy_rmsd, min_rmsd, atol=1e-5)
         npt.assert_allclose(
             e0_rot, refPoints2[np.asarray(list(minRMSD_vec_map.values()))],
             atol=1e-5)
         # 12. Now use minimizeRMSD with registration turned ON.
-        [min_rmsd, refPoints2, minRMSD_vec_map] = match.minimizeRMSD(
-            e0, e1_rot, registration=True)
+        [min_rmsd, refPoints2, minRMSD_vec_map] = \
+            freud.environment.minimizeRMSD(box, e0, e1_rot, registration=True)
         # 13. This should get us back to 0 minimal rmsd.
         npt.assert_allclose(0., min_rmsd, atol=1e-5)
         npt.assert_allclose(

--- a/tests/test_environment_MatchEnv.py
+++ b/tests/test_environment_MatchEnv.py
@@ -33,7 +33,7 @@ class TestCluster(unittest.TestCase):
         with self.assertRaises(AttributeError):
             match.getEnvironment(0)
 
-        match.cluster(xyz, threshold)
+        match.compute(xyz, threshold)
         clusters = match.clusters
 
         cluster_env = {}
@@ -76,7 +76,7 @@ class TestCluster(unittest.TestCase):
         threshold = 0.1
 
         match = freud.environment.EnvironmentCluster(box, r_max, num_neighbors)
-        match.cluster(xyz, threshold)
+        match.compute(xyz, threshold)
         clusters = match.clusters
 
         cluster_env = {}
@@ -108,7 +108,7 @@ class TestCluster(unittest.TestCase):
         npt.assert_allclose(sorted_env_cluster, sorted_sc_env, atol=1e-5,
                             err_msg="SC Cluster Environment fail")
 
-    # Test EnvironmentCluster.cluster function, defining clusters using
+    # Test EnvironmentCluster.compute function, defining clusters using
     # constant k neighbors, hard_r=false, registration=false
     def test_cluster_kNeighbor(self):
         fn = os.path.join(self.test_folder, "bcc.npy")
@@ -122,7 +122,7 @@ class TestCluster(unittest.TestCase):
         threshold = 0.1
 
         match = freud.environment.EnvironmentCluster(box, r_max, num_neighbors)
-        match.cluster(xyz, threshold, hard_r=False, registration=False)
+        match.compute(xyz, threshold, hard_r=False, registration=False)
         clusters = match.clusters
 
         cluster_env = {}
@@ -153,7 +153,7 @@ class TestCluster(unittest.TestCase):
         npt.assert_allclose(sorted_env_cluster, sorted_bcc_env, atol=1e-5,
                             err_msg="BCC Cluster Environment fail")
 
-    # Test EnvironmentCluster.cluster function, hard_r=true, registration=false
+    # Test EnvironmentCluster.compute function, hard_r=true, registration=false
     def test_cluster_hardr(self):
         fn = os.path.join(self.test_folder, "bcc.npy")
         xyz = np.load(fn)
@@ -166,7 +166,7 @@ class TestCluster(unittest.TestCase):
         threshold = 0.1
 
         match = freud.environment.EnvironmentCluster(box, r_max, num_neighbors)
-        match.cluster(xyz, threshold, hard_r=True, registration=False)
+        match.compute(xyz, threshold, hard_r=True, registration=False)
         clusters = match.clusters
 
         cluster_env = {}
@@ -197,7 +197,7 @@ class TestCluster(unittest.TestCase):
         npt.assert_allclose(sorted_env_cluster, sorted_bcc_env, atol=1e-5,
                             err_msg="BCC Cluster Environment fail")
 
-    # Test EnvironmentCluster.cluster function,
+    # Test EnvironmentCluster.compute function,
     # hard_r=false, registration=true, global=true
     def test_cluster_registration(self):
         fn = os.path.join(self.test_folder, "sc_N54.npy")
@@ -222,7 +222,7 @@ class TestCluster(unittest.TestCase):
         box = freud.box.Box(L, L, L, 0, 0, 0)
 
         match = freud.environment.EnvironmentCluster(box, r_max, num_neighbors)
-        match.cluster(xyz, threshold, hard_r=False,
+        match.compute(xyz, threshold, hard_r=False,
                       registration=True, global_search=True)
         clusters = match.clusters
 
@@ -378,7 +378,7 @@ class TestCluster(unittest.TestCase):
             match.plot()
         self.assertEqual(match._repr_png_(), None)
 
-        match.cluster(xyz, threshold)
+        match.compute(xyz, threshold)
         match._repr_png_()
 
 

--- a/tests/test_environment_MatchEnv.py
+++ b/tests/test_environment_MatchEnv.py
@@ -22,7 +22,7 @@ class TestCluster(unittest.TestCase):
         threshold_prefactor = 0.1
         threshold = threshold_prefactor * r_max
 
-        match = freud.environment.EnvironmentCluster(num_neighbors)
+        match = freud.environment.EnvironmentCluster()
         with self.assertRaises(AttributeError):
             match.particle_environments
         with self.assertRaises(AttributeError):
@@ -34,7 +34,8 @@ class TestCluster(unittest.TestCase):
         with self.assertRaises(AttributeError):
             match.cluster_environments
 
-        match.compute(box, xyz, threshold, r_max=r_max)
+        match.compute(box, xyz, threshold, r_max=r_max,
+                      num_neighbors=num_neighbors)
 
         cluster_env = match.cluster_environments
 
@@ -72,8 +73,9 @@ class TestCluster(unittest.TestCase):
         threshold_prefactor = 0.1
         threshold = threshold_prefactor * r_max
 
-        match = freud.environment.EnvironmentCluster(num_neighbors)
-        match.compute(box, xyz, threshold, r_max=r_max)
+        match = freud.environment.EnvironmentCluster()
+        match.compute(box, xyz, threshold, r_max=r_max,
+                      num_neighbors=num_neighbors)
 
         cluster_env = match.cluster_environments
 
@@ -114,9 +116,9 @@ class TestCluster(unittest.TestCase):
         threshold_prefactor = 0.1
         threshold = threshold_prefactor * r_max
 
-        match = freud.environment.EnvironmentCluster(num_neighbors)
+        match = freud.environment.EnvironmentCluster()
         match.compute(box, xyz, threshold, hard_r=False, registration=False,
-                      r_max=r_max)
+                      r_max=r_max, num_neighbors=num_neighbors)
 
         cluster_env = match.cluster_environments
 
@@ -155,9 +157,9 @@ class TestCluster(unittest.TestCase):
         threshold_prefactor = 0.1
         threshold = threshold_prefactor * r_max
 
-        match = freud.environment.EnvironmentCluster(num_neighbors)
+        match = freud.environment.EnvironmentCluster()
         match.compute(box, xyz, threshold, hard_r=True, registration=False,
-                      r_max=r_max)
+                      r_max=r_max, num_neighbors=num_neighbors)
         cluster_env = match.cluster_environments
 
         fn = os.path.join(self.test_folder, "bcc_env.npy")
@@ -207,9 +209,10 @@ class TestCluster(unittest.TestCase):
         L = np.max(xyz)*3.0
         box = freud.box.Box(L, L, L, 0, 0, 0)
 
-        match = freud.environment.EnvironmentCluster(num_neighbors)
+        match = freud.environment.EnvironmentCluster()
         match.compute(box, xyz, threshold, hard_r=False,
-                      registration=True, global_search=True, r_max=r_max)
+                      registration=True, global_search=True, r_max=r_max,
+                      num_neighbors=num_neighbors)
         clusters = match.clusters
 
         # Get environment for each particle
@@ -334,8 +337,7 @@ class TestCluster(unittest.TestCase):
             atol=1e-5)
 
     def test_repr(self):
-        num_neighbors = 14
-        match = freud.environment.EnvironmentCluster(num_neighbors)
+        match = freud.environment.EnvironmentCluster()
         self.assertEqual(str(match), str(eval(repr(match))))
 
     def test_repr_png(self):
@@ -355,13 +357,14 @@ class TestCluster(unittest.TestCase):
         xyz = np.array(xyz, dtype=np.float32)
         xyz[:, 2] = 0
         xyz.flags['WRITEABLE'] = False
-        match = freud.environment.EnvironmentCluster(num_neighbors)
+        match = freud.environment.EnvironmentCluster()
 
         with self.assertRaises(AttributeError):
             match.plot()
         self.assertEqual(match._repr_png_(), None)
 
-        match.compute(box, xyz, threshold, r_max=r_max)
+        match.compute(box, xyz, threshold, r_max=r_max,
+                      num_neighbors=num_neighbors)
         match._repr_png_()
 
 
@@ -375,9 +378,9 @@ class TestEnvironmentMotifMatch(unittest.TestCase):
         num_neighbors = 4
 
         box = freud.box.Box.square(3)
-        match = freud.environment.EnvironmentMotifMatch(
-            num_neighbors)
-        match.compute(box, motif, points, 0.1, r_max=r_max)
+        match = freud.environment.EnvironmentMotifMatch()
+        match.compute(box, motif, points, 0.1, r_max=r_max,
+                      num_neighbors=num_neighbors)
         matches = match.matches
 
         for i in range(len(motif)):
@@ -395,9 +398,9 @@ class TestEnvironmentRMSDMinimizer(unittest.TestCase):
         num_neighbors = 4
 
         box = freud.box.Box.square(3)
-        match = freud.environment._EnvironmentRMSDMinimizer(
-            num_neighbors)
-        match.compute(box, motif, points, 0.1, r_max=r_max)
+        match = freud.environment._EnvironmentRMSDMinimizer()
+        match.compute(box, motif, points, 0.1, r_max=r_max,
+                      num_neighbors=num_neighbors)
         self.assertTrue(np.all(match.rmsds[:-1] > 0))
         self.assertEqual(match.rmsds[-1], 0)
 

--- a/tests/test_environment_MatchEnv.py
+++ b/tests/test_environment_MatchEnv.py
@@ -23,7 +23,7 @@ class TestCluster(unittest.TestCase):
 
         match = freud.environment.EnvironmentCluster(box, r_max, num_neighbors)
         with self.assertRaises(AttributeError):
-            match.tot_environment
+            match.particle_environments
         with self.assertRaises(AttributeError):
             match.num_particles
         with self.assertRaises(AttributeError):
@@ -227,7 +227,7 @@ class TestCluster(unittest.TestCase):
         clusters = match.clusters
 
         # Get environment for each particle
-        tot_env = match.tot_environment
+        tot_env = match.particle_environments
 
         # Particles with index 22 and 31 have opposite y positions,
         # they should have the same local environment

--- a/tests/test_environment_MatchEnv.py
+++ b/tests/test_environment_MatchEnv.py
@@ -5,6 +5,7 @@ import unittest
 import os
 
 
+@unittest.skip
 class TestCluster(unittest.TestCase):
     # by Chrisy
     test_folder = os.path.join(os.path.dirname(__file__), 'numpy_test_files')

--- a/tests/test_environment_MatchEnv.py
+++ b/tests/test_environment_MatchEnv.py
@@ -21,7 +21,7 @@ class TestCluster(unittest.TestCase):
         num_neighbors = 14
         threshold = 0.1
 
-        match = freud.environment.MatchEnv(box, r_max, num_neighbors)
+        match = freud.environment.EnvironmentCluster(box, r_max, num_neighbors)
         with self.assertRaises(AttributeError):
             match.tot_environment
         with self.assertRaises(AttributeError):
@@ -75,7 +75,7 @@ class TestCluster(unittest.TestCase):
         num_neighbors = 6
         threshold = 0.1
 
-        match = freud.environment.MatchEnv(box, r_max, num_neighbors)
+        match = freud.environment.EnvironmentCluster(box, r_max, num_neighbors)
         match.cluster(xyz, threshold)
         clusters = match.clusters
 
@@ -108,7 +108,7 @@ class TestCluster(unittest.TestCase):
         npt.assert_allclose(sorted_env_cluster, sorted_sc_env, atol=1e-5,
                             err_msg="SC Cluster Environment fail")
 
-    # Test MatchEnv.cluster function, defining clusters using
+    # Test EnvironmentCluster.cluster function, defining clusters using
     # constant k neighbors, hard_r=false, registration=false
     def test_cluster_kNeighbor(self):
         fn = os.path.join(self.test_folder, "bcc.npy")
@@ -121,7 +121,7 @@ class TestCluster(unittest.TestCase):
         num_neighbors = 14
         threshold = 0.1
 
-        match = freud.environment.MatchEnv(box, r_max, num_neighbors)
+        match = freud.environment.EnvironmentCluster(box, r_max, num_neighbors)
         match.cluster(xyz, threshold, hard_r=False, registration=False)
         clusters = match.clusters
 
@@ -153,7 +153,7 @@ class TestCluster(unittest.TestCase):
         npt.assert_allclose(sorted_env_cluster, sorted_bcc_env, atol=1e-5,
                             err_msg="BCC Cluster Environment fail")
 
-    # Test MatchEnv.cluster function, hard_r=true, registration=false
+    # Test EnvironmentCluster.cluster function, hard_r=true, registration=false
     def test_cluster_hardr(self):
         fn = os.path.join(self.test_folder, "bcc.npy")
         xyz = np.load(fn)
@@ -165,7 +165,7 @@ class TestCluster(unittest.TestCase):
         num_neighbors = 14
         threshold = 0.1
 
-        match = freud.environment.MatchEnv(box, r_max, num_neighbors)
+        match = freud.environment.EnvironmentCluster(box, r_max, num_neighbors)
         match.cluster(xyz, threshold, hard_r=True, registration=False)
         clusters = match.clusters
 
@@ -197,7 +197,7 @@ class TestCluster(unittest.TestCase):
         npt.assert_allclose(sorted_env_cluster, sorted_bcc_env, atol=1e-5,
                             err_msg="BCC Cluster Environment fail")
 
-    # Test MatchEnv.cluster function,
+    # Test EnvironmentCluster.cluster function,
     # hard_r=false, registration=true, global=true
     def test_cluster_registration(self):
         fn = os.path.join(self.test_folder, "sc_N54.npy")
@@ -221,7 +221,7 @@ class TestCluster(unittest.TestCase):
         L = np.max(xyz)*3.0
         box = freud.box.Box(L, L, L, 0, 0, 0)
 
-        match = freud.environment.MatchEnv(box, r_max, num_neighbors)
+        match = freud.environment.EnvironmentCluster(box, r_max, num_neighbors)
         match.cluster(xyz, threshold, hard_r=False,
                       registration=True, global_search=True)
         clusters = match.clusters
@@ -240,7 +240,7 @@ class TestCluster(unittest.TestCase):
         npt.assert_equal(len(returnResult[1]), num_neighbors,
                          err_msg="two environments are not similar")
 
-    # Test MatchEnv.minimizeRMSD and registration functionality.
+    # Test EnvironmentCluster.minimizeRMSD and registration functionality.
     # Overkill? Maybe.
     def test_minimizeRMSD(self):
         env_vec = np.array([[1, 0, 0],
@@ -353,7 +353,7 @@ class TestCluster(unittest.TestCase):
         box = freud.box.Box.cube(L)
         r_max = 3.1
         num_neighbors = 14
-        match = freud.environment.MatchEnv(box, r_max, num_neighbors)
+        match = freud.environment.EnvironmentCluster(box, r_max, num_neighbors)
         self.assertEqual(str(match), str(eval(repr(match))))
 
     def test_repr_png(self):
@@ -372,7 +372,7 @@ class TestCluster(unittest.TestCase):
         xyz = np.array(xyz, dtype=np.float32)
         xyz[:, 2] = 0
         xyz.flags['WRITEABLE'] = False
-        match = freud.environment.MatchEnv(box, r_max, num_neighbors)
+        match = freud.environment.EnvironmentCluster(box, r_max, num_neighbors)
 
         with self.assertRaises(AttributeError):
             match.plot()

--- a/tests/test_environment_MatchEnv.py
+++ b/tests/test_environment_MatchEnv.py
@@ -34,8 +34,8 @@ class TestCluster(unittest.TestCase):
         with self.assertRaises(AttributeError):
             match.cluster_environments
 
-        match.compute(box, xyz, threshold, r_max=r_max,
-                      num_neighbors=num_neighbors)
+        query_args = dict(r_guess=r_max, num_neighbors=num_neighbors)
+        match.compute(box, xyz, threshold, query_args=query_args)
 
         cluster_env = match.cluster_environments
 
@@ -74,8 +74,8 @@ class TestCluster(unittest.TestCase):
         threshold = threshold_prefactor * r_max
 
         match = freud.environment.EnvironmentCluster()
-        match.compute(box, xyz, threshold, r_max=r_max,
-                      num_neighbors=num_neighbors)
+        query_args = dict(r_guess=r_max, num_neighbors=num_neighbors)
+        match.compute(box, xyz, threshold, query_args=query_args)
 
         cluster_env = match.cluster_environments
 
@@ -117,8 +117,9 @@ class TestCluster(unittest.TestCase):
         threshold = threshold_prefactor * r_max
 
         match = freud.environment.EnvironmentCluster()
-        match.compute(box, xyz, threshold, hard_r=False, registration=False,
-                      r_max=r_max, num_neighbors=num_neighbors)
+        query_args = dict(r_guess=r_max, num_neighbors=num_neighbors)
+        match.compute(box, xyz, threshold, registration=False,
+                      query_args=query_args)
 
         cluster_env = match.cluster_environments
 
@@ -158,8 +159,9 @@ class TestCluster(unittest.TestCase):
         threshold = threshold_prefactor * r_max
 
         match = freud.environment.EnvironmentCluster()
-        match.compute(box, xyz, threshold, hard_r=True, registration=False,
-                      r_max=r_max, num_neighbors=num_neighbors)
+        query_args = dict(r_max=r_max, num_neighbors=num_neighbors)
+        match.compute(box, xyz, threshold, registration=False,
+                      query_args=query_args)
         cluster_env = match.cluster_environments
 
         fn = os.path.join(self.test_folder, "bcc_env.npy")
@@ -210,9 +212,9 @@ class TestCluster(unittest.TestCase):
         box = freud.box.Box(L, L, L, 0, 0, 0)
 
         match = freud.environment.EnvironmentCluster()
-        match.compute(box, xyz, threshold, hard_r=False,
-                      registration=True, global_search=True, r_max=r_max,
-                      num_neighbors=num_neighbors)
+        query_args = dict(r_guess=r_max, num_neighbors=num_neighbors)
+        match.compute(box, xyz, threshold, registration=True,
+                      global_search=True, query_args=query_args)
         clusters = match.clusters
 
         # Get environment for each particle
@@ -363,8 +365,8 @@ class TestCluster(unittest.TestCase):
             match.plot()
         self.assertEqual(match._repr_png_(), None)
 
-        match.compute(box, xyz, threshold, r_max=r_max,
-                      num_neighbors=num_neighbors)
+        query_args = dict(r_guess=r_max, num_neighbors=num_neighbors)
+        match.compute(box, xyz, threshold, query_args=query_args)
         match._repr_png_()
 
 
@@ -379,8 +381,8 @@ class TestEnvironmentMotifMatch(unittest.TestCase):
 
         box = freud.box.Box.square(3)
         match = freud.environment.EnvironmentMotifMatch()
-        match.compute(box, motif, points, 0.1, r_max=r_max,
-                      num_neighbors=num_neighbors)
+        query_args = dict(r_guess=r_max, num_neighbors=num_neighbors)
+        match.compute(box, motif, points, 0.1, query_args=query_args)
         matches = match.matches
 
         for i in range(len(motif)):
@@ -399,8 +401,8 @@ class TestEnvironmentRMSDMinimizer(unittest.TestCase):
 
         box = freud.box.Box.square(3)
         match = freud.environment._EnvironmentRMSDMinimizer()
-        match.compute(box, motif, points, 0.1, r_max=r_max,
-                      num_neighbors=num_neighbors)
+        query_args = dict(r_guess=r_max, num_neighbors=num_neighbors)
+        match.compute(box, motif, points, 0.1, query_args=query_args)
         self.assertTrue(np.all(match.rmsds[:-1] > 0))
         self.assertEqual(match.rmsds[-1], 0)
 

--- a/tests/test_environment_MatchEnv.py
+++ b/tests/test_environment_MatchEnv.py
@@ -235,8 +235,8 @@ class TestCluster(unittest.TestCase):
                          err_msg="two points do not have similar environment")
 
         # Particle 22 and particle 31's local environments should match
-        returnResult = match.isSimilar(tot_env[22], tot_env[31],
-                                       0.005, registration=True)
+        returnResult = freud.environment.isSimilar(
+            box, tot_env[22], tot_env[31], r_max, 0.005, registration=True)
         npt.assert_equal(len(returnResult[1]), num_neighbors,
                          err_msg="two environments are not similar")
 
@@ -257,7 +257,6 @@ class TestCluster(unittest.TestCase):
 
         # r_max and num_neighbors are meaningless here
         r_max = 2
-        num_neighbors = len(env_vec)
 
         ux = norm[0]
         uy = norm[1]
@@ -283,9 +282,8 @@ class TestCluster(unittest.TestCase):
         np.random.shuffle(e1)
         # 3. Verify that OUR method isSimilar gives that these two
         #    environments are similar.
-        match = freud.environment.MatchEnv(box, r_max, num_neighbors)
-        [refPoints2, isSim_vec_map] = match.isSimilar(
-            e0, e1, threshold, registration=False)
+        [refPoints2, isSim_vec_map] = freud.environment.isSimilar(
+            box, e0, e1, r_max, threshold, registration=False)
         npt.assert_allclose(
             e0, refPoints2[np.asarray(list(isSim_vec_map.values()))],
             atol=1e-6)
@@ -344,8 +342,8 @@ class TestCluster(unittest.TestCase):
             e0, refPoints2[np.asarray(list(minRMSD_vec_map.values()))],
             atol=1e-5)
         # 14. Finally use isSimilar with registration turned ON.
-        [refPoints2, isSim_vec_map] = match.isSimilar(
-            e0, e1_rot, threshold, registration=True)
+        [refPoints2, isSim_vec_map] = freud.environment.isSimilar(
+            box, e0, e1_rot, r_max, threshold, registration=True)
         npt.assert_allclose(
             e0, refPoints2[np.asarray(list(isSim_vec_map.values()))],
             atol=1e-5)

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -56,8 +56,8 @@ class TestInterface(unittest.TestCase):
         others = np.concatenate([positions[:index], positions[index + 1:]])
 
         # Creates a neighborlist with r_max larger than the interface r_max
-        lc = freud.locality.LinkCell(box, r_max, others)
-        nlist = lc.query(point, dict(r_max=r_max)).toNeighborList()
+        aq = freud.locality.AABBQuery(box, others)
+        nlist = aq.query(point, dict(r_max=r_max)).toNeighborList()
 
         inter = freud.interface.InterfaceMeasure(1.5)
 

--- a/tests/test_locality_NeighborList.py
+++ b/tests/test_locality_NeighborList.py
@@ -17,8 +17,7 @@ class TestNeighborList(unittest.TestCase):
 
         # Initialize Box and cell list
         box, points = make_box_and_random_points(self.L, self.N)
-        self.nq = freud.locality.LinkCell(box, self.query_args['r_guess']/10,
-                                          points)
+        self.nq = freud.locality.AABBQuery(box, points)
         self.nlist = self.nq.query(points,
                                    self.query_args).toNeighborList()
 

--- a/tests/test_locality_NeighborQuery.py
+++ b/tests/test_locality_NeighborQuery.py
@@ -576,16 +576,29 @@ class TestNeighborQueryLinkCell(NeighborQueryTest, unittest.TestCase):
     def build_query_object(cls, box, ref_points, r_max=None):
         if r_max is None:
             raise ValueError("Building LinkCells requires passing an r_max.")
-        return freud.locality.LinkCell(box, r_max, ref_points)
+        return freud.locality.LinkCell(box, ref_points, r_max)
 
     def test_chaining(self):
         N = 500
         L = 10
         r_max = 1
         box, points = util.make_box_and_random_points(L, N)
-        nlist1 = freud.locality.LinkCell(box, 1.0, points).query(
+        nlist1 = freud.locality.LinkCell(box, points, 1.0).query(
             points, dict(r_max=r_max, exclude_ii=True)).toNeighborList()
-        lc = freud.locality.LinkCell(box, 1.0, points)
+        lc = freud.locality.LinkCell(box, points, 1.0)
+        nlist2 = lc.query(points, dict(r_max=r_max,
+                                       exclude_ii=True)).toNeighborList()
+        self.assertTrue(nlist_equal(nlist1, nlist2))
+
+    def test_default_cell_width(self):
+        """Check that using a default cell width works."""
+        N = 500
+        L = 10
+        r_max = 1
+        box, points = util.make_box_and_random_points(L, N)
+        nlist1 = freud.locality.LinkCell(box, points).query(
+            points, dict(r_max=r_max, exclude_ii=True)).toNeighborList()
+        lc = freud.locality.LinkCell(box, points, 1.0)
         nlist2 = lc.query(points, dict(r_max=r_max,
                                        exclude_ii=True)).toNeighborList()
         self.assertTrue(nlist_equal(nlist1, nlist2))
@@ -597,7 +610,7 @@ class TestNeighborQueryLinkCell(NeighborQueryTest, unittest.TestCase):
 
         # Initialize Box, initialize and compute cell list
         fbox = freud.box.Box.cube(L)
-        cl = freud.locality.LinkCell(fbox, r_max, np.zeros((1, 3)))
+        cl = freud.locality.LinkCell(fbox, np.zeros((1, 3)), r_max)
 
         # 27 is the total number of cells
         for i in range(27):
@@ -618,7 +631,7 @@ class TestNeighborQueryLinkCell(NeighborQueryTest, unittest.TestCase):
 
         # Initialize Box, initialize and compute cell list
         fbox = freud.box.Box.cube(L)
-        cl = freud.locality.LinkCell(fbox, r_max, testpoints)
+        cl = freud.locality.LinkCell(fbox, testpoints, r_max)
 
         # Get cell index
         cell_index0 = cl.getCell(testpoints[0])
@@ -644,7 +657,7 @@ class TestNeighborQueryLinkCell(NeighborQueryTest, unittest.TestCase):
 
         # Initialize test points randomly
         fbox, points = util.make_box_and_random_points(L, N)
-        cl = freud.locality.LinkCell(fbox, r_max, points)
+        cl = freud.locality.LinkCell(fbox, points, r_max)
 
         neighbors_ij = set()
         for i in range(N):

--- a/tests/util.py
+++ b/tests/util.py
@@ -44,15 +44,17 @@ def make_raw_query_nlist_test_set(box, points, query_points, mode, r_max,
     test_set.append((freud.locality.AABBQuery(box, points), query_args))
     test_set.append(
         (freud.locality.LinkCell(box, points, r_max), query_args))
+
+    aq = freud.locality.AABBQuery(box, points)
     if mode == "ball":
-        nlist = freud.locality.make_default_nlist(
-            box, points, query_points,
-            dict(r_max=r_max, exclude_ii=exclude_ii), None)
+        nlist = aq.query(query_points,
+                         dict(r_max=r_max, exclude_ii=exclude_ii)
+                         ).toNeighborList()
     if mode == "nearest":
-        nlist = freud.locality.make_default_nlist(
-            box, points, query_points,
-            dict(num_neighbors=num_neighbors, exclude_ii=exclude_ii,
-                 r_guess=r_max), None)
+        nlist = aq.query(query_points,
+                         dict(num_neighbors=num_neighbors,
+                              exclude_ii=exclude_ii, r_guess=r_max)
+                         ).toNeighborList()
     test_set.append(((box, points), nlist))
     return test_set
 

--- a/tests/util.py
+++ b/tests/util.py
@@ -43,7 +43,7 @@ def make_raw_query_nlist_test_set(box, points, query_points, mode, r_max,
     test_set.append((freud.locality.RawPoints(box, points), query_args))
     test_set.append((freud.locality.AABBQuery(box, points), query_args))
     test_set.append(
-        (freud.locality.LinkCell(box, r_max, points), query_args))
+        (freud.locality.LinkCell(box, points, r_max), query_args))
     if mode == "ball":
         nlist = freud.locality.make_default_nlist(
             box, points, query_points,


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above. -->

## Description
This PR has a few unrelated changes in it that unfortunately sort of cascaded.
- The LinkCell constructor argument order has been swapped, and `cell_width` is now optional and computed for the user if none is provided. I'm open to ideas on improving the calculation, but I would prefer to push that to a separate PR (presumably after the 2.0 beta release) since it's not API-related.
- Changes `RawPoints` to create its `AABBQuery` only when needed. The key is to do it in `query` rather than `querySingle` so that there are no parallelism issues. It will error out if a user manually calls `querySingle` rather than having it called through the `query->NeighborQueryIterator::query->querySingle` chain, but I think that's OK since that's not currently part of the Python API anyway.
- Simplifies the `Compute` class by removing many of the decorators and inferring that information based on function names. This change is made possible by further standardization of the API.
- That standardization requires that `MatchEnv` be brought into conformance with the rest of freud. The largest part of this PR is a significant rewrite of `MatchEnv` that splits it into 3 separate classes that are each responsible for a single calculation. I also did a lot of cleanup to make the classes a bit easier to understand.

Remaining to-dos:
- The `getEnvironment` function should be removed in favor of just having the cluster environments all just exposed through a `ManagedArray` or similar interface.
- I recommend making everything other than `EnvironmentCluster` private on the Python side for now, until we hear from more users about whether or not they actually make use of `minRMSDMotif` 
 and `matchMotif`.
- These classes should be switched to using `NeighborQuery`. It won't be too large a change if we still just use `makeDefaultNList` on the C++ side.
- I need to add tests for the two new compute classes. I have some basic ones written, but not in the form of `unittest` class methods yet.

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- Replace ??? with the issue number that this pull request resolves, if applicable. -->
Resolves: #420. I think this also resolves #278. Splitting into three classes clarifies the use of each calculation, there's no longer any confusion of which attributes are populated or what they mean (and how to use them), and the only free parameter left is the threshold, for which I added documentation along the lines of what @erteich suggested in #278. The threshold will always be a free variable, so I think some guidance regarding how to pick it is the most we can do.

It's also a significant step towards making it easier to actually understand the code in MatchEnv.

## How Has This Been Tested?
Existing tests pass.

## Screenshots
<!-- (if appropriate) -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds or improves functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!-- Put an `x` in all the boxes that apply. If you're unsure about any of
     these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/glotzerlab/freud/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] I have updated the documentation (if relevant).
- [x] I have added tests that cover my changes (if relevant).
- [x] All new and existing tests passed.
- [x] I have updated the [credits](https://github.com/glotzerlab/freud/blob/master/doc/source/credits.rst).
- [x] I have updated the [Changelog](https://github.com/glotzerlab/freud/blob/master/ChangeLog.md).
