### PR TITLE
Fix numthreads access in msd

### DIFF
--- a/freud/msd.pyx
+++ b/freud/msd.pyx
@@ -22,9 +22,9 @@ try:
     import pyfftw
     logger.info("Using PyFFTW for FFTs")
 
-    pyfftw.config.NUM_THREADS = min(1, freud.parallel._numThreads)
+    pyfftw.config.NUM_THREADS = min(1, freud.parallel.get_num_threads())
     logger.info("Setting number of threads to {}".format(
-        freud.parallel._numThreads))
+        freud.parallel.get_num_threads()))
 
     # Note that currently these functions are defined to match only the parts
     # of the numpy/scipy API that are actually used below. There is no promise


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above. -->

## Description
Use `freud.parallel` API in msd rather than accessing hidden variable.

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- Replace ??? with the issue number that this pull request resolves, if applicable. -->
This was causing runtime issues with actually accessing the variable since it's been renamed, but better to just use the API.

## How Has This Been Tested?
Existing tests pass.

## Screenshots
<!-- (if appropriate) -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds or improves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!-- Put an `x` in all the boxes that apply. If you're unsure about any of
     these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/glotzerlab/freud/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] I have updated the documentation (if relevant).
- [x] I have added tests that cover my changes (if relevant).
- [x] All new and existing tests passed.
- [x] I have updated the [credits](https://github.com/glotzerlab/freud/blob/master/doc/source/credits.rst).
- [x] I have updated the [Changelog](https://github.com/glotzerlab/freud/blob/master/ChangeLog.md).
