### PR TITLE
Add macros for quieter builds

### DIFF
--- a/freud/environment.pyx
+++ b/freud/environment.pyx
@@ -538,9 +538,9 @@ cdef class MatchEnv(Compute):
         points = freud.common.convert_array(points, shape=(None, 3))
         ref_points = freud.common.convert_array(ref_points, shape=(None, 3))
 
-        cdef const float[::1] l_points = np.ascontiguousarray(
+        cdef np.ndarray[float, ndim=1] l_points = np.ascontiguousarray(
             points.flatten())
-        cdef const float[::1] l_ref_points = np.ascontiguousarray(
+        cdef np.ndarray[float, ndim=1] l_ref_points = np.ascontiguousarray(
             ref_points.flatten())
         cdef unsigned int nP = l_points.shape[0]
         cdef unsigned int nRef = l_ref_points.shape[0]
@@ -582,9 +582,9 @@ cdef class MatchEnv(Compute):
         points = freud.common.convert_array(points, shape=(None, 3))
         ref_points = freud.common.convert_array(ref_points, shape=(None, 3))
 
-        cdef const float[::1] l_points = np.ascontiguousarray(
+        cdef np.ndarray[float, ndim=1] l_points = np.ascontiguousarray(
             points.flatten())
-        cdef const float[::1] l_ref_points = np.ascontiguousarray(
+        cdef np.ndarray[float, ndim=1] l_ref_points = np.ascontiguousarray(
             ref_points.flatten())
         cdef unsigned int nP = l_points.shape[0]
         cdef unsigned int nRef = l_ref_points.shape[0]

--- a/freud/environment.pyx
+++ b/freud/environment.pyx
@@ -538,9 +538,9 @@ cdef class MatchEnv(Compute):
         points = freud.common.convert_array(points, shape=(None, 3))
         ref_points = freud.common.convert_array(ref_points, shape=(None, 3))
 
-        cdef np.ndarray[float, ndim=1] l_points = np.ascontiguousarray(
+        cdef const float[::1] l_points = np.ascontiguousarray(
             points.flatten())
-        cdef np.ndarray[float, ndim=1] l_ref_points = np.ascontiguousarray(
+        cdef const float[::1] l_ref_points = np.ascontiguousarray(
             ref_points.flatten())
         cdef unsigned int nP = l_points.shape[0]
         cdef unsigned int nRef = l_ref_points.shape[0]
@@ -582,9 +582,9 @@ cdef class MatchEnv(Compute):
         points = freud.common.convert_array(points, shape=(None, 3))
         ref_points = freud.common.convert_array(ref_points, shape=(None, 3))
 
-        cdef np.ndarray[float, ndim=1] l_points = np.ascontiguousarray(
+        cdef const float[::1] l_points = np.ascontiguousarray(
             points.flatten())
-        cdef np.ndarray[float, ndim=1] l_ref_points = np.ascontiguousarray(
+        cdef const float[::1] l_ref_points = np.ascontiguousarray(
             ref_points.flatten())
         cdef unsigned int nP = l_points.shape[0]
         cdef unsigned int nRef = l_ref_points.shape[0]

--- a/freud/locality.pyx
+++ b/freud/locality.pyx
@@ -537,7 +537,7 @@ cdef class NeighborList:
         """  # noqa E501
         filt = np.ascontiguousarray(filt, dtype=np.bool)
         cdef np.ndarray[np.uint8_t, ndim=1, cast=True] filt_c = filt
-        cdef cbool * filt_ptr = <cbool*> filt_c.data
+        cdef cbool * filt_ptr = <cbool*> &filt_c[0]
         self.thisptr.filter(filt_ptr)
         return self
 

--- a/setup.py
+++ b/setup.py
@@ -209,7 +209,10 @@ directives = {
     'embedsignature': True,
     'language_level': 3,
 }
-macros = []
+macros = [
+    ('NPY_NO_DEPRECATED_API', 'NPY_1_10_API_VERSION'),
+    ('VOROPP_VERBOSE', '1'),
+]
 
 # Decide whether or not to compile with coverage support
 if args.use_coverage:


### PR DESCRIPTION
## Description
I was getting annoying messages from voro++ while testing #460. I added preprocessor directives to silence those. I also decided to add the NumPy deprecation directive that pops up a warning about being unset every time freud is built. That required a couple of small changes to our code, to remove deprecated features (in my understanding, Cython would have to implement some updates to use newer NumPy APIs, the features aren't really gone).

## Motivation and Context
Makes builds quieter.

## How Has This Been Tested?
Tests pass.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds or improves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!-- Put an `x` in all the boxes that apply. If you're unsure about any of
     these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/glotzerlab/freud/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] I have updated the documentation (if relevant).
- [x] I have added tests that cover my changes (if relevant).
- [x] All new and existing tests passed.
- [x] I have updated the [credits](https://github.com/glotzerlab/freud/blob/master/doc/source/credits.rst).
- [x] I have updated the [Changelog](https://github.com/glotzerlab/freud/blob/master/ChangeLog.md).