### PR TITLE
Fix/localdensity query points

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -55,6 +55,7 @@ and this project adheres to
 * RDF no longer forces the first bin of the PCF and first two bins of the cumulative counts to be 0.
 * LinkCell nearest neighbor queries properly check the largest distance found before proceeding to next shell.
 * Compute classes requiring 2D systems check the dimensionality of their input boxes.
+* LocalDensity uses the correct number of points/query points.
 
 ### Removed
 * The freud.util module.

--- a/cpp/density/LocalDensity.cc
+++ b/cpp/density/LocalDensity.cc
@@ -22,10 +22,8 @@ void LocalDensity::compute(const freud::locality::NeighborQuery* neighbor_query,
 {
     m_box = neighbor_query->getBox();
 
-    const unsigned int n_points = neighbor_query->getNPoints();
-
-    m_density_array.prepare(n_points);
-    m_num_neighbors_array.prepare(n_points);
+    m_density_array.prepare(n_query_points);
+    m_num_neighbors_array.prepare(n_query_points);
 
     const float area = M_PI * m_r_max * m_r_max;
     const float volume = float(4.0/3.0) * M_PI * m_r_max * m_r_max * m_r_max;

--- a/doc/source/credits.rst
+++ b/doc/source/credits.rst
@@ -130,6 +130,7 @@ Bradley Dice - **Lead developer**
 * NeighborQuery support to ClusterProperties, GaussianDensity, Voronoi, PeriodicBuffer, Interface.
 * Standardized APIs for order parameters.
 * Improved Voronoi plotting code.
+* Corrected number of points/query points in LocalDensity.
 
 Richmond Newman
 

--- a/freud/density.pyx
+++ b/freud/density.pyx
@@ -303,10 +303,10 @@ cdef class LocalDensity(PairCompute):
     R"""Computes the local density around a particle.
 
     The density of the local environment is computed and averaged for a given
-    set of reference points in a sea of data points. Providing the same points
+    set of query points in a sea of data points. Providing the same points
     calculates them against themselves. Computing the local density results in
-    an array listing the value of the local density around each reference
-    point. Also available is the number of neighbors for each reference point,
+    an array listing the value of the local density around each query
+    point. Also available is the number of neighbors for each query point,
     giving the user the ability to count the number of particles in that
     region. Note that the computed density is essentially a number density
     (that allows for fractional values as described below). If your particles
@@ -319,10 +319,10 @@ cdef class LocalDensity(PairCompute):
     determine the exact amount of overlap area (volume), the LocalDensity class
     performs a simple linear interpolation relative to the centers of the data
     points.  Specifically, a point is counted as one neighbor of a given
-    reference point if it is entirely contained within the :code:`r_max`, half
+    query point if it is entirely contained within the :code:`r_max`, half
     of a neighbor if the distance to its center is exactly :code:`r_max`, and
     zero if its center is a distance greater than or equal to :code:`r_max +
-    diameter` from the reference point's center. Graphically, this looks like:
+    diameter` from the query point's center. Graphically, this looks like:
 
     .. image:: images/density.png
 
@@ -400,7 +400,7 @@ cdef class LocalDensity(PairCompute):
     @Compute._computed_property
     def density(self):
         """(:math:`N_{points}`) :class:`numpy.ndarray`: Density of points per
-        ref_point."""
+        query point."""
         return freud.util.make_managed_numpy_array(
             &self.thisptr.getDensity(),
             freud.util.arr_type_t.FLOAT)
@@ -408,7 +408,7 @@ cdef class LocalDensity(PairCompute):
     @Compute._computed_property
     def num_neighbors(self):
         """(:math:`N_{points}`) :class:`numpy.ndarray`: Number of neighbor
-        points for each ref_point."""
+        points for each query point."""
         return freud.util.make_managed_numpy_array(
             &self.thisptr.getNumNeighbors(),
             freud.util.arr_type_t.FLOAT)
@@ -424,7 +424,7 @@ cdef class RDF(SpatialHistogram1D):
     R"""Computes RDF for supplied data.
 
     The RDF (:math:`g \left( r \right)`) is computed and averaged for a given
-    set of reference points in a sea of data points. Providing the same points
+    set of query points in a sea of data points. Providing the same points
     calculates them against themselves. Computing the RDF results in an RDF
     array listing the value of the RDF at each given :math:`r`, listed in the
     :code:`R` array.

--- a/freud/environment.pyx
+++ b/freud/environment.pyx
@@ -729,14 +729,6 @@ cdef class _EnvironmentRMSDMinimizer(_MatchEnv):
     def __init__(self):
         pass
 
-    @Compute._computed_property
-    def rmsds(self):
-        """:math:`(N_p, )` :class:`numpy.ndarray`: A boolean array of the RMSDs
-        found for each point's environment."""
-        return freud.util.make_managed_numpy_array(
-            &self.thisptr.getRMSDs(),
-            freud.util.arr_type_t.FLOAT)
-
     def compute(self, system, motif, neighbors=None,
                 registration=False):
         R"""Rotate (if registration=True) and permute the environments of all
@@ -787,10 +779,18 @@ cdef class _EnvironmentRMSDMinimizer(_MatchEnv):
 
         return self
 
+    @Compute._computed_property
+    def rmsds(self):
+        """:math:`(N_p, )` :class:`numpy.ndarray`: A boolean array of the RMSDs
+        found for each point's environment."""
+        return freud.util.make_managed_numpy_array(
+            &self.thisptr.getRMSDs(),
+            freud.util.arr_type_t.FLOAT)
+
 
 cdef class AngularSeparationNeighbor(PairCompute):
-    R"""Calculates the minimum angles of separation between particles and
-    references."""
+    R"""Calculates the minimum angles of separation between orientations and
+    query orientations."""
     cdef freud._environment.AngularSeparationNeighbor * thisptr
 
     def __cinit__(self):
@@ -827,8 +827,8 @@ cdef class AngularSeparationNeighbor(PairCompute):
                 :code:`orientations` if :code:`None`.  (Default
                 value = :code:`None`).
             equiv_orientations ((:math:`N_{equiv}`, 4) :class:`numpy.ndarray`, optional):
-                The set of all equivalent quaternions that takes the point
-                as it is defined to some global reference orientation.
+                The set of all equivalent quaternions that map the particle
+                to itself (the elements of its rotational symmetry group).
                 Important: :code:`equiv_orientations` must include both
                 :math:`q` and :math:`-q`, for all included quaternions. Note
                 that this calculation assumes that all points in the system
@@ -901,8 +901,8 @@ cdef class AngularSeparationNeighbor(PairCompute):
 
 
 cdef class AngularSeparationGlobal(Compute):
-    R"""Calculates the minimum angles of separation between particles and
-    references."""
+    R"""Calculates the minimum angles of separation between orientations and
+    global orientations."""
     cdef freud._environment.AngularSeparationGlobal * thisptr
 
     def __cinit__(self):
@@ -923,13 +923,13 @@ cdef class AngularSeparationGlobal(Compute):
 
         Args:
             global_orientations ((:math:`N_{global}`, 4) :class:`numpy.ndarray`):
-                Set of global reference orientations to calculate the order
+                Set of global orientations to calculate the order
                 parameter.
             orientations ((:math:`N_{particles}`, 4) :class:`numpy.ndarray`):
                 Orientations to calculate the order parameter.
             equiv_orientations ((:math:`N_{equiv}`, 4) :class:`numpy.ndarray`, optional):
-                The set of all equivalent quaternions that takes the point
-                as it is defined to some global reference orientation.
+                The set of all equivalent quaternions that map the particle
+                to itself (the elements of its rotational symmetry group).
                 Important: :code:`equiv_orientations` must include both
                 :math:`q` and :math:`-q`, for all included quaternions. Note
                 that this calculation assumes that all points in the system
@@ -989,12 +989,6 @@ cdef class LocalBondProjection(PairCompute):
     def __dealloc__(self):
         del self.thisptr
 
-    @Compute._computed_property
-    def nlist(self):
-        """:class:`freud.locality.NeighborList`: The neighbor list from the
-        last compute."""
-        return freud.locality._nlist_from_cnlist(self.thisptr.getNList())
-
     def compute(self, system, orientations, proj_vecs,
                 query_points=None, equiv_orientations=np.array([[1, 0, 0, 0]]),
                 neighbors=None):
@@ -1013,7 +1007,7 @@ cdef class LocalBondProjection(PairCompute):
                 Orientations associated with system points that are used to
                 calculate bonds.
             proj_vecs ((:math:`N_{vectors}`, 3) :class:`numpy.ndarray`):
-                The set of reference vectors, defined in the reference
+                The set of projection vectors, defined in the query
                 particles' reference frame, to calculate maximal local bond
                 projections onto.
             query_points ((:math:`N_{query\_points}`, 3) :class:`numpy.ndarray`, optional):
@@ -1022,8 +1016,8 @@ cdef class LocalBondProjection(PairCompute):
                 value = :code:`None`).
                 (Default value = :code:`None`).
             equiv_orientations ((:math:`N_{equiv}`, 4) :class:`numpy.ndarray`, optional):
-                The set of all equivalent quaternions that takes the point
-                as it is defined to some global reference orientation.
+                The set of all equivalent quaternions that map the particle
+                to itself (the elements of its rotational symmetry group).
                 Important: :code:`equiv_orientations` must include both
                 :math:`q` and :math:`-q`, for all included quaternions. Note
                 that this calculation assumes that all points in the system
@@ -1070,10 +1064,16 @@ cdef class LocalBondProjection(PairCompute):
         return self
 
     @Compute._computed_property
+    def nlist(self):
+        """:class:`freud.locality.NeighborList`: The neighbor list from the
+        last compute."""
+        return freud.locality._nlist_from_cnlist(self.thisptr.getNList())
+
+    @Compute._computed_property
     def projections(self):
-        """:math:`\\left(N_{reference}, N_{neighbors}, N_{projection\\_vecs}
+        """:math:`\\left(N_{bonds}, N_{projection\\_vecs}
         \\right)` :class:`numpy.ndarray`: The projection of each bond between
-        reference particles and their neighbors onto each of the projection
+        query particles and their neighbors onto each of the projection
         vectors."""
         return freud.util.make_managed_numpy_array(
             &self.thisptr.getProjections(),
@@ -1081,8 +1081,8 @@ cdef class LocalBondProjection(PairCompute):
 
     @Compute._computed_property
     def normed_projections(self):
-        """:math:`\\left(N_{reference}, N_{neighbors}, N_{projection\\_vecs} \\right)` :class:`numpy.ndarray`:
-        The projection of each bond between reference particles and their
+        """:math:`\\left(N_{bonds}, N_{projection\\_vecs} \\right)` :class:`numpy.ndarray`:
+        The projection of each bond between query particles and their
         neighbors onto each of the projection vectors, normalized by the length
         of the bond."""  # noqa: E501
         return freud.util.make_managed_numpy_array(

--- a/freud/environment.pyx
+++ b/freud/environment.pyx
@@ -134,7 +134,7 @@ cdef class BondOrder(SpatialHistogram):
             "either provide query arguments or a neighbor list to this "
             "compute method.".format(type(self).__name__))
 
-    def compute(self, system, orientations, query_points=None,
+    def compute(self, system, orientations=None, query_points=None,
                 query_orientations=None, neighbors=None, reset=True):
         R"""Calculates the correlation function and adds to the current
         histogram.
@@ -145,7 +145,8 @@ cdef class BondOrder(SpatialHistogram):
                 :class:`freud.locality.NeighborQuery.from_system`.
             orientations ((:math:`N_{points}`, 4) :class:`numpy.ndarray`):
                 Orientations associated with system points that are used to
-                calculate bonds.
+                calculate bonds. Uses identity quaternions if :code:`None`
+                (Default value = :code:`None`).
             query_points ((:math:`N_{query\_points}`, 3) :class:`numpy.ndarray`, optional):
                 Query points used to calculate the correlation function.  Uses
                 the system's points if :code:`None` (Default
@@ -177,6 +178,8 @@ cdef class BondOrder(SpatialHistogram):
 
         nq, nlist, qargs, l_query_points, num_query_points = \
             self._preprocess_arguments(system, query_points, neighbors)
+        if orientations is None:
+            orientations = np.array([[1, 0, 0, 0]] * nq.points.shape[0])
         if query_orientations is None:
             query_orientations = orientations
 
@@ -935,7 +938,7 @@ cdef class AngularSeparationGlobal(Compute):
                 that this calculation assumes that all points in the system
                 share the same set of equivalent orientations.
                 (Default value = :code:`[[1, 0, 0, 0]]`)
-        """  # noqa
+        """  # noqa: E501
         global_orientations = freud.util._convert_array(
             global_orientations, shape=(None, 4))
         orientations = freud.util._convert_array(
@@ -962,8 +965,8 @@ cdef class AngularSeparationGlobal(Compute):
 
     @Compute._computed_property
     def angles(self):
-        """:math:`\\left(N_{bonds}\\right)` :class:`numpy.ndarray`: The global
-        angles in radians."""
+        """:math:`\\left(N_{orientations}, N_{global\\_orientations}\\right)` :class:`numpy.ndarray`:
+        The global angles in radians."""  # noqa: E501
         return freud.util.make_managed_numpy_array(
             &self.thisptr.getAngles(),
             freud.util.arr_type_t.FLOAT)
@@ -1082,9 +1085,9 @@ cdef class LocalBondProjection(PairCompute):
     @Compute._computed_property
     def normed_projections(self):
         """:math:`\\left(N_{bonds}, N_{projection\\_vecs} \\right)` :class:`numpy.ndarray`:
-        The projection of each bond between query particles and their
-        neighbors onto each of the projection vectors, normalized by the length
-        of the bond."""  # noqa: E501
+        The projection of each bond between query particles and their neighbors
+        onto each of the projection vectors, normalized by the length of the
+        bond."""  # noqa: E501
         return freud.util.make_managed_numpy_array(
             &self.thisptr.getNormedProjections(),
             freud.util.arr_type_t.FLOAT)

--- a/freud/pmft.pyx
+++ b/freud/pmft.pyx
@@ -6,11 +6,11 @@ The :class:`freud.pmft` module allows for the calculation of the Potential of
 Mean Force and Torque (PMFT) [vanAndersKlotsa2014]_ [vanAndersAhmed2014]_ in a
 number of different coordinate systems. The shape of the arrays computed by
 this module depend on the coordinate system used, with space discretized into a
-set of bins created by the PMFT object's constructor. Each reference point's
+set of bins created by the PMFT object's constructor. Each query point's
 neighboring points are assigned to bins, determined by the relative positions
 and/or orientations of the particles. Next, the positional correlation function
 (PCF) is computed by normalizing the binned histogram, by dividing out the
-number of accumulated frames, bin sizes (the Jacobian), and reference point
+number of accumulated frames, bin sizes (the Jacobian), and query point
 number density. The PMFT is then defined as the negative logarithm of the PCF.
 For further descriptions of the numerical methods used to compute the PMFT,
 refer to the supplementary information of [vanAndersKlotsa2014]_.

--- a/tests/test_density_LocalDensity.py
+++ b/tests/test_density_LocalDensity.py
@@ -76,7 +76,7 @@ class TestLD(unittest.TestCase):
     def test_points_ne_query_points(self):
         box = freud.box.Box.cube(10)
         points = np.array([[0, 0, 0], [1, 0, 0]])
-        query_points = np.array([[0, 1, 0], [-1, -1, 0]])
+        query_points = np.array([[0, 1, 0], [-1, -1, 0], [4, 0, 0]])
         diameter = 1
         r_max = 2
 
@@ -88,7 +88,7 @@ class TestLD(unittest.TestCase):
         cd0 = 2/v_around
         cd1 = (1 + get_fraction(np.linalg.norm(points[1] - query_points[1]),
                                 r_max, diameter)) / v_around
-        correct_density = [cd0, cd1]
+        correct_density = [cd0, cd1, 0]
         npt.assert_allclose(ld.density, correct_density, rtol=1e-4)
 
 

--- a/tests/test_environment_BondOrder.py
+++ b/tests/test_environment_BondOrder.py
@@ -115,7 +115,12 @@ class TestBondOrder(unittest.TestCase):
             bod = freud.environment.BondOrder(
                 bins=(n_bins_theta, n_bins_phi))
 
-            bod.compute(nq, query_points=query_points, neighbors=neighbors)
+            # orientations are not used in bod mode
+            orientations = np.array([[1, 0, 0, 0]]*len(points))
+            query_orientations = np.array([[1, 0, 0, 0]]*len(query_points))
+
+            bod.compute(nq, orientations, query_points, query_orientations,
+                        neighbors=neighbors)
 
             # we want to make sure that we get 12 nonzero places, so we can
             # test whether we are not considering neighbors between points

--- a/tests/test_environment_BondOrder.py
+++ b/tests/test_environment_BondOrder.py
@@ -115,12 +115,7 @@ class TestBondOrder(unittest.TestCase):
             bod = freud.environment.BondOrder(
                 bins=(n_bins_theta, n_bins_phi))
 
-            # orientations are not used in bod mode
-            ref_orientations = np.array([[1, 0, 0, 0]]*len(points))
-            orientations = np.array([[1, 0, 0, 0]]*len(query_points))
-
-            bod.compute(nq, ref_orientations,
-                        query_points, orientations, neighbors=neighbors)
+            bod.compute(nq, query_points=query_points, neighbors=neighbors)
 
             # we want to make sure that we get 12 nonzero places, so we can
             # test whether we are not considering neighbors between points


### PR DESCRIPTION
## Description
`LocalDensity` was using the wrong number of points (`n_points` instead of `n_query_points`) for its array sizes. Also its docs were still using the term "reference points."

## Motivation and Context
I caught this while rewriting examples. The example has `n_query_points != n_points` and it wasn't possible to get the desired answer without fixing this behavior.

## How Has This Been Tested?
I edited a test so that `points != query_points` **and** `n_points != n_query_points`.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds or improves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!-- Put an `x` in all the boxes that apply. If you're unsure about any of
     these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/glotzerlab/freud/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] I have updated the documentation (if relevant).
- [x] I have added tests that cover my changes (if relevant).
- [x] All new and existing tests passed.
- [x] I have updated the [credits](https://github.com/glotzerlab/freud/blob/master/doc/source/credits.rst).
- [x] I have updated the [Changelog](https://github.com/glotzerlab/freud/blob/master/ChangeLog.md).