### PR TITLE
Add radii_of_gyration to ClusterProperties.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -20,6 +20,7 @@ and this project adheres to
 * NeighborLists and query arguments are now accepted on equal footing by compute methods that involve neighbor finding.
 * 2D PMFTs accept quaternions as well as angles for their orientations.
 * Extensive new documentation including tutorial for new users and reference sections on crucial topics.
+* ClusterProperties computes radius of gyration from the gyration tensor for each cluster.
 
 ### Changed
 * All compute objects that perform neighbor computations now use NeighborQuery internally.

--- a/doc/source/credits.rst
+++ b/doc/source/credits.rst
@@ -129,6 +129,8 @@ Bradley Dice - **Lead developer**
 * Standardized vector directionality in computes.
 * NeighborQuery support to ClusterProperties, GaussianDensity, Voronoi, PeriodicBuffer, Interface.
 * Standardized APIs for order parameters.
+* Added radius of gyration to ClusterProperties.
+
 
 Richmond Newman
 

--- a/freud/cluster.pyx
+++ b/freud/cluster.pyx
@@ -220,6 +220,12 @@ cdef class ClusterProperties(Compute):
             freud.util.arr_type_t.FLOAT)
 
     @Compute._computed_property
+    def radii_of_gyration(self):
+        """(:math:`N_{clusters}`,) :class:`numpy.ndarray`: The radius of
+        gyration of each cluster."""
+        return np.sqrt(np.trace(self.gyrations, axis1=-2, axis2=-1))
+
+    @Compute._computed_property
     def sizes(self):
         """(:math:`N_{clusters}`) :class:`numpy.ndarray`: The cluster sizes."""
         return freud.util.make_managed_numpy_array(

--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -83,17 +83,19 @@ class TestCluster(unittest.TestCase):
         props = freud.cluster.ClusterProperties()
         props.compute((box, positions), clust.cluster_idx)
 
-        com_1 = np.array([[0, -2, 0]])
-        com_2 = np.array([[-0.05, 1.95, 0]])
-        g_tensor_2 = np.array([[0.0025, 0.0025, 0],
-                               [0.0025, 0.0025, 0],
-                               [0, 0, 0]])
-        rg_2 = np.sqrt(2*(0.0025**2))
-        npt.assert_allclose(props.centers[0, :], com_1)
-        npt.assert_allclose(props.centers[1, :], com_2)
-        npt.assert_allclose(props.gyrations[0], 0)
-        npt.assert_allclose(props.gyrations[1], g_tensor_2)
-        npt.assert_allclose(props.radii_of_gyration, [0, rg_2])
+        com_1 = [0, -2, 0]
+        com_2 = [-0.05, 1.95, 0]
+        g_tensor_2 = [[0.0025, 0.0025, 0],
+                      [0.0025, 0.0025, 0],
+                      [0, 0, 0]]
+        rg_2 = np.sqrt(np.trace(g_tensor_2))
+        npt.assert_allclose(props.centers[0, :], com_1, rtol=1e-5, atol=1e-5)
+        npt.assert_allclose(props.centers[1, :], com_2, rtol=1e-5, atol=1e-5)
+        npt.assert_allclose(props.gyrations[0], 0, atol=1e-5)
+        npt.assert_allclose(
+            props.gyrations[1], g_tensor_2, rtol=1e-5, atol=1e-5)
+        npt.assert_allclose(
+            props.radii_of_gyration, [0, rg_2], rtol=1e-5, atol=1e-5)
 
     def test_cluster_keys(self):
         Nlattice = 4

--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -88,10 +88,12 @@ class TestCluster(unittest.TestCase):
         g_tensor_2 = np.array([[0.0025, 0.0025, 0],
                                [0.0025, 0.0025, 0],
                                [0, 0, 0]])
-        self.assertTrue(np.all(props.centers[0, :] == com_1))
-        self.assertTrue(np.allclose(props.centers[1, :], com_2))
-        self.assertTrue(np.all(props.gyrations[0] == 0))
-        self.assertTrue(np.allclose(props.gyrations[1], g_tensor_2))
+        rg_2 = np.sqrt(2*(0.0025**2))
+        npt.assert_allclose(props.centers[0, :], com_1)
+        npt.assert_allclose(props.centers[1, :], com_2)
+        npt.assert_allclose(props.gyrations[0], 0)
+        npt.assert_allclose(props.gyrations[1], g_tensor_2)
+        npt.assert_allclose(props.radii_of_gyration, [0, rg_2])
 
     def test_cluster_keys(self):
         Nlattice = 4


### PR DESCRIPTION
## Description
The radius of gyration is a pretty common quantity that users may want from the gyration tensors that are already being computed in `ClusterProperties`. I decided to add this after discussion with @atravitz.

## Motivation and Context
Resolves #407.

## How Has This Been Tested?
Added a new test.

## Screenshots
Yellow = larger radius of gyration (longer, stretched out). Purple = curled up, small radius of gyration.
![image](https://user-images.githubusercontent.com/3943761/66428182-90efe680-e9e3-11e9-85d0-260bdcd35cfd.png)


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds or improves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!-- Put an `x` in all the boxes that apply. If you're unsure about any of
     these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/glotzerlab/freud/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] I have updated the documentation (if relevant).
- [x] I have added tests that cover my changes (if relevant).
- [x] All new and existing tests passed.
- [x] I have updated the [credits](https://github.com/glotzerlab/freud/blob/master/doc/source/credits.rst).
- [x] I have updated the [Changelog](https://github.com/glotzerlab/freud/blob/master/ChangeLog.md).
