### PR TITLE
Use heuristic to determine voro++ block sizes based on particle density.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -11,6 +11,7 @@ and this project adheres to
 
 ### Changed
 * The make\_random\_box system method no longer overwrites the NumPy global random number generator state.
+* The Voronoi class uses smarter heuristics for its voro++ block sizes, resulting in significant performance gains for large systems.
 
 ### Fixed
 * The from\_box method correctly passes user provided dimensions to from\_matrix it if is called.

--- a/cpp/locality/Voronoi.cc
+++ b/cpp/locality/Voronoi.cc
@@ -34,13 +34,20 @@ void Voronoi::compute(const freud::locality::NeighborQuery* nq)
     {
         boxLatticeVectors[2] = box.getLatticeVector(2);
     }
-    // TODO: This container uses 3 blocks in x, y, and z, and an initial
-    // memory allocation of 3, which should be improved. Ideally, this code
-    // should use a pre_container or implement its own heuristics to choose
-    // a number of blocks.
+
+    // This heuristic for choosing blocks is based on the voro::pre_container
+    // guess_optimal method. By computing the heuristic directly, we avoid
+    // having to create a pre_container. This saves time because the
+    // pre_container cannot be used to set up container_periodic (only
+    // non-periodic containers are compatible).
+    float block_scale = std::pow(n_points / (voro::optimal_particles * box.getVolume()), 1.0/3.0);
+    int voro_blocks_x = int(box.getLx() * block_scale + 1);
+    int voro_blocks_y = int(box.getLy() * block_scale + 1);
+    int voro_blocks_z = int(box.getLz() * block_scale + 1);
+
     voro::container_periodic container(boxLatticeVectors[0].x, boxLatticeVectors[1].x, boxLatticeVectors[1].y,
                                        boxLatticeVectors[2].x, boxLatticeVectors[2].y, boxLatticeVectors[2].z,
-                                       3, 3, 3, 3);
+                                       voro_blocks_x, voro_blocks_y, voro_blocks_z, 3);
 
     for (size_t query_point_id = 0; query_point_id < n_points; query_point_id++)
     {

--- a/doc/source/reference/credits.rst
+++ b/doc/source/reference/credits.rst
@@ -94,6 +94,7 @@ Bradley Dice - **Lead developer**
 * Added test PyPI support to continuous integration.
 * Added continuous integration to freud-examples.
 * Implemented periodic center of mass computations in C++.
+* Implemented smarter heuristics in Voronoi for voro++ block sizes, resulting in significant performance gains for large systems.
 
 Eric Harper, University of Michigan - **Former lead developer**
 


### PR DESCRIPTION
## Description
I was investigating a large system (500,000 particles) and the performance of Voronoi slowed to a crawl. When I implemented voro++, I hard-coded the block sizes and it seemed to perform fine for the test systems. However, those hard-coded sizes were terrible for performance with this large system. I have fixed the TODO item in the code, by implementing a heuristic that aims for an average of 5.6 particles per block (which is the optimal value provided by voro++).

## Motivation and Context
Significant performance improvement for Voronoi in large systems (>10k particles).

## How Has This Been Tested?
Existing tests pass.

Performance test:
```python
import freud
from datetime import datetime

voro = freud.locality.Voronoi()
for N in 500, 5000, 50000, 500000:
    system = freud.data.make_random_system(10, N, seed=42)
    start = datetime.now()
    voro.compute(system)
    end = datetime.now()
    print(N, 'particles', end-start, 'elapsed')
```

Results:

Particles | With Heuristics | master | Speedup
-- | -- | -- | --
500 | 0.020 | 0.024 | 1.2x
5000 | 0.181 | 0.523 | 2.9x
50000 | 1.679 | 16.893 | 10.1x
500000 | 14.410 | 1114.164 | 77.3x

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds or improves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!-- Put an `x` in all the boxes that apply. If you're unsure about any of
     these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/glotzerlab/freud/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] I have updated the documentation (if relevant).
- [x] I have added tests that cover my changes (if relevant).
- [x] All new and existing tests passed.
- [x] I have updated the [credits](https://github.com/glotzerlab/freud/blob/master/doc/source/reference/credits.rst).
- [x] I have updated the [Changelog](https://github.com/glotzerlab/freud/blob/master/ChangeLog.md).
