### PR TITLE
Update CI configuration and dependencies.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,16 +46,14 @@ references:
       name: Install dependencies
       command: |
         git submodule update --init
-        $PIP install --user -r requirements.txt
-        $PIP install --user -U coverage cython matplotlib rowan sympy
+        $PIP install --user -r requirements-testing.txt
 
   get_style_requirements: &get_style_requirements
     run:
       name: Install style check dependencies
       command: |
         git submodule update --init
-        $PIP install --user -r requirements.txt
-        $PIP install --user flake8==3.7.7
+        $PIP install --user flake8==3.7.8
 
   check_style: &check_style
     run:
@@ -100,8 +98,7 @@ references:
     run:
       name: Run benchmarks
       command: |
-          $PIP install --user gitpython
-          $PIP install --user rowan
+          $PIP install --user -r requirements-testing.txt
           echo 'export PYTHONPATH=$PYTHONPATH:.' >> $BASH_ENV
           echo 'export BENCHMARK_NPROC=2' >> $BASH_ENV
           source $BASH_ENV

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,7 +13,7 @@ build_script:
   - conda config --set always_yes yes --set changeps1 no
   - conda config --add channels conda-forge
   - conda update -q conda
-  - conda install pip cython matplotlib numpy rowan scipy sympy tbb tbb-devel
+  - conda install pip cython garnett gsd matplotlib numpy rowan scipy sympy tbb tbb-devel
   - "set TBB_INCLUDE=%MINICONDA%\\Library\\include"
   - "set TBB_LINK=%MINICONDA%\\Library\\lib"
   - python --version

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,7 +13,7 @@ build_script:
   - conda config --set always_yes yes --set changeps1 no
   - conda config --add channels conda-forge
   - conda update -q conda
-  - conda install pip cython garnett gsd matplotlib numpy rowan scipy sympy tbb tbb-devel
+  - conda install pip cython garnett matplotlib numpy rowan scipy sympy tbb tbb-devel
   - "set TBB_INCLUDE=%MINICONDA%\\Library\\include"
   - "set TBB_LINK=%MINICONDA%\\Library\\lib"
   - python --version

--- a/requirements-testing.txt
+++ b/requirements-testing.txt
@@ -1,0 +1,10 @@
+coverage==4.5.4
+cython==0.29.13
+garnett==0.5.0
+GitPython==3.0.2
+gsd==1.9.2
+matplotlib==3.1.1
+numpy==1.17.2
+rowan==1.2.2
+scipy==1.3.1
+sympy==1.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
 numpy
-scipy

--- a/setup.py
+++ b/setup.py
@@ -452,7 +452,7 @@ try:
                 'gsd>=1.9',
                 'garnett>=0.5',
                 'matplotlib>=2.0',
-                'rowan>=1.0',
+                'rowan>=1.2',
                 'sympy>=1.0',
             ],
             ext_modules=extensions)


### PR DESCRIPTION
## Description
Updates the CI configuration to enable the validation tests added in #460.

Notably, `scipy` is no longer a runtime requirement for freud. It's only used in tests, now that Voronoi has been rewritten.