### PR TITLE
Feature/compute periodicbuffer

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -37,7 +37,7 @@ and this project adheres to
 * APIs for several order parameters have been standardized.
 * SolidLiquid order parameter has been completely rewritten, fixing several bugs and simplifying its C++ code.
 * NeighborQuery objects require z == 0 for all points if the box is 2D.
-* Renamed several Box methods, ParticleBuffer is now PeriodicBuffer.
+* Renamed several Box methods, box.ParticleBuffer is now locality.PeriodicBuffer.
 * Refactored and renamed attributes of Cluster and ClusterProperties modules.
 * All class attributes are stored in the C++ members and accessed via getters wrapped as Python properties.
 * Bond vector directionality is standardized for all computes that use it (always from query\_point to point).

--- a/cpp/locality/PeriodicBuffer.cc
+++ b/cpp/locality/PeriodicBuffer.cc
@@ -9,7 +9,7 @@
     \brief Replicates points across periodic boundaries.
 */
 
-namespace freud { namespace box {
+namespace freud { namespace locality {
 
 void PeriodicBuffer::compute(const freud::locality::NeighborQuery* neighbor_query,
                              const vec3<float> buff, const bool use_images)
@@ -34,12 +34,12 @@ void PeriodicBuffer::compute(const freud::locality::NeighborQuery* neighbor_quer
     {
         images = vec3<int>(ceil(buff.x), ceil(buff.y), ceil(buff.z));
         m_buffer_box
-            = Box((1 + images.x) * L.x, (1 + images.y) * L.y, (1 + images.z) * L.z, xy, xz, yz, is2D);
+            = freud::box::Box((1 + images.x) * L.x, (1 + images.y) * L.y, (1 + images.z) * L.z, xy, xz, yz, is2D);
     }
     else
     {
         images = vec3<int>(ceil(buff.x / L.x), ceil(buff.y / L.y), ceil(buff.z / L.z));
-        m_buffer_box = Box(L.x + 2 * buff.x, L.y + 2 * buff.y, L.z + 2 * buff.z, xy, xz, yz, is2D);
+        m_buffer_box = freud::box::Box(L.x + 2 * buff.x, L.y + 2 * buff.y, L.z + 2 * buff.z, xy, xz, yz, is2D);
     }
 
     if (is2D)
@@ -109,4 +109,4 @@ void PeriodicBuffer::compute(const freud::locality::NeighborQuery* neighbor_quer
     }
 }
 
-}; }; // end namespace freud::box
+}; }; // end namespace freud::locality

--- a/cpp/locality/PeriodicBuffer.h
+++ b/cpp/locality/PeriodicBuffer.h
@@ -14,7 +14,7 @@
     \brief Replicates points across periodic boundaries.
 */
 
-namespace freud { namespace box {
+namespace freud { namespace locality {
 
 class PeriodicBuffer
 {
@@ -23,13 +23,13 @@ public:
     PeriodicBuffer() {}
 
     //! Get the simulation box
-    const Box& getBox() const
+    const freud::box::Box& getBox() const
     {
         return m_box;
     }
 
     //! Get the buffer box
-    const Box& getBufferBox() const
+    const freud::box::Box& getBufferBox() const
     {
         return m_buffer_box;
     }
@@ -51,12 +51,12 @@ public:
     }
 
 private:
-    Box m_box;  //!< Simulation box of the original points
-    Box m_buffer_box; //!< Simulation box of the replicated points
+    freud::box::Box m_box;  //!< Simulation box of the original points
+    freud::box::Box m_buffer_box; //!< Simulation box of the replicated points
     std::vector<vec3<float> > m_buffer_points; //!< The replicated points
     std::vector<unsigned int> m_buffer_ids; //!< The replicated points' original point ids
 };
 
-}; }; // end namespace freud::box
+}; }; // end namespace freud::locality
 
 #endif // PERIODIC_BUFFER_H

--- a/doc/source/box.rst
+++ b/doc/source/box.rst
@@ -8,7 +8,6 @@ Box Module
     :nosignatures:
 
     freud.box.Box
-    freud.box.PeriodicBuffer
 
 .. rubric:: Details
 

--- a/doc/source/credits.rst
+++ b/doc/source/credits.rst
@@ -132,6 +132,7 @@ Bradley Dice - **Lead developer**
 * Added radius of gyration to ClusterProperties.
 * Improved Voronoi plotting code.
 * Corrected number of points/query points in LocalDensity.
+* Made PeriodicBuffer inherit from _Compute.
 
 Richmond Newman
 

--- a/doc/source/locality.rst
+++ b/doc/source/locality.rst
@@ -12,6 +12,7 @@ Locality Module
     freud.locality.NeighborList
     freud.locality.NeighborQuery
     freud.locality.NeighborQueryResult
+    freud.locality.PeriodicBuffer
     freud.locality.RawPoints
     freud.locality.Voronoi
 

--- a/freud/_box.pxd
+++ b/freud/_box.pxd
@@ -3,7 +3,7 @@
 
 from libcpp.memory cimport shared_ptr
 from libcpp.vector cimport vector
-from libcpp cimport bool as bool_t
+from libcpp cimport bool
 from freud.util cimport vec3
 from libcpp.vector cimport vector
 from libcpp.string cimport string
@@ -14,15 +14,15 @@ ctypedef unsigned int uint
 cdef extern from "Box.h" namespace "freud::box":
     cdef cppclass Box:
         Box()
-        Box(float, bool_t)
-        Box(float, float, float, bool_t)
-        Box(float, float, float, float, float, float, bool_t)
+        Box(float, bool)
+        Box(float, float, float, bool)
+        Box(float, float, float, float, float, float, bool)
 
         void setL(vec3[float])
         void setL(float, float, float)
 
-        void set2D(bool_t)
-        bool_t is2D() const
+        void set2D(bool)
+        bool is2D() const
 
         float getLx() const
         float getLy() const
@@ -52,24 +52,11 @@ cdef extern from "Box.h" namespace "freud::box":
         void unwrap(vec3[float]*, const vec3[int]*,
                     unsigned int) const
 
-        vec3[bool_t] getPeriodic() const
-        bool_t getPeriodicX() const
-        bool_t getPeriodicY() const
-        bool_t getPeriodicZ() const
-        void setPeriodic(bool_t, bool_t, bool_t)
-        void setPeriodicX(bool_t)
-        void setPeriodicY(bool_t)
-        void setPeriodicZ(bool_t)
-
-
-cdef extern from "PeriodicBuffer.h" namespace "freud::box":
-    cdef cppclass PeriodicBuffer:
-        PeriodicBuffer()
-        const Box & getBox() const
-        const Box & getBufferBox() const
-        void compute(
-            const freud._locality.NeighborQuery*,
-            const vec3[float],
-            const bool_t) except +
-        vector[vec3[float]] getBufferPoints() const
-        vector[uint] getBufferIds() const
+        vec3[bool] getPeriodic() const
+        bool getPeriodicX() const
+        bool getPeriodicY() const
+        bool getPeriodicZ() const
+        void setPeriodic(bool, bool, bool)
+        void setPeriodicX(bool)
+        void setPeriodicY(bool)
+        void setPeriodicZ(bool)

--- a/freud/_locality.pxd
+++ b/freud/_locality.pxd
@@ -108,14 +108,6 @@ cdef extern from "AABBQuery.h" namespace "freud::locality":
                   const vec3[float]*,
                   unsigned int) except +
 
-cdef extern from "Voronoi.h" namespace "freud::locality":
-    cdef cppclass Voronoi:
-        Voronoi()
-        void compute(const NeighborQuery*) nogil except +
-        vector[vector[vec3[double]]] getPolytopes() const
-        const freud.util.ManagedArray[double] &getVolumes() const
-        shared_ptr[NeighborList] getNeighborList() const
-
 cdef extern from "BondHistogramCompute.h" namespace "freud::locality":
     cdef cppclass BondHistogramCompute:
         BondHistogramCompute()
@@ -127,3 +119,23 @@ cdef extern from "BondHistogramCompute.h" namespace "freud::locality":
         vector[vector[float]] getBinCenters() const
         vector[pair[float, float]] getBounds() const
         vector[unsigned int] getAxisSizes() const
+
+cdef extern from "PeriodicBuffer.h" namespace "freud::locality":
+    cdef cppclass PeriodicBuffer:
+        PeriodicBuffer()
+        const freud._box.Box & getBox() const
+        const freud._box.Box & getBufferBox() const
+        void compute(
+            const NeighborQuery*,
+            const vec3[float],
+            const bool) except +
+        vector[vec3[float]] getBufferPoints() const
+        vector[uint] getBufferIds() const
+
+cdef extern from "Voronoi.h" namespace "freud::locality":
+    cdef cppclass Voronoi:
+        Voronoi()
+        void compute(const NeighborQuery*) nogil except +
+        vector[vector[vec3[double]]] getPolytopes() const
+        const freud.util.ManagedArray[double] &getVolumes() const
+        shared_ptr[NeighborList] getNeighborList() const

--- a/freud/box.pxd
+++ b/freud/box.pxd
@@ -7,6 +7,3 @@ cdef class Box:
     cdef freud._box.Box * thisptr
 
 cdef BoxFromCPP(const freud._box.Box & cppbox)
-
-cdef class PeriodicBuffer:
-    cdef freud._box.PeriodicBuffer * thisptr

--- a/freud/cluster.pyx
+++ b/freud/cluster.pyx
@@ -12,7 +12,7 @@ import freud.locality
 import freud.util
 
 from cython.operator cimport dereference
-from freud.util cimport Compute
+from freud.util cimport _Compute
 from freud.locality cimport _PairCompute
 from freud.util cimport vec3, uint
 
@@ -101,12 +101,12 @@ cdef class Cluster(_PairCompute):
             l_keys_ptr)
         return self
 
-    @Compute._computed_property
+    @_Compute._computed_property
     def num_clusters(self):
         """int: The number of clusters."""
         return self.thisptr.getNumClusters()
 
-    @Compute._computed_property
+    @_Compute._computed_property
     def cluster_idx(self):
         """:math:`N_{points}` :class:`numpy.ndarray`: The cluster index for
         each point."""
@@ -114,7 +114,7 @@ cdef class Cluster(_PairCompute):
             &self.thisptr.getClusterIdx(),
             freud.util.arr_type_t.UNSIGNED_INT)
 
-    @Compute._computed_property
+    @_Compute._computed_property
     def cluster_keys(self):
         """list(list): A list of lists of the keys contained in each
         cluster."""
@@ -152,7 +152,7 @@ cdef class Cluster(_PairCompute):
             return None
 
 
-cdef class ClusterProperties(Compute):
+cdef class ClusterProperties(_Compute):
     R"""Routines for computing properties of point clusters.
 
     Given a set of points and cluster ids (from :class:`~.Cluster` or another
@@ -203,7 +203,7 @@ cdef class ClusterProperties(Compute):
             <unsigned int*> &l_cluster_idx[0])
         return self
 
-    @Compute._computed_property
+    @_Compute._computed_property
     def centers(self):
         """(:math:`N_{clusters}`, 3) :class:`numpy.ndarray`: The centers of
         mass of the clusters."""
@@ -211,7 +211,7 @@ cdef class ClusterProperties(Compute):
             &self.thisptr.getClusterCenters(),
             freud.util.arr_type_t.FLOAT, 3)
 
-    @Compute._computed_property
+    @_Compute._computed_property
     def gyrations(self):
         """(:math:`N_{clusters}`, 3, 3) :class:`numpy.ndarray`: The gyration
         tensors of the clusters."""
@@ -219,13 +219,13 @@ cdef class ClusterProperties(Compute):
             &self.thisptr.getClusterGyrations(),
             freud.util.arr_type_t.FLOAT)
 
-    @Compute._computed_property
+    @_Compute._computed_property
     def radii_of_gyration(self):
         """(:math:`N_{clusters}`,) :class:`numpy.ndarray`: The radius of
         gyration of each cluster."""
         return np.sqrt(np.trace(self.gyrations, axis1=-2, axis2=-1))
 
-    @Compute._computed_property
+    @_Compute._computed_property
     def sizes(self):
         """(:math:`N_{clusters}`) :class:`numpy.ndarray`: The cluster sizes."""
         return freud.util.make_managed_numpy_array(

--- a/freud/density.pyx
+++ b/freud/density.pyx
@@ -12,7 +12,7 @@ import warnings
 import numpy as np
 
 from cython.operator cimport dereference
-from freud.util cimport Compute
+from freud.util cimport _Compute
 from freud.locality cimport _PairCompute, _SpatialHistogram1D
 from freud.util cimport vec3
 
@@ -141,7 +141,7 @@ cdef class CorrelationFunction(_SpatialHistogram1D):
             dereference(qargs.thisptr))
         return self
 
-    @Compute._computed_property
+    @_Compute._computed_property
     def correlation(self):
         """(:math:`N_{bins}`) :class:`numpy.ndarray`: Expected (average)
         product of all values at a given radial distance."""
@@ -180,7 +180,7 @@ cdef class CorrelationFunction(_SpatialHistogram1D):
             return None
 
 
-cdef class GaussianDensity(Compute):
+cdef class GaussianDensity(_Compute):
     R"""Computes the density of a system on a grid.
 
     Replaces particle positions with a Gaussian blur and calculates the
@@ -221,7 +221,7 @@ cdef class GaussianDensity(Compute):
     def __dealloc__(self):
         del self.thisptr
 
-    @Compute._computed_property
+    @_Compute._computed_property
     def box(self):
         """:class:`freud.box.Box`: Box used in the calculation."""
         return freud.box.BoxFromCPP(self.thisptr.getBox())
@@ -239,7 +239,7 @@ cdef class GaussianDensity(Compute):
         self.thisptr.compute(nq.get_ptr())
         return self
 
-    @Compute._computed_property
+    @_Compute._computed_property
     def density(self):
         """(:math:`w_x`, :math:`w_y`, :math:`w_z`) :class:`numpy.ndarray`: The
         image grid with the Gaussian density."""
@@ -350,7 +350,7 @@ cdef class LocalDensity(_PairCompute):
         """float: Diameter of particle circumsphere."""
         return self.thisptr.getDiameter()
 
-    @Compute._computed_property
+    @_Compute._computed_property
     def box(self):
         """:class:`freud.box.Box`: Box used in the calculation."""
         return freud.box.BoxFromCPP(self.thisptr.getBox())
@@ -397,7 +397,7 @@ cdef class LocalDensity(_PairCompute):
         return dict(mode="ball",
                     r_max=self.r_max + 0.5*self.diameter)
 
-    @Compute._computed_property
+    @_Compute._computed_property
     def density(self):
         """(:math:`N_{points}`) :class:`numpy.ndarray`: Density of points per
         query point."""
@@ -405,7 +405,7 @@ cdef class LocalDensity(_PairCompute):
             &self.thisptr.getDensity(),
             freud.util.arr_type_t.FLOAT)
 
-    @Compute._computed_property
+    @_Compute._computed_property
     def num_neighbors(self):
         """(:math:`N_{points}`) :class:`numpy.ndarray`: Number of neighbor
         points for each query point."""
@@ -507,7 +507,7 @@ cdef class RDF(_SpatialHistogram1D):
             dereference(qargs.thisptr))
         return self
 
-    @Compute._computed_property
+    @_Compute._computed_property
     def rdf(self):
         """(:math:`N_{bins}`,) :class:`numpy.ndarray`: Histogram of RDF
         values."""
@@ -515,7 +515,7 @@ cdef class RDF(_SpatialHistogram1D):
             &self.thisptr.getRDF(),
             freud.util.arr_type_t.FLOAT)
 
-    @Compute._computed_property
+    @_Compute._computed_property
     def n_r(self):
         """(:math:`N_{bins}`,) :class:`numpy.ndarray`: Histogram of cumulative
         bin_counts values. More precisely, :code:`n_r[i]` is the average number

--- a/freud/environment.pyx
+++ b/freud/environment.pyx
@@ -12,7 +12,7 @@ import numpy as np
 import warnings
 import freud.locality
 
-from freud.util cimport Compute
+from freud.util cimport _Compute
 from freud.locality cimport _PairCompute, _SpatialHistogram
 from freud.util cimport vec3, quat
 from libcpp.vector cimport vector
@@ -200,14 +200,14 @@ cdef class BondOrder(_SpatialHistogram):
             nlist.get_ptr(), dereference(qargs.thisptr))
         return self
 
-    @Compute._computed_property
+    @_Compute._computed_property
     def bond_order(self):
         """:math:`\\left(N_{\\phi}, N_{\\theta} \\right)` :class:`numpy.ndarray`: Bond order."""  # noqa: E501
         return freud.util.make_managed_numpy_array(
             &self.thisptr.getBondOrder(),
             freud.util.arr_type_t.FLOAT)
 
-    @Compute._computed_property
+    @_Compute._computed_property
     def box(self):
         """:class:`freud.box.Box`: Box used in the calculation."""
         return freud.box.BoxFromCPP(self.thisptr.getBox())
@@ -326,13 +326,13 @@ cdef class LocalDescriptors(_PairCompute):
             nlist.get_ptr(), dereference(qargs.thisptr))
         return self
 
-    @Compute._computed_property
+    @_Compute._computed_property
     def nlist(self):
         """:class:`freud.locality.NeighborList`: The neighbor list from the
         last compute."""
         return freud.locality._nlist_from_cnlist(self.thisptr.getNList())
 
-    @Compute._computed_property
+    @_Compute._computed_property
     def sph(self):
         """:math:`\\left(N_{bonds}, \\text{SphWidth} \\right)`
         :class:`numpy.ndarray`: The last computed spherical harmonic array."""
@@ -340,7 +340,7 @@ cdef class LocalDescriptors(_PairCompute):
             &self.thisptr.getSph(),
             freud.util.arr_type_t.COMPLEX_FLOAT)
 
-    @Compute._computed_property
+    @_Compute._computed_property
     def num_sphs(self):
         """unsigned int: The last number of spherical harmonics computed. This
         is equal to the number of bonds in the last computation, which is at
@@ -486,7 +486,7 @@ cdef class _MatchEnv(_PairCompute):
         # Abstract class
         pass
 
-    @Compute._computed_property
+    @_Compute._computed_property
     def point_environments(self):
         """:math:`\\left(N_{points}, N_{neighbors}, 3\\right)`
         :class:`numpy.ndarray`: All environments for all points."""
@@ -581,7 +581,7 @@ cdef class EnvironmentCluster(_MatchEnv):
             registration, global_search)
         return self
 
-    @Compute._computed_property
+    @_Compute._computed_property
     def cluster_idx(self):
         """:math:`\\left(N_{particles}\\right)` :class:`numpy.ndarray`: The
         per-particle index indicating cluster membership."""
@@ -589,12 +589,12 @@ cdef class EnvironmentCluster(_MatchEnv):
             &self.thisptr.getClusters(),
             freud.util.arr_type_t.UNSIGNED_INT)
 
-    @Compute._computed_property
+    @_Compute._computed_property
     def num_clusters(self):
         """unsigned int: The number of clusters."""
         return self.thisptr.getNumClusters()
 
-    @Compute._computed_property
+    @_Compute._computed_property
     def cluster_environments(self):
         """:math:`\\left(N_{clusters}, N_{neighbors}, 3\\right`
         :class:`numpy.ndarray`): The environments for all clusters."""
@@ -700,7 +700,7 @@ cdef class EnvironmentMotifMatch(_MatchEnv):
             <vec3[float]*> &l_motif[0, 0], nRef,
             threshold, registration)
 
-    @Compute._computed_property
+    @_Compute._computed_property
     def matches(self):
         """:math:`(N_p, )` :class:`numpy.ndarray`: A boolean array indicating
         whether each point matches the motif."""
@@ -782,7 +782,7 @@ cdef class _EnvironmentRMSDMinimizer(_MatchEnv):
 
         return self
 
-    @Compute._computed_property
+    @_Compute._computed_property
     def rmsds(self):
         """:math:`(N_p, )` :class:`numpy.ndarray`: A boolean array of the RMSDs
         found for each point's environment."""
@@ -883,7 +883,7 @@ cdef class AngularSeparationNeighbor(_PairCompute):
             dereference(qargs.thisptr))
         return self
 
-    @Compute._computed_property
+    @_Compute._computed_property
     def angles(self):
         """:math:`\\left(N_{bonds}\\right)` :class:`numpy.ndarray`: The
         neighbor angles in radians. The angles are stored in the order of the
@@ -896,14 +896,14 @@ cdef class AngularSeparationNeighbor(_PairCompute):
         return "freud.environment.{cls}()".format(
             cls=type(self).__name__)
 
-    @Compute._computed_property
+    @_Compute._computed_property
     def nlist(self):
         """:class:`freud.locality.NeighborList`: The neighbor list from the
         last compute."""
         return freud.locality._nlist_from_cnlist(self.thisptr.getNList())
 
 
-cdef class AngularSeparationGlobal(Compute):
+cdef class AngularSeparationGlobal(_Compute):
     R"""Calculates the minimum angles of separation between orientations and
     global orientations."""
     cdef freud._environment.AngularSeparationGlobal * thisptr
@@ -963,7 +963,7 @@ cdef class AngularSeparationGlobal(Compute):
             n_equiv_orientations)
         return self
 
-    @Compute._computed_property
+    @_Compute._computed_property
     def angles(self):
         """:math:`\\left(N_{orientations}, N_{global\\_orientations}\\right)` :class:`numpy.ndarray`:
         The global angles in radians."""  # noqa: E501
@@ -1066,13 +1066,13 @@ cdef class LocalBondProjection(_PairCompute):
             nlist.get_ptr(), dereference(qargs.thisptr))
         return self
 
-    @Compute._computed_property
+    @_Compute._computed_property
     def nlist(self):
         """:class:`freud.locality.NeighborList`: The neighbor list from the
         last compute."""
         return freud.locality._nlist_from_cnlist(self.thisptr.getNList())
 
-    @Compute._computed_property
+    @_Compute._computed_property
     def projections(self):
         """:math:`\\left(N_{bonds}, N_{projection\\_vecs}
         \\right)` :class:`numpy.ndarray`: The projection of each bond between
@@ -1082,7 +1082,7 @@ cdef class LocalBondProjection(_PairCompute):
             &self.thisptr.getProjections(),
             freud.util.arr_type_t.FLOAT)
 
-    @Compute._computed_property
+    @_Compute._computed_property
     def normed_projections(self):
         """:math:`\\left(N_{bonds}, N_{projection\\_vecs} \\right)` :class:`numpy.ndarray`:
         The projection of each bond between query particles and their neighbors

--- a/freud/interface.pyx
+++ b/freud/interface.pyx
@@ -8,7 +8,7 @@ between sets of points.
 
 import numpy as np
 
-from freud.util cimport Compute
+from freud.util cimport _Compute
 from freud.locality cimport _PairCompute
 from freud.util cimport vec3
 from cython.operator cimport dereference
@@ -63,23 +63,23 @@ cdef class Interface(_PairCompute):
         self._query_point_ids = np.unique(nlist.query_point_indices)
         return self
 
-    @Compute._computed_property
+    @_Compute._computed_property
     def point_count(self):
         """int: Number of particles from :code:`points` on the interface."""
         return len(self._point_ids)
 
-    @Compute._computed_property
+    @_Compute._computed_property
     def point_ids(self):
         """:class:`np.ndarray`: The particle IDs from :code:`points`."""
         return np.asarray(self._point_ids)
 
-    @Compute._computed_property
+    @_Compute._computed_property
     def query_point_count(self):
         """int: Number of particles from :code:`query_points` on the
         interface."""
         return len(self._query_point_ids)
 
-    @Compute._computed_property
+    @_Compute._computed_property
     def query_point_ids(self):
         """:class:`np.ndarray`: The particle IDs from :code:`query_points`."""
         return np.asarray(self._query_point_ids)

--- a/freud/locality.pxd
+++ b/freud/locality.pxd
@@ -3,10 +3,10 @@
 
 from libcpp cimport bool as cbool
 from libcpp.memory cimport shared_ptr
-from freud.util cimport Compute
+from freud.util cimport _Compute
 
 from cython.operator cimport dereference
-from freud.util cimport Compute
+from freud.util cimport _Compute
 
 cimport freud._locality
 cimport freud.box
@@ -61,7 +61,7 @@ cdef class RawPoints(NeighborQuery):
 cdef class _QueryArgs:
     cdef freud._locality.QueryArgs * thisptr
 
-cdef class _PairCompute(Compute):
+cdef class _PairCompute(_Compute):
     pass
 
 cdef class _SpatialHistogram(_PairCompute):
@@ -71,7 +71,10 @@ cdef class _SpatialHistogram(_PairCompute):
 cdef class _SpatialHistogram1D(_SpatialHistogram):
     pass
 
-cdef class Voronoi(Compute):
+cdef class PeriodicBuffer(_Compute):
+    cdef freud._locality.PeriodicBuffer * thisptr
+
+cdef class Voronoi(_Compute):
     cdef freud._locality.Voronoi * thisptr
     cdef NeighborList _nlist
     cdef freud.box.Box _box

--- a/freud/locality.pyx
+++ b/freud/locality.pyx
@@ -19,7 +19,7 @@ from cython.operator cimport dereference
 from libcpp.memory cimport shared_ptr
 from libcpp.vector cimport vector
 from freud._locality cimport ITERATOR_TERMINATOR
-from freud.util cimport Compute
+from freud.util cimport _Compute
 
 cimport freud._locality
 cimport freud.box
@@ -666,8 +666,8 @@ def _make_default_nlist(system, neighbors, query_points=None):
 
 
 cdef class RawPoints(NeighborQuery):
-    R"""Dummy class that only contains minimal information
-    to make C++ side work well."""
+    R"""Class containing :class:`~.box.Box` and points with no spatial data
+    structures for accelerating neighbor queries."""
 
     def __cinit__(self, box, points):
         cdef const float[:, ::1] l_points
@@ -675,8 +675,7 @@ cdef class RawPoints(NeighborQuery):
         if type(self) is RawPoints:
             # Assume valid set of arguments is passed
             b = freud.util._convert_box(box)
-            self.points = freud.util._convert_array(
-                points, shape=(None, 3))
+            self.points = freud.util._convert_array(points, shape=(None, 3))
             l_points = self.points
             self.thisptr = self.nqptr = new freud._locality.RawPoints(
                 dereference(b.thisptr),
@@ -720,10 +719,9 @@ cdef class LinkCell(NeighborQuery):
         points (:class:`np.ndarray`):
             The points to bin into the cell list.
         cell_width (float, optional):
-            Maximum distance to find particles within. If not provided,
-            `~.LinkCell` will estimate a cell width based on the number of
-            points and the box size assuming constant density of points
-            throughout the box.
+            Width of cells. If not provided, `~.LinkCell` will estimate a cell
+            width based on the number of points and the box size assuming
+            constant density of points throughout the box.
     """
 
     def __cinit__(self, box, points, cell_width=0):
@@ -742,141 +740,11 @@ cdef class LinkCell(NeighborQuery):
 
     @property
     def cell_width(self):
-        """float: Maximum distance to find particles within."""
+        """float: Cell width."""
         return self.thisptr.getCellWidth()
 
 
-cdef class Voronoi(Compute):
-    R"""Computes Voronoi diagrams using voro++.
-
-    Voronoi diagrams (`Wikipedia
-    <https://en.wikipedia.org/wiki/Voronoi_diagram>`_) are composed of convex
-    polytopes (polyhedra in 3D, polygons in 2D) called cells, corresponding to
-    each input point. The cells bound a region of Euclidean space for which all
-    contained points are closer to a corresponding input point than any other
-    input point. A ridge is defined as a boundary between cells, which contains
-    points equally close to two or more input points.
-
-    The voro++ library [Rycroft2009]_ is used for fast computations of the
-    Voronoi diagram.
-
-    .. [Rycroft2009] Rycroft, Chris (2009). Voro++: a three-dimensional Voronoi
-       cell library in C++. Technical Report. https://doi.org/10.2172/946741
-    """
-
-    def __cinit__(self):
-        self.thisptr = new freud._locality.Voronoi()
-        self._nlist = NeighborList()
-
-    def __dealloc__(self):
-        del self.thisptr
-
-    def compute(self, system):
-        R"""Compute Voronoi diagram.
-
-        Args:
-            system:
-                Any object that is a valid argument to
-                :class:`freud.locality.NeighborQuery.from_system`.
-        """
-        cdef NeighborQuery nq = NeighborQuery.from_system(system)
-        self.thisptr.compute(nq.get_ptr())
-        self._box = nq.box
-        return self
-
-    @Compute._computed_property
-    def polytopes(self):
-        """list[:class:`numpy.ndarray`]: A list of :class:`numpy.ndarray`
-        defining Voronoi polytope vertices for each cell."""
-        polytopes = []
-        cdef vector[vector[vec3[double]]] raw_polytopes = \
-            self.thisptr.getPolytopes()
-        cdef size_t i
-        cdef size_t j
-        cdef size_t num_verts
-        cdef vector[vec3[double]] raw_vertices
-        cdef double[:, ::1] polytope_vertices
-        for i in range(raw_polytopes.size()):
-            raw_vertices = raw_polytopes[i]
-            num_verts = raw_vertices.size()
-            polytope_vertices = np.empty((num_verts, 3), dtype=np.float64)
-            for j in range(num_verts):
-                polytope_vertices[j, 0] = raw_vertices[j].x
-                polytope_vertices[j, 1] = raw_vertices[j].y
-                polytope_vertices[j, 2] = raw_vertices[j].z
-            polytopes.append(np.asarray(polytope_vertices))
-        return polytopes
-
-    @Compute._computed_property
-    def volumes(self):
-        """:math:`\\left(N_{points} \\right)` :class:`numpy.ndarray`: Returns
-        an array of Voronoi cell volumes (areas in 2D)."""
-        return freud.util.make_managed_numpy_array(
-            &self.thisptr.getVolumes(),
-            freud.util.arr_type_t.DOUBLE)
-
-    @Compute._computed_property
-    def nlist(self):
-        R"""Returns the computed :class:`~.locality.NeighborList`.
-
-        The :class:`~.locality.NeighborList` computed by this class is
-        weighted. In 2D systems, the bond weight is the length of the ridge
-        (boundary line) between the neighboring points' Voronoi cells. In 3D
-        systems, the bond weight is the area of the ridge (boundary polygon)
-        between the neighboring points' Voronoi cells. The weights are not
-        normalized, and the weights for each query point sum to the surface
-        area (perimeter in 2D) of the polytope.
-
-        It is possible for pairs of points to appear multiple times in the
-        neighbor list. For example, in a small unit cell, points may neighbor
-        one another on multiple sides because of periodic boundary conditions.
-
-        Returns:
-            :class:`~.locality.NeighborList`: Neighbor list.
-        """
-        self._nlist = _nlist_from_cnlist(self.thisptr.getNeighborList().get())
-        return self._nlist
-
-    def __repr__(self):
-        return "freud.locality.{cls}()".format(
-            cls=type(self).__name__)
-
-    def __str__(self):
-        return repr(self)
-
-    def plot(self, ax=None, color_by_sides=True, cmap=None):
-        """Plot Voronoi diagram.
-
-        Args:
-            ax (:class:`matplotlib.axes.Axes`): Axis to plot on. If
-                :code:`None`, make a new figure and axis.
-                (Default value = :code:`None`)
-        color_by_sides (bool):
-            If :code:`True`, color cells by the number of sides.
-            If :code:`False`, random colors are used for each cell.
-            (Default value = :code:`True`)
-        cmap (str):
-            Colormap name to use (Default value = :code:`None`).
-
-        Returns:
-            :class:`matplotlib.axes.Axes`: Axis with the plot.
-        """
-        import freud.plot
-        if not self._box.is2D:
-            return None
-        else:
-            return freud.plot.voronoi_plot(
-                self._box, self.polytopes, ax, color_by_sides, cmap)
-
-    def _repr_png_(self):
-        import freud.plot
-        try:
-            return freud.plot.ax_to_bytes(self.plot())
-        except AttributeError:
-            return None
-
-
-cdef class _PairCompute(Compute):
+cdef class _PairCompute(_Compute):
     R"""Parent class for all compute classes in freud that depend on finding
     nearest neighbors.
 
@@ -970,13 +838,13 @@ cdef class _SpatialHistogram(_PairCompute):
         :code:`{'mode': 'ball', 'r_max': self.r_max}`."""
         return dict(mode="ball", r_max=self.r_max)
 
-    @Compute._computed_property
+    @_Compute._computed_property
     def box(self):
         """:class:`freud.box.Box`: The box object used in the last
         computation."""
         return freud.box.BoxFromCPP(self.histptr.getBox())
 
-    @Compute._computed_property
+    @_Compute._computed_property
     def bin_counts(self):
         """:class:`numpy.ndarray`: The bin counts in the histogram."""
         return freud.util.make_managed_numpy_array(
@@ -1057,3 +925,202 @@ cdef class _SpatialHistogram1D(_SpatialHistogram):
     def nbins(self):
         """int: The number of bins in the histogram"""
         return self.histptr.getAxisSizes()[0]
+
+
+cdef class PeriodicBuffer(_Compute):
+    R"""Replicate periodic images of points inside a box."""
+
+    def __cinit__(self):
+        self.thisptr = new freud._locality.PeriodicBuffer()
+
+    def __init__(self):
+        pass
+
+    def __dealloc__(self):
+        del self.thisptr
+
+    def compute(self, system, buffer, cbool images=False):
+        R"""Compute the periodic buffer.
+
+        Args:
+            system:
+                Any object that is a valid argument to
+                :class:`freud.locality.NeighborQuery.from_system`.
+            buffer (float or list of 3 floats):
+                Buffer distance for replication outside the box.
+            images (bool, optional):
+                If ``False``, ``buffer`` is a distance. If ``True``,
+                ``buffer`` is a number of images to replicate in each
+                dimension. Note that one image adds half of a box length to
+                each side, meaning that one image doubles the box side lengths,
+                two images triples the box side lengths, and so on.
+                (Default value = :code:`False`).
+        """
+        cdef NeighborQuery nq = _make_default_nq(system)
+        cdef vec3[float] buffer_vec
+        if np.ndim(buffer) == 0:
+            # catches more cases than np.isscalar
+            buffer_vec = vec3[float](buffer, buffer, buffer)
+        elif len(buffer) == 3:
+            buffer_vec = vec3[float](buffer[0], buffer[1], buffer[2])
+        else:
+            raise ValueError('buffer must be a scalar or have length 3.')
+
+        self.thisptr.compute(nq.get_ptr(), buffer_vec, images)
+        return self
+
+    @_Compute._computed_property
+    def buffer_points(self):
+        """:math:`\\left(N_{buffer}, 3\\right)` :class:`numpy.ndarray`: The
+        buffer point positions."""
+        points = self.thisptr.getBufferPoints()
+        return np.asarray([[p.x, p.y, p.z] for p in points])
+
+    @_Compute._computed_property
+    def buffer_ids(self):
+        """:math:`\\left(N_{buffer}\\right)` :class:`numpy.ndarray`: The buffer
+        point ids."""
+        return np.asarray(self.thisptr.getBufferIds())
+
+    @_Compute._computed_property
+    def buffer_box(self):
+        """:class:`freud.box.Box`: The buffer box, expanded to hold the
+        replicated points."""
+        return freud.box.BoxFromCPP(
+            <freud._box.Box> self.thisptr.getBufferBox())
+
+    def __repr__(self):
+        return "freud.locality.{cls}()".format(cls=type(self).__name__)
+
+    def __str__(self):
+        return repr(self)
+
+
+cdef class Voronoi(_Compute):
+    R"""Computes Voronoi diagrams using voro++.
+
+    Voronoi diagrams (`Wikipedia
+    <https://en.wikipedia.org/wiki/Voronoi_diagram>`_) are composed of convex
+    polytopes (polyhedra in 3D, polygons in 2D) called cells, corresponding to
+    each input point. The cells bound a region of Euclidean space for which all
+    contained points are closer to a corresponding input point than any other
+    input point. A ridge is defined as a boundary between cells, which contains
+    points equally close to two or more input points.
+
+    The voro++ library [Rycroft2009]_ is used for fast computations of the
+    Voronoi diagram.
+
+    .. [Rycroft2009] Rycroft, Chris (2009). Voro++: a three-dimensional Voronoi
+       cell library in C++. Technical Report. https://doi.org/10.2172/946741
+    """
+
+    def __cinit__(self):
+        self.thisptr = new freud._locality.Voronoi()
+        self._nlist = NeighborList()
+
+    def __dealloc__(self):
+        del self.thisptr
+
+    def compute(self, system):
+        R"""Compute Voronoi diagram.
+
+        Args:
+            system:
+                Any object that is a valid argument to
+                :class:`freud.locality.NeighborQuery.from_system`.
+        """
+        cdef NeighborQuery nq = NeighborQuery.from_system(system)
+        self.thisptr.compute(nq.get_ptr())
+        self._box = nq.box
+        return self
+
+    @_Compute._computed_property
+    def polytopes(self):
+        """list[:class:`numpy.ndarray`]: A list of :class:`numpy.ndarray`
+        defining Voronoi polytope vertices for each cell."""
+        polytopes = []
+        cdef vector[vector[vec3[double]]] raw_polytopes = \
+            self.thisptr.getPolytopes()
+        cdef size_t i
+        cdef size_t j
+        cdef size_t num_verts
+        cdef vector[vec3[double]] raw_vertices
+        cdef double[:, ::1] polytope_vertices
+        for i in range(raw_polytopes.size()):
+            raw_vertices = raw_polytopes[i]
+            num_verts = raw_vertices.size()
+            polytope_vertices = np.empty((num_verts, 3), dtype=np.float64)
+            for j in range(num_verts):
+                polytope_vertices[j, 0] = raw_vertices[j].x
+                polytope_vertices[j, 1] = raw_vertices[j].y
+                polytope_vertices[j, 2] = raw_vertices[j].z
+            polytopes.append(np.asarray(polytope_vertices))
+        return polytopes
+
+    @_Compute._computed_property
+    def volumes(self):
+        """:math:`\\left(N_{points} \\right)` :class:`numpy.ndarray`: Returns
+        an array of Voronoi cell volumes (areas in 2D)."""
+        return freud.util.make_managed_numpy_array(
+            &self.thisptr.getVolumes(),
+            freud.util.arr_type_t.DOUBLE)
+
+    @_Compute._computed_property
+    def nlist(self):
+        R"""Returns the computed :class:`~.locality.NeighborList`.
+
+        The :class:`~.locality.NeighborList` computed by this class is
+        weighted. In 2D systems, the bond weight is the length of the ridge
+        (boundary line) between the neighboring points' Voronoi cells. In 3D
+        systems, the bond weight is the area of the ridge (boundary polygon)
+        between the neighboring points' Voronoi cells. The weights are not
+        normalized, and the weights for each query point sum to the surface
+        area (perimeter in 2D) of the polytope.
+
+        It is possible for pairs of points to appear multiple times in the
+        neighbor list. For example, in a small unit cell, points may neighbor
+        one another on multiple sides because of periodic boundary conditions.
+
+        Returns:
+            :class:`~.locality.NeighborList`: Neighbor list.
+        """
+        self._nlist = _nlist_from_cnlist(self.thisptr.getNeighborList().get())
+        return self._nlist
+
+    def __repr__(self):
+        return "freud.locality.{cls}()".format(
+            cls=type(self).__name__)
+
+    def __str__(self):
+        return repr(self)
+
+    def plot(self, ax=None, color_by_sides=True, cmap=None):
+        """Plot Voronoi diagram.
+
+        Args:
+            ax (:class:`matplotlib.axes.Axes`): Axis to plot on. If
+                :code:`None`, make a new figure and axis.
+                (Default value = :code:`None`)
+        color_by_sides (bool):
+            If :code:`True`, color cells by the number of sides.
+            If :code:`False`, random colors are used for each cell.
+            (Default value = :code:`True`)
+        cmap (str):
+            Colormap name to use (Default value = :code:`None`).
+
+        Returns:
+            :class:`matplotlib.axes.Axes`: Axis with the plot.
+        """
+        import freud.plot
+        if not self._box.is2D:
+            return None
+        else:
+            return freud.plot.voronoi_plot(
+                self._box, self.polytopes, ax, color_by_sides, cmap)
+
+    def _repr_png_(self):
+        import freud.plot
+        try:
+            return freud.plot.ax_to_bytes(self.plot())
+        except AttributeError:
+            return None

--- a/freud/msd.pyx
+++ b/freud/msd.pyx
@@ -10,7 +10,7 @@ import numpy as np
 import freud.parallel
 import logging
 
-from freud.util cimport Compute
+from freud.util cimport _Compute
 cimport freud.box
 cimport numpy as np
 
@@ -60,7 +60,7 @@ def _autocorrelation(x):
     return res/n[:, np.newaxis]
 
 
-cdef class MSD(Compute):
+cdef class MSD(_Compute):
     R"""Compute the mean squared displacement.
 
     The mean squared displacement (MSD) measures how much particles move over
@@ -218,7 +218,7 @@ cdef class MSD(Compute):
         """:class:`freud.box.Box`: Box used in the calculation."""
         return self._box
 
-    @Compute._computed_property
+    @_Compute._computed_property
     def msd(self):
         """:math:`\\left(N_{frames}, \\right`) :class:`numpy.ndarray`: The mean
         squared displacement."""

--- a/freud/order.pyx
+++ b/freud/order.pyx
@@ -16,7 +16,7 @@ import time
 import freud.locality
 import logging
 
-from freud.util cimport Compute
+from freud.util cimport _Compute
 from freud.locality cimport _PairCompute
 from freud.util cimport vec3, quat
 from cython.operator cimport dereference
@@ -34,7 +34,7 @@ logger = logging.getLogger(__name__)
 # _always_ do that, or you will have segfaults
 np.import_array()
 
-cdef class Cubatic(Compute):
+cdef class Cubatic(_Compute):
     R"""Compute the cubatic order parameter [HajiAkbari2015]_ for a system of
     particles using simulated annealing instead of Newton-Raphson root finding.
 
@@ -116,19 +116,19 @@ cdef class Cubatic(Compute):
         """unsigned int: Random seed to use in calculations."""
         return self.thisptr.getSeed()
 
-    @Compute._computed_property
+    @_Compute._computed_property
     def order(self):
         """float: Cubatic order parameter of the system."""
         return self.thisptr.getCubaticOrderParameter()
 
-    @Compute._computed_property
+    @_Compute._computed_property
     def orientation(self):
         """:math:`\\left(4 \\right)` :class:`numpy.ndarray`: The quaternion of
         global orientation."""
         cdef quat[float] q = self.thisptr.getCubaticOrientation()
         return np.asarray([q.s, q.v.x, q.v.y, q.v.z], dtype=np.float32)
 
-    @Compute._computed_property
+    @_Compute._computed_property
     def particle_order(self):
         """:math:`\\left(N_{particles} \\right)` :class:`numpy.ndarray`: Order
         parameter."""
@@ -136,7 +136,7 @@ cdef class Cubatic(Compute):
             &self.thisptr.getParticleOrderParameter(),
             freud.util.arr_type_t.FLOAT)
 
-    @Compute._computed_property
+    @_Compute._computed_property
     def global_tensor(self):
         """:math:`\\left(3, 3, 3, 3 \\right)` :class:`numpy.ndarray`: Rank 4
         tensor corresponding to the global orientation. Computed from all
@@ -145,7 +145,7 @@ cdef class Cubatic(Compute):
             &self.thisptr.getGlobalTensor(),
             freud.util.arr_type_t.FLOAT)
 
-    @Compute._computed_property
+    @_Compute._computed_property
     def cubatic_tensor(self):
         """:math:`\\left(3, 3, 3, 3 \\right)` :class:`numpy.ndarray`: Rank 4
         homogeneous tensor representing the optimal system-wide coordinates."""
@@ -164,7 +164,7 @@ cdef class Cubatic(Compute):
                                        seed=self.seed)
 
 
-cdef class Nematic(Compute):
+cdef class Nematic(_Compute):
     R"""Compute the nematic order parameter for a system of particles.
 
     Args:
@@ -202,19 +202,19 @@ cdef class Nematic(Compute):
                              num_particles)
         return self
 
-    @Compute._computed_property
+    @_Compute._computed_property
     def order(self):
         """float: Nematic order parameter of the system."""
         return self.thisptr.getNematicOrderParameter()
 
-    @Compute._computed_property
+    @_Compute._computed_property
     def director(self):
         """:math:`\\left(3 \\right)` :class:`numpy.ndarray`: The average
         nematic director."""
         cdef vec3[float] n = self.thisptr.getNematicDirector()
         return np.asarray([n.x, n.y, n.z], dtype=np.float32)
 
-    @Compute._computed_property
+    @_Compute._computed_property
     def particle_tensor(self):
         """:math:`\\left(N_{particles}, 3, 3 \\right)` :class:`numpy.ndarray`:
             One 3x3 matrix per-particle corresponding to each individual
@@ -223,7 +223,7 @@ cdef class Nematic(Compute):
             &self.thisptr.getParticleTensor(),
             freud.util.arr_type_t.FLOAT)
 
-    @Compute._computed_property
+    @_Compute._computed_property
     def nematic_tensor(self):
         """:math:`\\left(3, 3 \\right)` :class:`numpy.ndarray`: 3x3 matrix
         corresponding to the average particle orientation."""
@@ -310,7 +310,7 @@ cdef class Hexatic(_PairCompute):
         :code:`{'mode': 'nearest', 'num_neighbors': self.k}`."""
         return dict(mode="nearest", num_neighbors=self.k)
 
-    @Compute._computed_property
+    @_Compute._computed_property
     def particle_order(self):
         """:math:`\\left(N_{particles} \\right)` :class:`numpy.ndarray`: Order
         parameter."""
@@ -381,7 +381,7 @@ cdef class Translational(_PairCompute):
         'num_neighbors': int(self.k)}`."""
         return dict(mode="nearest", num_neighbors=int(self.k))
 
-    @Compute._computed_property
+    @_Compute._computed_property
     def particle_order(self):
         """:math:`\\left(N_{particles} \\right)` :class:`numpy.ndarray`: Order
         parameter."""
@@ -490,13 +490,13 @@ cdef class Steinhardt(_PairCompute):
         """unsigned int: Spherical harmonic quantum number l."""
         return self.thisptr.getL()
 
-    @Compute._computed_property
+    @_Compute._computed_property
     def order(self):
         """float: The system wide normalization of the :math:`q_l` or
         :math:`w_l` order parameter."""
         return self.thisptr.getOrder()
 
-    @Compute._computed_property
+    @_Compute._computed_property
     def particle_order(self):
         """:math:`\\left(N_{particles}\\right)` :class:`numpy.ndarray`: Variant
         of the Steinhardt order parameter for each particle (filled with
@@ -505,7 +505,7 @@ cdef class Steinhardt(_PairCompute):
             &self.thisptr.getParticleOrder(),
             freud.util.arr_type_t.FLOAT)
 
-    @Compute._computed_property
+    @_Compute._computed_property
     def ql(self):
         """:math:`\\left(N_{particles}\\right)` :class:`numpy.ndarray`:
         :math:`q_l` Steinhardt order parameter for each particle (filled with
@@ -692,7 +692,7 @@ cdef class SolidLiquid(_PairCompute):
         """bool: Whether the dot product is normalized."""
         return self.thisptr.getNormalizeQ()
 
-    @Compute._computed_property
+    @_Compute._computed_property
     def cluster_idx(self):
         """:math:`\\left(N_{particles}\\right)` :class:`numpy.ndarray`:
         Solid-like cluster indices for each particle."""
@@ -700,7 +700,7 @@ cdef class SolidLiquid(_PairCompute):
             &self.thisptr.getClusterIdx(),
             freud.util.arr_type_t.UNSIGNED_INT)
 
-    @Compute._computed_property
+    @_Compute._computed_property
     def ql_ij(self):
         """:math:`\\left(N_{bonds}\\right)` :class:`numpy.ndarray`: Bond dot
         products :math:`q_l(i, j)`. Indexed by the elements of
@@ -709,24 +709,24 @@ cdef class SolidLiquid(_PairCompute):
             &self.thisptr.getQlij(),
             freud.util.arr_type_t.FLOAT)
 
-    @Compute._computed_property
+    @_Compute._computed_property
     def cluster_sizes(self):
         """:math:`(N_{clusters}, )` :class:`np.ndarray`: The sizes of all
         clusters."""
         return np.asarray(self.thisptr.getClusterSizes())
 
-    @Compute._computed_property
+    @_Compute._computed_property
     def largest_cluster_size(self):
         """unsigned int: The largest cluster size."""
         return self.thisptr.getLargestClusterSize()
 
-    @Compute._computed_property
+    @_Compute._computed_property
     def nlist(self):
         """:class:`freud.locality.NeighborList`: Neighbor list of solid-like
         bonds."""
         return freud.locality._nlist_from_cnlist(self.thisptr.getNList())
 
-    @Compute._computed_property
+    @_Compute._computed_property
     def num_connections(self):
         """:math:`\\left(N_{particles}\\right)` :class:`numpy.ndarray`: The
         number of solid-like bonds for each particle."""
@@ -772,7 +772,7 @@ cdef class SolidLiquid(_PairCompute):
             return None
 
 
-cdef class RotationalAutocorrelation(Compute):
+cdef class RotationalAutocorrelation(_Compute):
     """Calculates a measure of total rotational autocorrelation based on
     hyperspherical harmonics as laid out in "Design rules for engineering
     colloidal plastic crystals of hard polyhedra - phase behavior and
@@ -823,12 +823,12 @@ cdef class RotationalAutocorrelation(Compute):
             nP)
         return self
 
-    @Compute._computed_property
+    @_Compute._computed_property
     def order(self):
         """float: Autocorrelation of the system."""
         return self.thisptr.getRotationalAutocorrelation()
 
-    @Compute._computed_property
+    @_Compute._computed_property
     def particle_order(self):
         """(:math:`N_{orientations}`) :class:`numpy.ndarray`: Rotational
         autocorrelation values calculated for each orientation."""

--- a/freud/pmft.pyx
+++ b/freud/pmft.pyx
@@ -43,7 +43,7 @@ import freud.locality
 import warnings
 import rowan
 
-from freud.util cimport Compute
+from freud.util cimport _Compute
 from freud.locality cimport _SpatialHistogram
 from freud.util cimport vec3, quat
 from cython.operator cimport dereference
@@ -112,7 +112,7 @@ cdef class _PMFT(_SpatialHistogram):
         if type(self) is _PMFT:
             del self.pmftptr
 
-    @Compute._computed_property
+    @_Compute._computed_property
     def pmft(self):
         """:class:`np.ndarray`: The discrete potential of mean force and
         torque."""
@@ -121,7 +121,7 @@ cdef class _PMFT(_SpatialHistogram):
             result = -np.log(np.copy(self._pcf))
         return result
 
-    @Compute._computed_property
+    @_Compute._computed_property
     def _pcf(self):
         """:class:`np.ndarray`: The discrete pair correlation function."""
         return freud.util.make_managed_numpy_array(
@@ -429,7 +429,7 @@ cdef class PMFTXY(_PMFT):
                                   dereference(qargs.thisptr))
         return self
 
-    @Compute._computed_property
+    @_Compute._computed_property
     def bin_counts(self):
         """:class:`numpy.ndarray`: The bin counts in the histogram."""
         # Currently the parent function returns a 3D array that must be

--- a/freud/util.pxd
+++ b/freud/util.pxd
@@ -94,5 +94,5 @@ cdef inline make_managed_numpy_array(
         _ManagedArrayContainer.init(array, arr_type, element_size))
 
 
-cdef class Compute:
+cdef class _Compute:
     cdef public _called_compute

--- a/freud/util.pyx
+++ b/freud/util.pyx
@@ -127,7 +127,7 @@ cdef class _ManagedArrayContainer:
             else self.shape + (self.element_size, ))
 
 
-cdef class Compute(object):
+cdef class _Compute(object):
     R"""Parent class for all compute classes in freud.
 
     Currently, the primary purpose of this class is implementing functions to
@@ -139,12 +139,12 @@ cdef class Compute(object):
     To use this class, one would do, for example,
 
     .. code-block:: python
-        class Cluster(Compute):
+        class Cluster(_Compute):
 
             def compute(...)
                 ...
 
-            @Compute._computed_property()
+            @_Compute._computed_property()
             def cluster_idx(self):
                 return ...
 

--- a/tests/test_locality_PeriodicBuffer.py
+++ b/tests/test_locality_PeriodicBuffer.py
@@ -13,7 +13,7 @@ class TestPeriodicBuffer(unittest.TestCase):
         box, positions = util.make_box_and_random_points(L, N, True)
         positions.flags['WRITEABLE'] = False
 
-        pbuff = freud.box.PeriodicBuffer()
+        pbuff = freud.locality.PeriodicBuffer()
 
         # Compute with zero buffer distance
         pbuff.compute((box, positions), buffer=0, images=False)
@@ -61,7 +61,7 @@ class TestPeriodicBuffer(unittest.TestCase):
         box, positions = util.make_box_and_random_points(L, N, False)
         positions.flags['WRITEABLE'] = False
 
-        pbuff = freud.box.PeriodicBuffer()
+        pbuff = freud.locality.PeriodicBuffer()
 
         # Compute with zero buffer distance
         pbuff.compute((box, positions), buffer=0, images=False)
@@ -119,7 +119,7 @@ class TestPeriodicBuffer(unittest.TestCase):
         L = 2*s  # Box length
 
         box = freud.box.Box.cube(L)  # Initialize box
-        pbuff = freud.box.PeriodicBuffer()
+        pbuff = freud.locality.PeriodicBuffer()
         positions = np.array([(s, s, 0), (s, 0, s), (0, s, s), (0, 0, 0)])
         positions.flags['WRITEABLE'] = False
 
@@ -186,7 +186,7 @@ class TestPeriodicBuffer(unittest.TestCase):
         np.random.seed(0)
 
         box = freud.box.Box(Lx=2, Ly=2, Lz=2, xy=1, xz=0, yz=1)
-        pbuff = freud.box.PeriodicBuffer()
+        pbuff = freud.locality.PeriodicBuffer()
 
         # Generate random points in the box, in fractional coordinates
         positions = np.random.uniform(0, 1, size=(N, 3))
@@ -215,7 +215,7 @@ class TestPeriodicBuffer(unittest.TestCase):
                                box.L * np.array([2, 1, 2]))
 
     def test_repr(self):
-        pbuff = freud.box.PeriodicBuffer()
+        pbuff = freud.locality.PeriodicBuffer()
         self.assertEqual(str(pbuff), str(eval(repr(pbuff))))
 
 


### PR DESCRIPTION
## Description
Renamed `Compute` to `_Compute` and moved `PeriodicBuffer` from `box` into `locality`, it also now inherits from `_Compute`. **Merge after #515.**

## Motivation and Context
`_Compute` should match `_PairCompute` and other private classes.
`PeriodicBuffer` should be a `_Compute` class, and it couldn't inherit from `_Compute` while in the `box` module. Moving it made some sense.

## How Has This Been Tested?
Updated test.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds or improves functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have read the [**CONTRIBUTING**](https://github.com/glotzerlab/freud/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] I have updated the documentation (if relevant).
- [x] I have added tests that cover my changes (if relevant).
- [x] All new and existing tests passed.
- [x] I have updated the [credits](https://github.com/glotzerlab/freud/blob/master/doc/source/credits.rst).
- [x] I have updated the [Changelog](https://github.com/glotzerlab/freud/blob/master/ChangeLog.md).