### PR TITLE
Use query_orientations in PMFTXYZ.

### DIFF
--- a/cpp/pmft/PMFT.h
+++ b/cpp/pmft/PMFT.h
@@ -46,7 +46,7 @@ public:
         \param cf An object with operator(NeighborBond) as input.
     */
     template<typename Func>
-    void accumulateGeneral(const locality::NeighborQuery* neighbor_query, 
+    void accumulateGeneral(const locality::NeighborQuery* neighbor_query,
                            const vec3<float>* query_points, unsigned int n_query_points,
                            const locality::NeighborList* nlist,
                            freud::locality::QueryArgs qargs,

--- a/cpp/pmft/PMFTXY.cc
+++ b/cpp/pmft/PMFTXY.cc
@@ -54,7 +54,7 @@ void PMFTXY::reduce()
 /*! \brief Helper functionto direct the calculation to the correct helper class
  */
 void PMFTXY::accumulate(const locality::NeighborQuery* neighbor_query,
-                          float* orientations, vec3<float>* query_points,
+                          float* query_orientations, vec3<float>* query_points,
                           unsigned int n_query_points,
                           const locality::NeighborList* nlist, freud::locality::QueryArgs qargs)
 {
@@ -65,7 +65,7 @@ void PMFTXY::accumulate(const locality::NeighborQuery* neighbor_query,
 
         // rotate interparticle vector
         vec2<float> myVec(delta.x, delta.y);
-        rotmat2<float> myMat = rotmat2<float>::fromAngle(-orientations[neighbor_bond.point_idx]);
+        rotmat2<float> myMat = rotmat2<float>::fromAngle(-query_orientations[neighbor_bond.point_idx]);
         vec2<float> rotVec = myMat * myVec;
 
         m_local_histograms(rotVec.x, rotVec.y);

--- a/cpp/pmft/PMFTXY.h
+++ b/cpp/pmft/PMFTXY.h
@@ -22,7 +22,7 @@ public:
      *  be added to previous values of the PCF.
      */
     void accumulate(const locality::NeighborQuery* neighbor_query,
-                    float* orientations, vec3<float>* query_points,
+                    float* query_orientations, vec3<float>* query_points,
                     unsigned int n_query_points,
                     const locality::NeighborList* nlist, freud::locality::QueryArgs qargs);
 

--- a/cpp/pmft/PMFTXY.h
+++ b/cpp/pmft/PMFTXY.h
@@ -21,9 +21,9 @@ public:
     /*! Compute the PCF for the passed in set of points. The result will
      *  be added to previous values of the PCF.
      */
-    void accumulate(const locality::NeighborQuery* neighbor_query, 
+    void accumulate(const locality::NeighborQuery* neighbor_query,
                     float* orientations, vec3<float>* query_points,
-                    unsigned int n_query_points, 
+                    unsigned int n_query_points,
                     const locality::NeighborList* nlist, freud::locality::QueryArgs qargs);
 
     //! \internal

--- a/cpp/pmft/PMFTXYT.h
+++ b/cpp/pmft/PMFTXYT.h
@@ -21,7 +21,7 @@ public:
     /*! Compute the PCF for the passed in set of points. The function will be added to previous values
         of the PCF
     */
-    void accumulate(const locality::NeighborQuery* neighbor_query, 
+    void accumulate(const locality::NeighborQuery* neighbor_query,
                     float* orientations, vec3<float>* query_points, float* query_orientations,
                     unsigned int n_query_points, const locality::NeighborList* nlist, freud::locality::QueryArgs qargs);
 

--- a/cpp/pmft/PMFTXYZ.cc
+++ b/cpp/pmft/PMFTXYZ.cc
@@ -70,7 +70,7 @@ void PMFTXYZ::reduce()
 /*! \brief Helper function to direct the calculation to the correct helper class
  */
 void PMFTXYZ::accumulate(const locality::NeighborQuery* neighbor_query,
-                         quat<float>* orientations, vec3<float>* query_points,
+                         quat<float>* query_orientations, vec3<float>* query_points,
                          unsigned int n_query_points, quat<float>* face_orientations,
                          unsigned int n_faces, const locality::NeighborList* nlist,
                          freud::locality::QueryArgs qargs)
@@ -80,7 +80,7 @@ void PMFTXYZ::accumulate(const locality::NeighborQuery* neighbor_query,
     accumulateGeneral(neighbor_query, query_points, n_query_points, nlist, qargs,
         [=](const freud::locality::NeighborBond& neighbor_bond) {
         // create the reference point quaternion
-        quat<float> ref_q(orientations[neighbor_bond.point_idx]);
+        quat<float> ref_q(query_orientations[neighbor_bond.point_idx]);
         // make sure that the particles are wrapped into the box
         vec3<float> delta(bondVector(neighbor_bond, neighbor_query, query_points));
 

--- a/cpp/pmft/PMFTXYZ.h
+++ b/cpp/pmft/PMFTXYZ.h
@@ -23,7 +23,7 @@ public:
         of the pcf
     */
     void accumulate(const locality::NeighborQuery* neighbor_query,
-                    quat<float>* orientations, vec3<float>* query_points,
+                    quat<float>* query_orientations, vec3<float>* query_points,
                     unsigned int n_query_points, quat<float>* face_orientations,
                     unsigned int n_faces, const locality::NeighborList* nlist,
                     freud::locality::QueryArgs qargs);

--- a/cpp/pmft/PMFTXYZ.h
+++ b/cpp/pmft/PMFTXYZ.h
@@ -22,7 +22,7 @@ public:
     /*! Compute the PCF for the passed in set of points. The function will be added to previous values
         of the pcf
     */
-    void accumulate(const locality::NeighborQuery* neighbor_query, 
+    void accumulate(const locality::NeighborQuery* neighbor_query,
                     quat<float>* orientations, vec3<float>* query_points,
                     unsigned int n_query_points, quat<float>* face_orientations,
                     unsigned int n_faces, const locality::NeighborList* nlist,

--- a/freud/pmft.pyx
+++ b/freud/pmft.pyx
@@ -8,7 +8,7 @@ number of different coordinate systems. The shape of the arrays computed by
 this module depend on the coordinate system used, with space discretized into a
 set of bins created by the PMFT object's constructor. Each query point's
 neighboring points are assigned to bins, determined by the relative positions
-and/or orientations of the particles. Next, the positional correlation function
+and/or orientations of the particles. Next, the pair correlation function
 (PCF) is computed by normalizing the binned histogram, by dividing out the
 number of accumulated frames, bin sizes (the Jacobian), and query point
 number density. The PMFT is then defined as the negative logarithm of the PCF.
@@ -34,8 +34,8 @@ refer to the supplementary information of :cite:`vanAnders:2014aa`.
 
 .. note::
     For any bins where the histogram is zero (i.e. no observations were made
-    with that relative position/orientation of particles), the PCF will be zero
-    and the PMFT will return :code:`nan`.
+    with that relative position/orientation of particles), the PMFT will return
+    :code:`nan`.
 """
 
 import numpy as np
@@ -164,8 +164,7 @@ cdef class PMFTR12(_PMFT):
 
     def compute(self, system, orientations, query_points=None,
                 query_orientations=None, neighbors=None, reset=True):
-        R"""Calculates the positional correlation function and adds to the
-        current histogram.
+        R"""Calculates the PMFT.
 
         Args:
             system:
@@ -177,9 +176,8 @@ cdef class PMFTR12(_PMFT):
                 are treated as angles in radians corresponding to
                 **counterclockwise** rotations about the z axis.
             query_points ((:math:`N_{query\_points}`, 3) :class:`numpy.ndarray`, optional):
-                Query points used to calculate the correlation function.  Uses
-                the system's points if :code:`None` (Default
-                value = :code:`None`).
+                Query points used to calculate the PMFT. Uses the system's
+                points if :code:`None` (Default value = :code:`None`).
             query_orientations ((:math:`N_{query\_points}`, 4) :class:`numpy.ndarray`, optional):
                 Query orientations associated with query points that are used
                 to calculate bonds. If the array is one-dimensional, the values
@@ -275,8 +273,7 @@ cdef class PMFTXYT(_PMFT):
 
     def compute(self, system, orientations, query_points=None,
                 query_orientations=None, neighbors=None, reset=True):
-        R"""Calculates the positional correlation function and adds to the
-        current histogram.
+        R"""Calculates the PMFT.
 
         Args:
             system:
@@ -288,9 +285,8 @@ cdef class PMFTXYT(_PMFT):
                 are treated as angles in radians corresponding to
                 **counterclockwise** rotations about the z axis.
             query_points ((:math:`N_{query\_points}`, 3) :class:`numpy.ndarray`, optional):
-                Query points used to calculate the correlation function.  Uses
-                the system's points if :code:`None` (Default
-                value = :code:`None`).
+                Query points used to calculate the PMFT. Uses the system's
+                points if :code:`None` (Default value = :code:`None`).
             query_orientations ((:math:`N_{query\_points}`, 4) :class:`numpy.ndarray`, optional):
                 Query orientations associated with query points that are used
                 to calculate bonds. If the array is one-dimensional, the values
@@ -372,8 +368,8 @@ cdef class PMFTXY(_PMFT):
         y_max (float):
             Maximum :math:`y` distance at which to compute the PMFT.
         bins (unsigned int or sequence of length 2):
-            If an unsigned int, the number of bins in :math:`x`, :math:`y`, and
-            :math:`z`. If a sequence of two integers, interpreted as
+            If an unsigned int, the number of bins in :math:`x` and :math:`y`.
+            If a sequence of two integers, interpreted as
             :code:`(num_bins_x, num_bins_y)`.
     """  # noqa: E501
     cdef freud._pmft.PMFTXY * pmftxyptr
@@ -395,29 +391,27 @@ cdef class PMFTXY(_PMFT):
 
     def compute(self, system, query_orientations, query_points=None,
                 neighbors=None, reset=True):
-        R"""Calculates the positional correlation function and adds to the
-        current histogram.
+        R"""Calculates the PMFT.
 
         .. note::
             The orientations of the system points are irrelevant for this
             calculation because that dimension is integrated out. The provided
             ``query_orientations`` are therefore always associated with
-            ``query_points`` (which are equal to the system points of no
-            ``query_points`` are explicitly provided.
+            ``query_points`` (which are equal to the system points if no
+            ``query_points`` are explicitly provided).
 
         Args:
             system:
                 Any object that is a valid argument to
                 :class:`freud.locality.NeighborQuery.from_system`.
             query_orientations ((:math:`N_{query\_points}`, 4) or (:math:`N_{query\_points}`,) :class:`numpy.ndarray`):
-                Orientations associated with query points that are used to
-                calculate bonds. If the array is one-dimensional, the values
+                Query orientations associated with query points that are used
+                to calculate bonds. If the array is one-dimensional, the values
                 are treated as angles in radians corresponding to
                 **counterclockwise** rotations about the z axis.
             query_points ((:math:`N_{query\_points}`, 3) :class:`numpy.ndarray`, optional):
-                Query points used to calculate the correlation function.  Uses
-                the system's points if :code:`None` (Default
-                value = :code:`None`).
+                Query points used to calculate the PMFT. Uses the system's
+                points if :code:`None` (Default value = :code:`None`).
             neighbors (:class:`freud.locality.NeighborList` or dict, optional):
                 Either a :class:`NeighborList <freud.locality.NeighborList>` of
                 neighbor pairs to use in the calculation, or a dictionary of
@@ -555,22 +549,27 @@ cdef class PMFTXYZ(_PMFT):
         if type(self) is PMFTXYZ:
             del self.pmftxyzptr
 
-    def compute(self, system, orientations, query_points=None,
+    def compute(self, system, query_orientations, query_points=None,
                 face_orientations=None, neighbors=None, reset=True):
-        R"""Calculates the positional correlation function and adds to the
-        current histogram.
+        R"""Calculates the PMFT.
+
+        .. note::
+            The orientations of the system points are irrelevant for this
+            calculation because that dimension is integrated out. The provided
+            ``query_orientations`` are therefore always associated with
+            ``query_points`` (which are equal to the system points if no
+            ``query_points`` are explicitly provided.
 
         Args:
             system:
                 Any object that is a valid argument to
                 :class:`freud.locality.NeighborQuery.from_system`.
-            orientations ((:math:`N_{points}`, 4) :class:`numpy.ndarray`):
-                Orientations associated with system points that are used to
-                calculate bonds.
+            query_orientations ((:math:`N_{points}`, 4) :class:`numpy.ndarray`):
+                Query orientations associated with query points that are used
+                to calculate bonds.
             query_points ((:math:`N_{query\_points}`, 3) :class:`numpy.ndarray`, optional):
-                Query points used to calculate the correlation function.  Uses
-                the system's points if :code:`None` (Default
-                value = :code:`None`).
+                Query points used to calculate the PMFT. Uses the system's
+                points if :code:`None` (Default value = :code:`None`).
             face_orientations ((:math:`N_{points}`, :math:`N_{faces}`, 4) :class:`numpy.ndarray`, optional):
                 Orientations of particle faces to account for symmetry of the
                 points. If not supplied by user or :code:`None`, unit

--- a/tests/test_pmft.py
+++ b/tests/test_pmft.py
@@ -705,7 +705,8 @@ class TestPMFTXYZ(unittest.TestCase):
         nbinsY = 110
         nbinsZ = 120
         myPMFT = freud.pmft.PMFTXYZ(maxX, maxY, maxZ, (nbinsX, nbinsY, nbinsZ))
-        myPMFT.compute((box, points), orientations, points, orientations,
+        myPMFT.compute(system=(box, points), query_orientations=orientations,
+                       query_points=points, face_orientations=orientations,
                        reset=False)
         npt.assert_equal(myPMFT.box, freud.box.Box.cube(boxSize))
 
@@ -776,8 +777,8 @@ class TestPMFTXYZ(unittest.TestCase):
         with self.assertRaises(AttributeError):
             myPMFT.pmft
 
-        myPMFT.compute((box, points), orientations, points, orientations,
-                       reset=False)
+        myPMFT.compute(system=(box, points), query_orientations=orientations,
+                       query_points=points, reset=False)
 
         myPMFT.bin_counts
         myPMFT.pmft
@@ -795,7 +796,8 @@ class TestPMFTXYZ(unittest.TestCase):
         box = freud.box.Box.cube(boxSize)
         points = np.array([[-1.0, 0.0, 0.0], [1.0, 0.0, 0.0]],
                           dtype=np.float32)
-        orientations = np.array([[1, 0, 0, 0], [1, 0, 0, 0]], dtype=np.float32)
+        query_orientations = np.array([[1, 0, 0, 0], [1, 0, 0, 0]],
+                                      dtype=np.float32)
         maxX = 5.23
         maxY = 6.23
         maxZ = 7.23
@@ -826,45 +828,47 @@ class TestPMFTXYZ(unittest.TestCase):
         for nq, neighbors in test_set:
             myPMFT = freud.pmft.PMFTXYZ(
                 maxX, maxY, maxZ, (nbinsX, nbinsY, nbinsZ))
-            myPMFT.compute(nq, orientations, neighbors=neighbors, reset=False)
+            myPMFT.compute(nq, query_orientations, neighbors=neighbors,
+                           reset=False)
             npt.assert_allclose(myPMFT.bin_counts, correct_bin_counts,
                                 atol=absoluteTolerance)
-            myPMFT.compute(nq, orientations, neighbors=neighbors)
+            myPMFT.compute(nq, query_orientations, neighbors=neighbors)
             npt.assert_allclose(myPMFT.bin_counts, correct_bin_counts,
                                 atol=absoluteTolerance)
 
-            # Test face orientations, shape (N_faces, 4)
+            # Test face_orientations, shape (N_faces, 4)
             face_orientations = np.array([[1., 0., 0., 0.]])
-            myPMFT.compute(nq, orientations, neighbors=neighbors,
+            myPMFT.compute(nq, query_orientations, neighbors=neighbors,
                            face_orientations=face_orientations)
             npt.assert_allclose(myPMFT.bin_counts, correct_bin_counts,
                                 atol=absoluteTolerance)
-            # Test face orientations, shape (1, N_faces, 4)
+            # Test face_orientations, shape (1, N_faces, 4)
             face_orientations = np.array([[[1., 0., 0., 0.]]])
-            myPMFT.compute(nq, orientations, neighbors=neighbors,
+            myPMFT.compute(nq, query_orientations, neighbors=neighbors,
                            face_orientations=face_orientations)
             npt.assert_allclose(myPMFT.bin_counts, correct_bin_counts,
                                 atol=absoluteTolerance)
-            # Test face orientations, shape (N_particles, N_faces, 4)
+            # Test face_orientations, shape (N_particles, N_faces, 4)
             face_orientations = np.array([[[1., 0., 0., 0.]],
                                           [[1., 0., 0., 0.]]])
-            myPMFT.compute(nq, orientations, neighbors=neighbors,
+            myPMFT.compute(nq, query_orientations, neighbors=neighbors,
                            face_orientations=face_orientations)
             npt.assert_allclose(myPMFT.bin_counts, correct_bin_counts,
                                 atol=absoluteTolerance)
 
-            myPMFT.compute(nq, orientations, neighbors=neighbors)
+            myPMFT.compute(nq, query_orientations, neighbors=neighbors)
             npt.assert_allclose(myPMFT.bin_counts, correct_bin_counts,
                                 atol=absoluteTolerance)
 
     def test_shift_two_particles_dead_pixel(self):
         points = np.array([[1, 1, 1], [0, 0, 0]], dtype=np.float32)
-        orientations = np.array([[1, 0, 0, 0], [1, 0, 0, 0]], dtype=np.float32)
+        query_orientations = np.array([[1, 0, 0, 0], [1, 0, 0, 0]],
+                                      dtype=np.float32)
         noshift = freud.pmft.PMFTXYZ(0.5, 0.5, 0.5, 3, shiftvec=[0, 0, 0])
         shift = freud.pmft.PMFTXYZ(0.5, 0.5, 0.5, 3, shiftvec=[1, 1, 1])
 
         for pm in [noshift, shift]:
-            pm.compute((freud.box.Box.cube(3), points), orientations)
+            pm.compute((freud.box.Box.cube(3), points), query_orientations)
 
         # Ignore warnings about NaNs
         warnings.simplefilter("ignore", category=RuntimeWarning)


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above. -->

## Description
The PMFTXYZ argument `orientations` should have been labeled `query_orientations`. This PR also fixes several errors in the docs for the `pmft` module.

## How Has This Been Tested?
Existing tests should pass.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds or improves functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!-- Put an `x` in all the boxes that apply. If you're unsure about any of
     these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/glotzerlab/freud/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] I have updated the documentation (if relevant).
- [x] I have added tests that cover my changes (if relevant).
- [x] All new and existing tests passed.
- [x] I have updated the [credits](https://github.com/glotzerlab/freud/blob/master/doc/source/credits.rst).
- [x] I have updated the [Changelog](https://github.com/glotzerlab/freud/blob/master/ChangeLog.md).
