### PR TITLE
Pass dimensions in from_box through to from_matrix. Minor improvements to error handling

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,11 @@ The format is based on
 and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## next
+
+### Fixed
+* The from\_box method correctly passes user provided dimensions to from\_matrix it if is called.
+
 ## v2.0.1 - 2019-11-08
 
 ### Added

--- a/freud/box.pyx
+++ b/freud/box.pyx
@@ -529,7 +529,7 @@ cdef class Box:
         """
         if np.asarray(box).shape == (3, 3):
             # Handles 3x3 matrices
-            return cls.from_matrix(box)
+            return cls.from_matrix(box, dimensions=dimensions)
         try:
             # Handles freud.box.Box and objects with attributes
             Lx = box.Lx
@@ -540,11 +540,10 @@ cdef class Box:
             yz = getattr(box, 'yz', 0)
             if dimensions is None:
                 dimensions = getattr(box, 'dimensions', None)
-            else:
-                if dimensions != getattr(box, 'dimensions', dimensions):
-                    raise ValueError(
-                        "The provided dimensions argument conflicts with the "
-                        "dimensions attribute of the provided box object.")
+            elif dimensions != getattr(box, 'dimensions', dimensions):
+                raise ValueError(
+                    "The provided dimensions argument conflicts with the "
+                    "dimensions attribute of the provided box object.")
         except AttributeError:
             try:
                 # Handle dictionary-like
@@ -571,7 +570,7 @@ cdef class Box:
                 Lx = box[0]
                 Ly = box[1]
                 Lz = box[2] if len(box) > 2 else 0
-                xy, xz, yz = box[3:6] if len(box) >= 6 else (0, 0, 0)
+                xy, xz, yz = box[3:6] if len(box) == 6 else (0, 0, 0)
         except:  # noqa
             logger.debug('Supplied box cannot be converted to type '
                          'freud.box.Box.')

--- a/tests/test_box_Box.py
+++ b/tests/test_box_Box.py
@@ -325,6 +325,13 @@ class TestBox(unittest.TestCase):
         box4 = freud.box.Box.from_matrix(box3.to_matrix())
         self.assertTrue(np.isclose(box3.to_matrix(), box4.to_matrix()).all())
 
+    def test_set_dimensions(self):
+        b = np.asarray([[1, 0, 0],
+                        [0, 1, 0],
+                        [0, 0, 1]])
+        box = freud.Box.from_box(b, dimensions=2)
+        self.assertTrue(box.dimensions == 2)
+
     def test_2_dimensional(self):
         box = freud.box.Box.square(L=1)
         # Setting Lz for a 2D box throws a warning that we hide with setUp()


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above. -->

## Description
The dimensions argument to `from_box` was not being forwarded to `from_matrix`. 

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to
     see how your changes affect other areas of the code, etc. -->
New test is added.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds or improves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!-- Put an `x` in all the boxes that apply. If you're unsure about any of
     these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/glotzerlab/freud/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] I have updated the documentation (if relevant).
- [x] I have added tests that cover my changes (if relevant).
- [x] All new and existing tests passed.
- [x] I have updated the [credits](https://github.com/glotzerlab/freud/blob/master/doc/source/credits.rst).
- [x] I have updated the [Changelog](https://github.com/glotzerlab/freud/blob/master/ChangeLog.md).
