### PR TITLE
Add data module to docs.

### DIFF
--- a/doc/source/data.rst
+++ b/doc/source/data.rst
@@ -1,0 +1,16 @@
+===========
+Data Module
+===========
+
+.. rubric:: Overview
+
+.. autosummary::
+    :nosignatures:
+
+    freud.data.UnitCell
+
+.. rubric:: Details
+
+.. automodule:: freud.data
+    :synopsis: Data sets and utility functions for testing and examples.
+    :members:

--- a/doc/source/data.rst
+++ b/doc/source/data.rst
@@ -12,5 +12,5 @@ Data Module
 .. rubric:: Details
 
 .. automodule:: freud.data
-    :synopsis: Data sets and utility functions for testing and examples.
+    :synopsis: Utility functions for generating standard types of systems of points.
     :members:

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -27,6 +27,7 @@ Table of Contents
 
    box
    cluster
+   data
    density
    environment
    interface

--- a/freud/data.py
+++ b/freud/data.py
@@ -167,7 +167,7 @@ class UnitCell(object):
 
     @classmethod
     def sc(cls):
-        """Create an simple cubic crystal.
+        """Create a simple cubic crystal.
 
         Returns:
             :class:`~.UnitCell`: An sc unit cell.

--- a/freud/data.py
+++ b/freud/data.py
@@ -143,7 +143,7 @@ class UnitCell(object):
 
     @classmethod
     def fcc(cls):
-        """Create an fcc crystal.
+        """Create a face-centered cubic crystal.
 
         Returns:
             :class:`~.UnitCell`: An fcc unit cell.
@@ -156,10 +156,10 @@ class UnitCell(object):
 
     @classmethod
     def bcc(cls):
-        """Create an bcc crystal.
+        """Create a body-centered cubic crystal.
 
         Returns:
-            :class:`~.UnitCell`: An bcc unit cell.
+            :class:`~.UnitCell`: A bcc unit cell.
         """
         fractions = np.array([[.5, .5, .5],
                               [0, 0, 0]])
@@ -167,7 +167,7 @@ class UnitCell(object):
 
     @classmethod
     def sc(cls):
-        """Create an sc crystal.
+        """Create an simple cubic crystal.
 
         Returns:
             :class:`~.UnitCell`: An sc unit cell.


### PR DESCRIPTION
## Description
I added the data module to the freud documentation. I will be using it for example code, so I think it's appropriate to add to the docs. I plan to keep the `freud.plot` module un-documented for now, and use calls to `obj.plot()` as needed.