### PR TITLE
Use absolute value of z.

### DIFF
--- a/cpp/locality/NeighborQuery.h
+++ b/cpp/locality/NeighborQuery.h
@@ -85,11 +85,12 @@ public:
     NeighborQuery(const box::Box& box, const vec3<float>* points, unsigned int n_points)
         : m_box(box), m_points(points), m_n_points(n_points)
     {
+        // For 2D systems, check if any z-coordinates are outside some tolerance of z=0
         if (m_box.is2D())
         {
             for (unsigned int i(0); i < n_points; i++)
             {
-                if (m_points[i].z > 1e-6)
+                if (std::abs(m_points[i].z) > 1e-6)
                 {
                     throw std::invalid_argument("A point with z != 0 was provided in a 2D box.");
                 }


### PR DESCRIPTION
## Description
Uses `std::abs(z)` to determine 2D system z-coordinate tolerances.

## Motivation and Context
I noticed in #555 that the check was only testing for positive z-values. It seems like it would be most appropriate to check the tolerance as an absolute value.

## How Has This Been Tested?
@vyasr may have test files for this.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds or improves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!-- Put an `x` in all the boxes that apply. If you're unsure about any of
     these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/glotzerlab/freud/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] I have updated the documentation (if relevant).
- [x] I have added tests that cover my changes (if relevant).
- [x] All new and existing tests passed.
- [x] I have updated the [credits](https://github.com/glotzerlab/freud/blob/master/doc/source/reference/credits.rst).
- [x] I have updated the [Changelog](https://github.com/glotzerlab/freud/blob/master/ChangeLog.md).
