### PR TITLE
Fix searched name for ovito object

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,11 @@ The format is based on
 and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## next
+
+### Fixed
+* Correctly recognize Ovito DataCollection objects in from\_system.
+
 ## v2.0.1 - 2019-11-08
 
 ### Added

--- a/freud/locality.pyx
+++ b/freud/locality.pyx
@@ -357,8 +357,6 @@ cdef class NeighborQuery:
         if cls == NeighborQuery:
             # If called from this abstract parent class, always make
             # :class:`~._RawPoints`.
-            print("The system object: ")
-            print(system)
             return _RawPoints(*system)
         else:
             # Otherwise, use the current class.

--- a/freud/locality.pyx
+++ b/freud/locality.pyx
@@ -332,7 +332,8 @@ cdef class NeighborQuery:
 
         # OVITO compatibility
         elif (match_class_path(system, 'ovito.data.DataCollection') or
-              match_class_path(system, 'PyScript.DataCollection')):
+              match_class_path(system,
+                               'ovito.plugins.PyScript.DataCollection')):
             box = freud.Box.from_box(
                 system.cell.matrix[:, :3],
                 dimensions=2 if system.cell.is2D else 3)
@@ -356,6 +357,8 @@ cdef class NeighborQuery:
         if cls == NeighborQuery:
             # If called from this abstract parent class, always make
             # :class:`~._RawPoints`.
+            print("The system object: ")
+            print(system)
             return _RawPoints(*system)
         else:
             # Otherwise, use the current class.


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above. -->

## Description
The current classname being checked to determine if a system object is an Ovito DataCollection is wrong. This PR fixes that.

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to
     see how your changes affect other areas of the code, etc. -->
Tested inside Ovito.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds or improves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!-- Put an `x` in all the boxes that apply. If you're unsure about any of
     these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/glotzerlab/freud/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] I have updated the documentation (if relevant).
- [x] I have added tests that cover my changes (if relevant).
- [x] All new and existing tests passed.
- [x] I have updated the [credits](https://github.com/glotzerlab/freud/blob/master/doc/source/credits.rst).
- [x] I have updated the [Changelog](https://github.com/glotzerlab/freud/blob/master/ChangeLog.md).
