### PR TITLE
Fix/from system dimensionality

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -7,7 +7,7 @@ and this project adheres to
 ## next
 
 ### Fixed
-* Conversion of automatic conversion of 2D systems from various data sources.
+* Automatic conversion of 2D systems from various data sources.
 
 ## v2.0.0 - 2019-10-31
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,11 @@ The format is based on
 and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## next
+
+### Fixed
+* Conversion of automatic conversion of 2D systems from various data sources.
+
 ## v2.0.0 - 2019-10-31
 
 ### Added

--- a/doc/source/credits.rst
+++ b/doc/source/credits.rst
@@ -47,6 +47,7 @@ Vyas Ramasubramani - **Lead developer**
 * Standardized PMFT normalization.
 * Enabled optional normalization of RDF.
 * Changed correlation function to properly take the complex conjugate of inputs.
+* Fixed handling of 2D systems from various data sources.
 
 Bradley Dice - **Lead developer**
 

--- a/freud/locality.pyx
+++ b/freud/locality.pyx
@@ -315,11 +315,6 @@ cdef class NeighborQuery:
 
         # MDAnalysis compatibility
         elif match_class_path(system, 'MDAnalysis.coordinates.base.Timestep'):
-            if dimensions is None:
-                logger.warn("Assuming MDAnalysis timestep is a 3-dimensional "
-                            "system. You must specify the dimensionality in "
-                            "from_system (or manually convert the frame's box "
-                            "to a 2D freud box) if your system is 2D.")
             system = (system.triclinic_dimensions, system.positions)
 
         # GSD compatibility
@@ -348,7 +343,10 @@ cdef class NeighborQuery:
               hasattr(system.particles, 'position')):
             # Explicitly construct the box to silence warnings from box
             # constructor because HOOMD sets Lz=1 rather than 0 for 2D boxes.
-            box = freud.Box(system.box.Lx, system.box.Ly, xy=system.box.xy)
+            if system.box.dimensions == 2:
+                box = freud.Box(system.box.Lx, system.box.Ly, xy=system.box.xy)
+            else:
+                box = system.box
             system = (box, system.particles.position)
 
         # Duck type systems with attributes into a (box, points) tuple


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above. -->

## Description
I adapted `from_system` to correctly handle inputs from various data sources when the systems are 2-dimensional. I also fixed an error in how Ovito inputs were handled.

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- Replace ??? with the issue number that this pull request resolves, if applicable. -->
Currently the code simply passes the underlying object from various inputs through. This method doesn't work for 2D systems unless the object actually provides a `dimensions` attribute. Additionally, the current version will be a bit noisy for HOOMD outputs that set `Lz=1` for 2D systems, so we need to construct the box explicitly to silence these. 

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds or improves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!-- Put an `x` in all the boxes that apply. If you're unsure about any of
     these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/glotzerlab/freud/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] I have updated the documentation (if relevant).
- [x] I have added tests that cover my changes (if relevant).
- [x] All new and existing tests passed.
- [x] I have updated the [credits](https://github.com/glotzerlab/freud/blob/master/doc/source/credits.rst).
- [x] I have updated the [Changelog](https://github.com/glotzerlab/freud/blob/master/ChangeLog.md).
