### PR TITLE
Fix/gsd 2d from system

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -13,6 +13,7 @@ and this project adheres to
 * The from\_box method correctly passes user provided dimensions to from\_matrix it if is called.
 * Correctly recognize Ovito DataCollection objects in from\_system.
 * Corrected `ClusterProperties` calculation of centers of mass in specific systems.
+* Set z positions to 0 for 2D GSD systems in from\_system.
 
 ## v2.0.1 - 2019-11-08
 

--- a/cpp/locality/NeighborQuery.h
+++ b/cpp/locality/NeighborQuery.h
@@ -89,7 +89,7 @@ public:
         {
             for (unsigned int i(0); i < n_points; i++)
             {
-                if (m_points[i].z != 0)
+                if (m_points[i].z > 1e-6)
                 {
                     throw std::invalid_argument("A point with z != 0 was provided in a 2D box.");
                 }

--- a/freud/locality.pyx
+++ b/freud/locality.pyx
@@ -324,7 +324,12 @@ cdef class NeighborQuery:
             box = system.configuration.box.copy()
             if system.configuration.dimensions == 2:
                 box[[2, 4, 5]] = 0
-            system = (box, system.particles.position)
+                # GSD does not guarantee that the z position is 0 for 2D boxes.
+                positions = system.particles.position.copy()
+                positions[:, 2] = 0
+            else:
+                positions = system.particles.position
+            system = (box, position)
 
         # garnett compatibility
         elif match_class_path(system, 'garnett.trajectory.Frame'):

--- a/freud/locality.pyx
+++ b/freud/locality.pyx
@@ -329,7 +329,7 @@ cdef class NeighborQuery:
                 positions[:, 2] = 0
             else:
                 positions = system.particles.position
-            system = (box, position)
+            system = (box, positions)
 
         # garnett compatibility
         elif match_class_path(system, 'garnett.trajectory.Frame'):

--- a/freud/locality.pyx
+++ b/freud/locality.pyx
@@ -324,12 +324,7 @@ cdef class NeighborQuery:
             box = system.configuration.box.copy()
             if system.configuration.dimensions == 2:
                 box[[2, 4, 5]] = 0
-                # GSD does not guarantee that the z position is 0 for 2D boxes.
-                positions = system.particles.position.copy()
-                positions[:, 2] = 0
-            else:
-                positions = system.particles.position
-            system = (box, positions)
+            system = (box, system.particles.position)
 
         # garnett compatibility
         elif match_class_path(system, 'garnett.trajectory.Frame'):


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above. -->

## Description
<!-- Describe your changes in detail. -->
Set z positions read from 2D GSD trajectories to 0.

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- Replace ??? with the issue number that this pull request resolves, if applicable. -->
We had fixed the box reading (because the z dimension won't be 0), but sometimes the z position is also not quite 0. Having already made this change, I actually think a better solution might be to just add a threshold to the check in the constructor for `NeighborQuery` rather than just checking if it's equal to zero since this could be an issue with other formats as well. @bdice let me know your thoughts, I can change if you agree.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds or improves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!-- Put an `x` in all the boxes that apply. If you're unsure about any of
     these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/glotzerlab/freud/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] I have updated the documentation (if relevant).
- [x] I have added tests that cover my changes (if relevant).
- [x] All new and existing tests passed.
- [x] I have updated the [credits](https://github.com/glotzerlab/freud/blob/master/doc/source/reference/credits.rst).
- [x] I have updated the [Changelog](https://github.com/glotzerlab/freud/blob/master/ChangeLog.md).
