### PR TITLE
Add periodic center-of-mass computations to Box class.

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -30,5 +30,5 @@ Resolves: #???
 - [ ] I have updated the documentation (if relevant).
 - [ ] I have added tests that cover my changes (if relevant).
 - [ ] All new and existing tests passed.
-- [ ] I have updated the [credits](https://github.com/glotzerlab/freud/blob/master/doc/source/credits.rst).
+- [ ] I have updated the [credits](https://github.com/glotzerlab/freud/blob/master/doc/source/reference/credits.rst).
 - [ ] I have updated the [Changelog](https://github.com/glotzerlab/freud/blob/master/ChangeLog.md).

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,14 @@ The format is based on
 and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## next
+
+### Added
+* The Box class has methods `center_of_mass` and `center` for periodic-aware center of mass and shifting points to center on the origin.
+
+### Fixed
+* Corrected `ClusterProperties` calculation of centers of mass in specific systems (issue #552).
+
 ## v2.0.1 - 2019-11-08
 
 ### Added

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -12,7 +12,7 @@ and this project adheres to
 ### Fixed
 * The from\_box method correctly passes user provided dimensions to from\_matrix it if is called.
 * Correctly recognize Ovito DataCollection objects in from\_system.
-* Corrected `ClusterProperties` calculation of centers of mass in specific systems (issue #552).
+* Corrected `ClusterProperties` calculation of centers of mass in specific systems.
 
 ## v2.0.1 - 2019-11-08
 

--- a/cpp/box/Box.h
+++ b/cpp/box/Box.h
@@ -353,12 +353,12 @@ public:
      *  \param masses Optional array of masses, of length Nvecs
      *  \return Center of mass as a vec3<float>
      */
-    vec3<float> centerOfMass(vec3<float>* vecs, unsigned int Nvecs, float* masses = NULL) const
+    vec3<float> centerOfMass(vec3<float>* vecs, size_t Nvecs, float* masses = NULL) const
     {
         // This roughly follows the implementation in
         // https://en.wikipedia.org/wiki/Center_of_mass#Systems_with_periodic_boundary_conditions
         float total_mass(0);
-        vec3<std::complex<float>> xi_mean(vec3<std::complex<float>>(0.0, 0.0, 0.0));
+        vec3<std::complex<float>> xi_mean;
 
         for (size_t i = 0; i < Nvecs; ++i) {
             vec3<float> phase(TWO_PI * makeFractional(vecs[i]));

--- a/cpp/box/Box.h
+++ b/cpp/box/Box.h
@@ -5,6 +5,7 @@
 #define BOX_H
 
 #include "utils.h"
+#include <complex>
 #include <sstream>
 #include <stdexcept>
 
@@ -15,6 +16,9 @@
 */
 
 namespace freud { namespace box {
+
+// namespace-level constant 2*pi for convenient use everywhere.
+constexpr float TWO_PI = 2.0 * M_PI;
 
 //! Stores box dimensions and provides common routines for wrapping vectors back into the box
 /*! Box stores a standard HOOMD simulation box that goes from -L/2 to L/2 in each dimension, allowing Lx, Ly,
@@ -339,6 +343,53 @@ public:
                 {
                     vecs[i] += getLatticeVector(2) * float(images[i].z);
                 }
+            }
+        });
+    }
+
+    //! Compute center of mass for vectors
+    /*! \param vecs Vectors to compute center of mass
+     *  \param Nvecs Number of vectors
+     *  \param masses Optional array of masses, of length Nvecs
+     *  \return Center of mass as a vec3<float>
+     */
+    vec3<float> centerOfMass(vec3<float>* vecs, unsigned int Nvecs, float* masses = NULL) const
+    {
+        // This roughly follows the implementation in
+        // https://en.wikipedia.org/wiki/Center_of_mass#Systems_with_periodic_boundary_conditions
+        float total_mass(0);
+        vec3<std::complex<float>> xi_mean(vec3<std::complex<float>>(0.0, 0.0, 0.0));
+
+        for (size_t i = 0; i < Nvecs; ++i) {
+            vec3<float> phase(TWO_PI * makeFractional(vecs[i]));
+            vec3<std::complex<float>> xi(
+                    std::polar(float(1.0), phase.x),
+                    std::polar(float(1.0), phase.y),
+                    std::polar(float(1.0), phase.z));
+            float mass = (masses != NULL) ? masses[i] : 1.0;
+            total_mass += mass;
+            xi_mean += std::complex<float>(mass, 0) * xi;
+        }
+        xi_mean /= std::complex<float>(total_mass, 0);
+
+        return wrap(makeAbsolute(vec3<float>(
+                std::arg(xi_mean.x),
+                std::arg(xi_mean.y),
+                std::arg(xi_mean.z)) / TWO_PI));
+    }
+
+    //! Subtract center of mass from vectors
+    /*! \param vecs Vectors to center, updated to the minimum image obeying the periodic settings
+     *  \param Nvecs Number of vectors
+     *  \param masses Optional array of masses, of length Nvecs
+     */
+    void center(vec3<float>* vecs, unsigned int Nvecs, float* masses = NULL) const
+    {
+        vec3<float> com(centerOfMass(vecs, Nvecs, masses));
+        util::forLoopWrapper(0, Nvecs, [=](size_t begin, size_t end) {
+            for (size_t i = begin; i < end; ++i)
+            {
+                vecs[i] = wrap(vecs[i] - com);
             }
         });
     }

--- a/doc/source/reference/credits.rst
+++ b/doc/source/reference/credits.rst
@@ -93,6 +93,7 @@ Bradley Dice - **Lead developer**
 * Updated MSD to perform accumulation with `compute(..., reset=False)`.
 * Added test PyPI support to continuous integration.
 * Added continuous integration to freud-examples.
+* Implemented periodic center of mass computations in C++.
 
 Eric Harper, University of Michigan - **Former lead developer**
 

--- a/freud/_box.pxd
+++ b/freud/_box.pxd
@@ -46,8 +46,8 @@ cdef extern from "Box.h" namespace "freud::box":
         void wrap(vec3[float]* vs, unsigned int Nv) const
         void unwrap(vec3[float]*, const vec3[int]*,
                     unsigned int) const
-        vec3[float] centerOfMass(vec3[float]*, unsigned int, float*) const
-        void center(vec3[float]*, unsigned int, float*) const
+        vec3[float] centerOfMass(vec3[float]*, size_t, float*) const
+        void center(vec3[float]*, size_t, float*) const
 
         vec3[bool] getPeriodic() const
         bool getPeriodicX() const

--- a/freud/_box.pxd
+++ b/freud/_box.pxd
@@ -46,6 +46,8 @@ cdef extern from "Box.h" namespace "freud::box":
         void wrap(vec3[float]* vs, unsigned int Nv) const
         void unwrap(vec3[float]*, const vec3[int]*,
                     unsigned int) const
+        vec3[float] centerOfMass(vec3[float]*, unsigned int, float*) const
+        void center(vec3[float]*, unsigned int, float*) const
 
         vec3[bool] getPeriodic() const
         bool getPeriodicX() const

--- a/freud/box.pyx
+++ b/freud/box.pyx
@@ -356,15 +356,17 @@ cdef class Box:
                 Center of mass.
         """  # noqa: E501
         vecs = freud.util._convert_array(vecs, shape=(None, 3))
-        if masses is None:
-            masses = np.ones(len(vecs), dtype=np.float32)
-        masses = freud.util._convert_array(masses, shape=(len(vecs), ))
-
         cdef const float[:, ::1] l_points = vecs
-        cdef const float[::1] l_masses = masses
+
+        cdef float* l_masses_ptr = NULL
+        cdef float[::1] l_masses
+        if masses is not None:
+            l_masses = freud.util._convert_array(masses, shape=(len(vecs), ))
+            l_masses_ptr = &l_masses[0]
+
         cdef unsigned int Np = l_points.shape[0]
         cdef vec3[float] result = self.thisptr.centerOfMass(
-            <vec3[float]*> &l_points[0, 0], Np, <float*> &l_masses[0])
+            <vec3[float]*> &l_points[0, 0], Np, l_masses_ptr)
         return np.asarray([result.x, result.y, result.z])
 
     def center(self, vecs, masses=None):
@@ -382,16 +384,16 @@ cdef class Box:
                 Vectors wrapped into the box.
         """  # noqa: E501
         vecs = freud.util._convert_array(vecs, shape=(None, 3)).copy()
-        if masses is None:
-            masses = np.ones(len(vecs), dtype=np.float32)
-        masses = freud.util._convert_array(masses, shape=(len(vecs), ))
-
         cdef const float[:, ::1] l_points = vecs
-        cdef const float[::1] l_masses = masses
-        cdef unsigned int Np = l_points.shape[0]
-        self.thisptr.center(<vec3[float]*> &l_points[0, 0], Np,
-                            <float*> &l_masses[0])
 
+        cdef float* l_masses_ptr = NULL
+        cdef float[::1] l_masses
+        if masses is not None:
+            l_masses = freud.util._convert_array(masses, shape=(len(vecs), ))
+            l_masses_ptr = &l_masses[0]
+
+        cdef unsigned int Np = l_points.shape[0]
+        self.thisptr.center(<vec3[float]*> &l_points[0, 0], Np, l_masses_ptr)
         return vecs
 
     @property

--- a/freud/box.pyx
+++ b/freud/box.pyx
@@ -341,6 +341,59 @@ cdef class Box:
 
         return np.squeeze(vecs) if flatten else vecs
 
+    def center_of_mass(self, vecs, masses=None):
+        R"""Compute center of mass of an array of vectors, using periodic boundaries.
+
+        Args:
+            vecs (:math:`\left(N, 3\right)` :class:`numpy.ndarray`):
+                Vectors used to find center of mass.
+            masses (:math:`\left(N, 3\right)` :class:`numpy.ndarray`):
+                Masses corresponding to each vector, defaulting to 1 if not
+                provided or :code:`None` (Default value = :code:`None`).
+
+        Returns:
+            :math:`\left(3\right)` :class:`numpy.ndarray`:
+                Center of mass.
+        """  # noqa: E501
+        vecs = freud.util._convert_array(vecs, shape=(None, 3))
+        if masses is None:
+            masses = np.ones(len(vecs), dtype=np.float32)
+        masses = freud.util._convert_array(masses, shape=(len(vecs), ))
+
+        cdef const float[:, ::1] l_points = vecs
+        cdef const float[::1] l_masses = masses
+        cdef unsigned int Np = l_points.shape[0]
+        cdef vec3[float] result = self.thisptr.centerOfMass(
+                <vec3[float]*> &l_points[0, 0], Np, <float*> &l_masses[0])
+        return np.asarray([result.x, result.y, result.z])
+
+    def center(self, vecs, masses=None):
+        R"""Subtract center of mass from an array of vectors, using periodic boundaries.
+
+        Args:
+            vecs (:math:`\left(N, 3\right)` :class:`numpy.ndarray`):
+                Vectors to center.
+            masses (:math:`\left(N, 3\right)` :class:`numpy.ndarray`):
+                Masses corresponding to each vector, defaulting to 1 if not
+                provided or :code:`None` (Default value = :code:`None`).
+
+        Returns:
+            :math:`\left(N, 3\right)` :class:`numpy.ndarray`:
+                Vectors wrapped into the box.
+        """  # noqa: E501
+        vecs = freud.util._convert_array(vecs, shape=(None, 3)).copy()
+        if masses is None:
+            masses = np.ones(len(vecs), dtype=np.float32)
+        masses = freud.util._convert_array(masses, shape=(len(vecs), ))
+
+        cdef const float[:, ::1] l_points = vecs
+        cdef const float[::1] l_masses = masses
+        cdef unsigned int Np = l_points.shape[0]
+        self.thisptr.center(<vec3[float]*> &l_points[0, 0], Np,
+                            <float*> &l_masses[0])
+
+        return vecs
+
     @property
     def periodic(self):
         """:math:`\\left(3, \\right)` :class:`numpy.ndarray`: Get or set the

--- a/freud/box.pyx
+++ b/freud/box.pyx
@@ -364,7 +364,7 @@ cdef class Box:
         cdef const float[::1] l_masses = masses
         cdef unsigned int Np = l_points.shape[0]
         cdef vec3[float] result = self.thisptr.centerOfMass(
-                <vec3[float]*> &l_points[0, 0], Np, <float*> &l_masses[0])
+            <vec3[float]*> &l_points[0, 0], Np, <float*> &l_masses[0])
         return np.asarray([result.x, result.y, result.z])
 
     def center(self, vecs, masses=None):

--- a/freud/box.pyx
+++ b/freud/box.pyx
@@ -364,7 +364,7 @@ cdef class Box:
             l_masses = freud.util._convert_array(masses, shape=(len(vecs), ))
             l_masses_ptr = &l_masses[0]
 
-        cdef unsigned int Np = l_points.shape[0]
+        cdef size_t Np = l_points.shape[0]
         cdef vec3[float] result = self.thisptr.centerOfMass(
             <vec3[float]*> &l_points[0, 0], Np, l_masses_ptr)
         return np.asarray([result.x, result.y, result.z])
@@ -392,7 +392,7 @@ cdef class Box:
             l_masses = freud.util._convert_array(masses, shape=(len(vecs), ))
             l_masses_ptr = &l_masses[0]
 
-        cdef unsigned int Np = l_points.shape[0]
+        cdef size_t Np = l_points.shape[0]
         self.thisptr.center(<vec3[float]*> &l_points[0, 0], Np, l_masses_ptr)
         return vecs
 

--- a/tests/test_box_Box.py
+++ b/tests/test_box_Box.py
@@ -220,6 +220,10 @@ class TestBox(unittest.TestCase):
         npt.assert_allclose(box.center(points, masses),
                             box.wrap(points - com), atol=1e-6)
 
+        # Make sure the center of mass is not (0, 0, 0) if ignoring masses
+        assert not np.allclose(box.center_of_mass(points),
+                               [0, 0, 0], atol=1e-6)
+
     def test_absolute_coordinates(self):
         box = freud.box.Box(2, 2, 2)
         f_point = np.array([[0.5, 0.25, 0.75],

--- a/tests/test_box_Box.py
+++ b/tests/test_box_Box.py
@@ -171,6 +171,55 @@ class TestBox(unittest.TestCase):
                          np.array([[25, 20, 15],
                                    [-5, 0, 0]]))
 
+    def test_center_of_mass(self):
+        box = freud.box.Box.cube(5)
+
+        npt.assert_allclose(
+            box.center_of_mass([[0, 0, 0]]), [0, 0, 0], atol=1e-6)
+        npt.assert_allclose(
+            box.center_of_mass([[1, 1, 1]]), [1, 1, 1], atol=1e-6)
+        npt.assert_allclose(
+            box.center_of_mass([[1, 1, 1], [2, 2, 2]]),
+            [1.5, 1.5, 1.5], atol=1e-6)
+        npt.assert_allclose(
+            box.center_of_mass([[-2, -2, -2], [2, 2, 2]]),
+            [-2.5, -2.5, -2.5], atol=1e-6)
+        npt.assert_allclose(
+            box.center_of_mass([[-2.2, -2.2, -2.2], [2, 2, 2]]),
+            [2.4, 2.4, 2.4], atol=1e-6)
+
+    def test_center_of_mass_weighted(self):
+        box = freud.box.Box.cube(5)
+
+        points = [[0, 0, 0], -box.L/4]
+        masses = [2, 1]
+        phases = np.exp(2*np.pi*1j*box.make_fractional(points))
+        com_angle = np.angle(phases.T @ masses / np.sum(masses))
+        com = box.make_absolute(com_angle / (2*np.pi))
+        npt.assert_allclose(
+            box.center_of_mass(points, masses), com, atol=1e-6)
+
+    def test_center(self):
+        box = freud.box.Box.cube(5)
+
+        npt.assert_allclose(box.center([[0, 0, 0]]), [[0, 0, 0]], atol=1e-6)
+        npt.assert_allclose(box.center([[1, 1, 1]]), [[0, 0, 0]], atol=1e-6)
+        npt.assert_allclose(box.center([[1, 1, 1], [2, 2, 2]]),
+                            [[-0.5, -0.5, -0.5], [0.5, 0.5, 0.5]], atol=1e-6)
+        npt.assert_allclose(box.center([[-2, -2, -2], [2, 2, 2]]),
+                            [[0.5, 0.5, 0.5], [-0.5, -0.5, -0.5]], atol=1e-6)
+
+    def test_center_weighted(self):
+        box = freud.box.Box.cube(5)
+
+        points = [[0, 0, 0], -box.L/4]
+        masses = [2, 1]
+        phases = np.exp(2*np.pi*1j*box.make_fractional(points))
+        com_angle = np.angle(phases.T @ masses / np.sum(masses))
+        com = box.make_absolute(com_angle / (2*np.pi))
+        npt.assert_allclose(box.center(points, masses),
+                            box.wrap(points - com), atol=1e-6)
+
     def test_absolute_coordinates(self):
         box = freud.box.Box(2, 2, 2)
         f_point = np.array([[0.5, 0.25, 0.75],

--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -99,6 +99,20 @@ class TestCluster(unittest.TestCase):
         npt.assert_allclose(
             props.radii_of_gyration, [0, rg_2], rtol=1e-5, atol=1e-5)
 
+    def test_cluster_com_periodic(self):
+        "Tests center of mass for symmetric, box-spanning clusters."
+        box = freud.Box.cube(3)
+
+        # Center of mass is near the periodic boundary, not near the origin
+        points = [[0.1, 0, 0],
+                  [-0.9, 0, 0], [-0.9, 0.5, 0], [-0.9, -0.5, 0],
+                  [1.1, 0, 0], [1.1, 0.5, 0], [1.1, -0.5, 0]]
+
+        clp = freud.cluster.ClusterProperties()
+        clp.compute((box, points), np.zeros(len(points)))
+
+        npt.assert_allclose(clp.centers, [[-1.4, 0, 0]], rtol=1e-5, atol=1e-5)
+
     def test_cluster_keys(self):
         Nlattice = 4
         Nrep = 5


### PR DESCRIPTION
## Description
While reviewing #549, I realized that there were some instances in the C++ side of freud's code that also need to do center-of-mass computations. I recognized a bug in the implementation of this for `ClusterProperties` and rewrote #549 in C++ to solve the bug and enable this new feature. This replaces the `ClusterProperties` class's computations of center-of-mass, which is wrong in specific, unusual cases (see #552).

## Motivation and Context
Replaces #549. Resolves #552.

## How Has This Been Tested?
Added a test for the case in #552.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds or improves functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have read the [**CONTRIBUTING**](https://github.com/glotzerlab/freud/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] I have updated the documentation (if relevant).
- [x] I have added tests that cover my changes (if relevant).
- [x] All new and existing tests passed.
- [x] I have updated the [credits](https://github.com/glotzerlab/freud/blob/master/doc/source/credits.rst).
- [x] I have updated the [Changelog](https://github.com/glotzerlab/freud/blob/master/ChangeLog.md).