### PR TITLE
Fix/pmftxyz query orientations

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -11,12 +11,14 @@ and this project adheres to
 
 ### Changed
 * The make\_random\_box system method no longer overwrites the NumPy global random number generator state.
+* The face\_orientations argument of PMFTXYZ must be provided as an Nx2 array and must be identical for all query points.
 
 ### Fixed
 * The from\_box method correctly passes user provided dimensions to from\_matrix it if is called.
 * Correctly recognize Ovito DataCollection objects in from\_system.
 * Corrected `ClusterProperties` calculation of centers of mass in specific systems.
 * Set z positions to 0 for 2D GSD systems in from\_system.
+* PMFTXY and PMFTXYZ index into query orientations using the query point index instead of the point index.
 
 ## v2.0.1 - 2019-11-08
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -11,7 +11,7 @@ and this project adheres to
 
 ### Changed
 * The make\_random\_box system method no longer overwrites the NumPy global random number generator state.
-* The face\_orientations argument of PMFTXYZ must be provided as an Nx2 array and must be identical for all query points.
+* The face\_orientations argument of PMFTXYZ must be provided as an Mx4 array, where M is the number of symmetrically equivalent particle orientations.
 
 ### Fixed
 * The from\_box method correctly passes user provided dimensions to from\_matrix it if is called.

--- a/cpp/pmft/PMFTXY.cc
+++ b/cpp/pmft/PMFTXY.cc
@@ -64,7 +64,7 @@ void PMFTXY::accumulate(const locality::NeighborQuery* neighbor_query, float* qu
                           // rotate interparticle vector
                           vec2<float> myVec(delta.x, delta.y);
                           rotmat2<float> myMat
-                              = rotmat2<float>::fromAngle(-query_orientations[neighbor_bond.point_idx]);
+                              = rotmat2<float>::fromAngle(-query_orientations[neighbor_bond.query_point_idx]);
                           vec2<float> rotVec = myMat * myVec;
 
                           m_local_histograms(rotVec.x, rotVec.y);

--- a/cpp/pmft/PMFTXYZ.cc
+++ b/cpp/pmft/PMFTXYZ.cc
@@ -70,7 +70,7 @@ void PMFTXYZ::reduce()
  */
 void PMFTXYZ::accumulate(const locality::NeighborQuery* neighbor_query, quat<float>* query_orientations,
                          vec3<float>* query_points, unsigned int n_query_points,
-                         quat<float>* face_orientations, unsigned int n_faces,
+                         quat<float>* equiv_orientations, unsigned int n_faces,
                          const locality::NeighborList* nlist, freud::locality::QueryArgs qargs)
 {
     // precalc some values for faster computation within the loop
@@ -88,7 +88,7 @@ void PMFTXYZ::accumulate(const locality::NeighborQuery* neighbor_query, quat<flo
                               vec3<float> v(delta);
                               // rotate the vector
                               v = rotate(conj(ref_q), v);
-                              v = rotate(face_orientations[k], v);
+                              v = rotate(equiv_orientations[k], v);
 
                               m_local_histograms(v.x, v.y, v.z);
                           }

--- a/cpp/pmft/PMFTXYZ.cc
+++ b/cpp/pmft/PMFTXYZ.cc
@@ -70,7 +70,7 @@ void PMFTXYZ::reduce()
  */
 void PMFTXYZ::accumulate(const locality::NeighborQuery* neighbor_query, quat<float>* query_orientations,
                          vec3<float>* query_points, unsigned int n_query_points,
-                         quat<float>* equiv_orientations, unsigned int n_faces,
+                         quat<float>* equiv_orientations, unsigned int num_equiv_orientations,
                          const locality::NeighborList* nlist, freud::locality::QueryArgs qargs)
 {
     // precalc some values for faster computation within the loop
@@ -82,7 +82,7 @@ void PMFTXYZ::accumulate(const locality::NeighborQuery* neighbor_query, quat<flo
                           // make sure that the particles are wrapped into the box
                           vec3<float> delta(bondVector(neighbor_bond, neighbor_query, query_points));
 
-                          for (unsigned int k = 0; k < n_faces; k++)
+                          for (unsigned int k = 0; k < num_equiv_orientations; k++)
                           {
                               // create point vector
                               vec3<float> v(delta);

--- a/cpp/pmft/PMFTXYZ.cc
+++ b/cpp/pmft/PMFTXYZ.cc
@@ -78,7 +78,7 @@ void PMFTXYZ::accumulate(const locality::NeighborQuery* neighbor_query, quat<flo
     accumulateGeneral(neighbor_query, query_points, n_query_points, nlist, qargs,
                       [=](const freud::locality::NeighborBond& neighbor_bond) {
                           // create the reference point quaternion
-                          quat<float> ref_q(query_orientations[neighbor_bond.point_idx]);
+                          quat<float> ref_q(query_orientations[neighbor_bond.query_point_idx]);
                           // make sure that the particles are wrapped into the box
                           vec3<float> delta(bondVector(neighbor_bond, neighbor_query, query_points));
 

--- a/cpp/pmft/PMFTXYZ.cc
+++ b/cpp/pmft/PMFTXYZ.cc
@@ -84,14 +84,11 @@ void PMFTXYZ::accumulate(const locality::NeighborQuery* neighbor_query, quat<flo
 
                           for (unsigned int k = 0; k < n_faces; k++)
                           {
-                              // create the extra quaternion
-                              quat<float> qe(face_orientations[util::ManagedArray<unsigned int>::getIndex(
-                                  {neighbor_query->getNPoints(), n_faces}, {neighbor_bond.point_idx, k})]);
                               // create point vector
                               vec3<float> v(delta);
                               // rotate the vector
                               v = rotate(conj(ref_q), v);
-                              v = rotate(qe, v);
+                              v = rotate(face_orientations[k], v);
 
                               m_local_histograms(v.x, v.y, v.z);
                           }

--- a/cpp/pmft/PMFTXYZ.h
+++ b/cpp/pmft/PMFTXYZ.h
@@ -23,7 +23,7 @@ public:
         of the pcf
     */
     void accumulate(const locality::NeighborQuery* neighbor_query, quat<float>* query_orientations,
-                    vec3<float>* query_points, unsigned int n_query_points, quat<float>* face_orientations,
+                    vec3<float>* query_points, unsigned int n_query_points, quat<float>* equiv_orientations,
                     unsigned int n_faces, const locality::NeighborList* nlist,
                     freud::locality::QueryArgs qargs);
 

--- a/cpp/pmft/PMFTXYZ.h
+++ b/cpp/pmft/PMFTXYZ.h
@@ -24,7 +24,7 @@ public:
     */
     void accumulate(const locality::NeighborQuery* neighbor_query, quat<float>* query_orientations,
                     vec3<float>* query_points, unsigned int n_query_points, quat<float>* equiv_orientations,
-                    unsigned int n_faces, const locality::NeighborList* nlist,
+                    unsigned int num_equiv_orientations, const locality::NeighborList* nlist,
                     freud::locality::QueryArgs qargs);
 
     //! \internal

--- a/doc/source/reference/credits.rst
+++ b/doc/source/reference/credits.rst
@@ -49,6 +49,7 @@ Vyas Ramasubramani - **Lead developer**
 * Changed correlation function to properly take the complex conjugate of inputs.
 * Wrote developer documentation for version 2.0.
 * Fixed handling of 2D systems from various data sources.
+* Fixed usage of query orientations in PMFTXY and PMFTXYZ when points and query points are not identical.
 
 Bradley Dice - **Lead developer**
 

--- a/freud/pmft.pyx
+++ b/freud/pmft.pyx
@@ -550,7 +550,7 @@ cdef class PMFTXYZ(_PMFT):
             del self.pmftxyzptr
 
     def compute(self, system, query_orientations, query_points=None,
-                face_orientations=None, neighbors=None, reset=True):
+                equiv_orientations=None, neighbors=None, reset=True):
         R"""Calculates the PMFT.
 
         .. note::
@@ -570,7 +570,7 @@ cdef class PMFTXYZ(_PMFT):
             query_points ((:math:`N_{query\_points}`, 3) :class:`numpy.ndarray`, optional):
                 Query points used to calculate the PMFT. Uses the system's
                 points if :code:`None` (Default value = :code:`None`).
-            face_orientations ((:math:`N_{faces}`, 4) :class:`numpy.ndarray`, optional):
+            equiv_orientations ((:math:`N_{faces}`, 4) :class:`numpy.ndarray`, optional):
                 Orientations to be treated as equivalent to account for
                 symmetry of the points. For instance, if the
                 :code:`query_points` are rectangular prisms with the long axis
@@ -610,20 +610,20 @@ cdef class PMFTXYZ(_PMFT):
 
         cdef const float[:, ::1] l_query_orientations = query_orientations
 
-        if face_orientations is None:
-            face_orientations = np.array([[1, 0, 0, 0]], dtype=np.float32)
+        if equiv_orientations is None:
+            equiv_orientations = np.array([[1, 0, 0, 0]], dtype=np.float32)
         else:
-            face_orientations = freud.util._convert_array(
-                face_orientations, shape=(None, 4))
+            equiv_orientations = freud.util._convert_array(
+                equiv_orientations, shape=(None, 4))
 
-        cdef const float[:, ::1] l_face_orientations = face_orientations
-        cdef unsigned int num_faces = l_face_orientations.shape[0]
+        cdef const float[:, ::1] l_equiv_orientations = equiv_orientations
+        cdef unsigned int num_faces = l_equiv_orientations.shape[0]
         self.pmftxyzptr.accumulate(
             nq.get_ptr(),
             <quat[float]*> &l_query_orientations[0, 0],
             <vec3[float]*> &l_query_points[0, 0],
             num_query_points,
-            <quat[float]*> &l_face_orientations[0, 0],
+            <quat[float]*> &l_equiv_orientations[0, 0],
             num_faces, nlist.get_ptr(), dereference(qargs.thisptr))
         return self
 

--- a/freud/pmft.pyx
+++ b/freud/pmft.pyx
@@ -617,14 +617,16 @@ cdef class PMFTXYZ(_PMFT):
                 equiv_orientations, shape=(None, 4))
 
         cdef const float[:, ::1] l_equiv_orientations = equiv_orientations
-        cdef unsigned int num_faces = l_equiv_orientations.shape[0]
+        cdef unsigned int num_equiv_orientations = \
+            l_equiv_orientations.shape[0]
         self.pmftxyzptr.accumulate(
             nq.get_ptr(),
             <quat[float]*> &l_query_orientations[0, 0],
             <vec3[float]*> &l_query_points[0, 0],
             num_query_points,
             <quat[float]*> &l_equiv_orientations[0, 0],
-            num_faces, nlist.get_ptr(), dereference(qargs.thisptr))
+            num_equiv_orientations, nlist.get_ptr(),
+            dereference(qargs.thisptr))
         return self
 
     def __repr__(self):

--- a/freud/pmft.pyx
+++ b/freud/pmft.pyx
@@ -605,7 +605,7 @@ cdef class PMFTXYZ(_PMFT):
         l_query_points = l_query_points - self.shiftvec.reshape(1, 3)
 
         query_orientations = freud.util._convert_array(
-            np.atleast_1d(query_orientations), shape=(nq.points.shape[0], 4))
+            np.atleast_1d(query_orientations), shape=(num_query_points, 4))
 
         cdef const float[:, ::1] l_query_orientations = query_orientations
 

--- a/freud/pmft.pyx
+++ b/freud/pmft.pyx
@@ -438,7 +438,7 @@ cdef class PMFTXY(_PMFT):
                 system, query_points, neighbors)
 
         query_orientations = _gen_angle_array(
-            query_orientations, shape=(nq.points.shape[0], ))
+            query_orientations, shape=(num_query_points, ))
         cdef const float[::1] l_query_orientations = query_orientations
 
         self.pmftxyptr.accumulate(nq.get_ptr(),

--- a/freud/pmft.pyx
+++ b/freud/pmft.pyx
@@ -574,11 +574,11 @@ cdef class PMFTXYZ(_PMFT):
                 Orientations to be treated as equivalent to account for
                 symmetry of the points. For instance, if the
                 :code:`query_points` are rectangular prisms with the long axis
-                corresponding to the x-axis, then a point at :math:`(1, 0, 0) `
-                and a point at :math:`(-1, 0, 0) ` are symmetrically equivalent
+                corresponding to the x-axis, then a point at :math:`(1, 0, 0)`
+                and a point at :math:`(-1, 0, 0)` are symmetrically equivalent
                 and can be counted towards both the positive and negative bins.
-                If not supplied by user or :code:`None`, unit quaternions will
-                be supplied (Default value = :code:`None`).
+                If not supplied by user or :code:`None`, a unit quaternion will
+                be used (Default value = :code:`None`).
             neighbors (:class:`freud.locality.NeighborList` or dict, optional):
                 Either a :class:`NeighborList <freud.locality.NeighborList>` of
                 neighbor pairs to use in the calculation, or a dictionary of

--- a/freud/pmft.pyx
+++ b/freud/pmft.pyx
@@ -616,14 +616,14 @@ cdef class PMFTXYZ(_PMFT):
             face_orientations = freud.util._convert_array(
                 face_orientations, shape=(None, 4))
 
-        cdef const float[:, :, ::1] l_face_orientations = face_orientations
-        cdef unsigned int num_faces = l_face_orientations.shape[1]
+        cdef const float[:, ::1] l_face_orientations = face_orientations
+        cdef unsigned int num_faces = l_face_orientations.shape[0]
         self.pmftxyzptr.accumulate(
             nq.get_ptr(),
             <quat[float]*> &l_query_orientations[0, 0],
             <vec3[float]*> &l_query_points[0, 0],
             num_query_points,
-            <quat[float]*> &l_face_orientations[0, 0, 0],
+            <quat[float]*> &l_face_orientations[0, 0],
             num_faces, nlist.get_ptr(), dereference(qargs.thisptr))
         return self
 

--- a/freud/pmft.pyx
+++ b/freud/pmft.pyx
@@ -570,14 +570,15 @@ cdef class PMFTXYZ(_PMFT):
             query_points ((:math:`N_{query\_points}`, 3) :class:`numpy.ndarray`, optional):
                 Query points used to calculate the PMFT. Uses the system's
                 points if :code:`None` (Default value = :code:`None`).
-            face_orientations ((:math:`N_{points}`, :math:`N_{faces}`, 4) :class:`numpy.ndarray`, optional):
-                Orientations of particle faces to account for symmetry of the
-                points. If not supplied by user or :code:`None`, unit
-                quaternions will be supplied. If a 2D array of shape
-                (:math:`N_{faces}`, 4) or a 3D array of shape (1,
-                :math:`N_{faces}`, 4) is supplied, the supplied quaternions
-                will be broadcast for all points.
-                (Default value = :code:`None`).
+            face_orientations ((:math:`N_{faces}`, 4) :class:`numpy.ndarray`, optional):
+                Orientations to be treated as equivalent to account for
+                symmetry of the points. For instance, if the
+                :code:`query_points` are rectangular prisms with the long axis
+                corresponding to the x-axis, then a point at :math:`(1, 0, 0) `
+                and a point at :math:`(-1, 0, 0) ` are symmetrically equivalent
+                and can be counted towards both the positive and negative bins.
+                If not supplied by user or :code:`None`, unit quaternions will
+                be supplied (Default value = :code:`None`).
             neighbors (:class:`freud.locality.NeighborList` or dict, optional):
                 Either a :class:`NeighborList <freud.locality.NeighborList>` of
                 neighbor pairs to use in the calculation, or a dictionary of
@@ -609,46 +610,11 @@ cdef class PMFTXYZ(_PMFT):
 
         cdef const float[:, ::1] l_query_orientations = query_orientations
 
-        # handle multiple ways to input
         if face_orientations is None:
-            # set to unit quaternion, q = [1, 0, 0, 0]
-            face_orientations = np.zeros(
-                shape=(nq.points.shape[0], 1, 4), dtype=np.float32)
-            face_orientations[:, :, 0] = 1.0
+            face_orientations = np.array([[1, 0, 0, 0]], dtype=np.float32)
         else:
-            if face_orientations.ndim < 2 or face_orientations.ndim > 3:
-                raise ValueError("face_orientations must be a 2 or 3 "
-                                 "dimensional array.")
-            face_orientations = freud.util._convert_array(face_orientations)
-            if face_orientations.ndim == 2:
-                if face_orientations.shape[1] != 4:
-                    raise ValueError(
-                        "2nd dimension for face_orientations must have "
-                        "4 values: w, x, y, z.")
-                # need to broadcast into new array
-                tmp_face_orientations = np.zeros(
-                    shape=(nq.points.shape[0],
-                           face_orientations.shape[0],
-                           face_orientations.shape[1]),
-                    dtype=np.float32)
-                tmp_face_orientations[:] = face_orientations
-                face_orientations = tmp_face_orientations
-            else:
-                # Make sure that the first dimension is actually the number
-                # of particles
-                if face_orientations.shape[2] != 4:
-                    raise ValueError(
-                        "3rd dimension for face_orientations must have "
-                        "4 values: w, x, y, z.")
-                elif face_orientations.shape[0] not in (
-                        1, nq.points.shape[0]):
-                    raise ValueError(
-                        "If provided as a 3D array, the first dimension of "
-                        "the face_orientations array must be either of "
-                        "size 1 or the number of query_points.")
-                elif face_orientations.shape[0] == 1:
-                    face_orientations = np.repeat(
-                        face_orientations, nq.points.shape[0], axis=0)
+            face_orientations = freud.util._convert_array(
+                face_orientations, shape=(None, 4))
 
         cdef const float[:, :, ::1] l_face_orientations = face_orientations
         cdef unsigned int num_faces = l_face_orientations.shape[1]

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,7 +7,7 @@ message = Bump up to version {new_version}.
 [flake8]
 filename = *.py,*.pyx,*.pxi,*.pxd
 exclude = .eggs,*.egg,build,extern,doc/source/gettingstarted/examples
-ignore = E225,E226,E227,E999,W504
+ignore = E225,E226,E227,E999,W504,N
 per-file-ignores = 
 	freud/__init__.py: F401
 

--- a/tests/test_pmft.py
+++ b/tests/test_pmft.py
@@ -11,8 +11,8 @@ from test_managedarray import TestManagedArray
 
 class TestPMFTR12(unittest.TestCase):
     def test_box(self):
-        boxSize = 16.0
-        box = freud.box.Box.square(boxSize)
+        L = 16.0
+        box = freud.box.Box.square(L)
         points = np.array([[-1.0, 0.0, 0.0], [1.0, 0.0, 0.0]],
                           dtype=np.float32)
         angles = np.array([0.0, 0.0], dtype=np.float32)
@@ -22,10 +22,10 @@ class TestPMFTR12(unittest.TestCase):
         nbinsT2 = 30
         myPMFT = freud.pmft.PMFTR12(maxR, (nbinsR, nbinsT1, nbinsT2))
         myPMFT.compute((box, points), angles, points, angles, reset=False)
-        npt.assert_equal(myPMFT.box, freud.box.Box.square(boxSize))
+        npt.assert_equal(myPMFT.box, freud.box.Box.square(L))
 
         # Ensure expected errors are raised
-        box = freud.box.Box.cube(boxSize)
+        box = freud.box.Box.cube(L)
         with self.assertRaises(ValueError):
             myPMFT.compute((box, points), angles, reset=False)
 
@@ -68,8 +68,8 @@ class TestPMFTR12(unittest.TestCase):
         npt.assert_equal(nbinsT2, myPMFT.nbins[2])
 
     def test_attribute_access(self):
-        boxSize = 16.0
-        box = freud.box.Box.square(boxSize)
+        L = 16.0
+        box = freud.box.Box.square(L)
         points = np.array([[-1.0, 0.0, 0.0], [1.0, 0.1, 0.0]],
                           dtype=np.float32)
         points.flags['WRITEABLE'] = False
@@ -101,8 +101,8 @@ class TestPMFTR12(unittest.TestCase):
         myPMFT.box
 
     def test_two_particles(self):
-        boxSize = 16.0
-        box = freud.box.Box.square(boxSize)
+        L = 16.0
+        box = freud.box.Box.square(L)
         points = np.array([[-1.0, 0.0, 0.0], [1.0, 0.1, 0.0]],
                           dtype=np.float32)
         points.flags['WRITEABLE'] = False
@@ -184,8 +184,8 @@ class TestPMFTR12(unittest.TestCase):
 
 class TestPMFTXYT(unittest.TestCase):
     def test_box(self):
-        boxSize = 16.0
-        box = freud.box.Box.square(boxSize)
+        L = 16.0
+        box = freud.box.Box.square(L)
         points = np.array([[-1.0, 0.0, 0.0], [1.0, 0.0, 0.0]],
                           dtype=np.float32)
         angles = np.array([0.0, 0.0], dtype=np.float32)
@@ -196,10 +196,10 @@ class TestPMFTXYT(unittest.TestCase):
         nbinsT = 40
         myPMFT = freud.pmft.PMFTXYT(maxX, maxY, (nbinsX, nbinsY, nbinsT))
         myPMFT.compute((box, points), angles, points, angles, reset=False)
-        npt.assert_equal(myPMFT.box, freud.box.Box.square(boxSize))
+        npt.assert_equal(myPMFT.box, freud.box.Box.square(L))
 
         # Ensure expected errors are raised
-        box = freud.box.Box.cube(boxSize)
+        box = freud.box.Box.cube(L)
         with self.assertRaises(ValueError):
             myPMFT.compute((box, points), angles, points, angles, reset=False)
 
@@ -245,8 +245,8 @@ class TestPMFTXYT(unittest.TestCase):
         npt.assert_equal(nbinsT, myPMFT.nbins[2])
 
     def test_attribute_access(self):
-        boxSize = 16.0
-        box = freud.box.Box.square(boxSize)
+        L = 16.0
+        box = freud.box.Box.square(L)
         points = np.array([[-1.0, 0.0, 0.0], [1.0, 0.1, 0.0]],
                           dtype=np.float32)
         angles = np.array([0.0, np.pi/2], dtype=np.float32)
@@ -277,8 +277,8 @@ class TestPMFTXYT(unittest.TestCase):
         myPMFT.box
 
     def test_two_particles(self):
-        boxSize = 16.0
-        box = freud.box.Box.square(boxSize)
+        L = 16.0
+        box = freud.box.Box.square(L)
         points = np.array([[-1.0, 0.0, 0.0], [1.0, 0.1, 0.0]],
                           dtype=np.float32)
         angles = np.array([0.0, np.pi/2], dtype=np.float32)
@@ -370,8 +370,8 @@ class TestPMFTXYT(unittest.TestCase):
 
 class TestPMFTXY(unittest.TestCase):
     def test_box(self):
-        boxSize = 16.0
-        box = freud.box.Box.square(boxSize)
+        L = 16.0
+        box = freud.box.Box.square(L)
         points = np.array([[-1.0, 0.0, 0.0], [1.0, 0.0, 0.0]],
                           dtype=np.float32)
         angles = np.array([0.0, 0.0], dtype=np.float32)
@@ -381,10 +381,10 @@ class TestPMFTXY(unittest.TestCase):
         nbinsY = 110
         myPMFT = freud.pmft.PMFTXY(maxX, maxY, (nbinsX, nbinsY))
         myPMFT.compute((box, points), angles, points, reset=False)
-        npt.assert_equal(myPMFT.box, freud.box.Box.square(boxSize))
+        npt.assert_equal(myPMFT.box, freud.box.Box.square(L))
 
         # Ensure expected errors are raised
-        box = freud.box.Box.cube(boxSize)
+        box = freud.box.Box.cube(L)
         with self.assertRaises(ValueError):
             myPMFT.compute((box, points), angles, points, reset=False)
 
@@ -420,8 +420,8 @@ class TestPMFTXY(unittest.TestCase):
         npt.assert_equal(nbinsY, myPMFT.nbins[1])
 
     def test_attribute_access(self):
-        boxSize = 16.0
-        box = freud.box.Box.square(boxSize)
+        L = 16.0
+        box = freud.box.Box.square(L)
         points = np.array([[-1.0, 0.0, 0.0], [1.0, 0.0, 0.0]],
                           dtype=np.float32)
         angles = np.array([0.0, 0.0], dtype=np.float32)
@@ -452,8 +452,8 @@ class TestPMFTXY(unittest.TestCase):
         myPMFT.box
 
     def test_two_particles(self):
-        boxSize = 16.0
-        box = freud.box.Box.square(boxSize)
+        L = 16.0
+        box = freud.box.Box.square(L)
         points = np.array([[-1.0, 0.0, 0.0], [1.0, 0.0, 0.0]],
                           dtype=np.float32)
         angles = np.array([0.0, 0.0], dtype=np.float32)
@@ -501,8 +501,8 @@ class TestPMFTXY(unittest.TestCase):
         self.assertEqual(str(myPMFT), str(eval(repr(myPMFT))))
 
     def test_repr_png(self):
-        boxSize = 16.0
-        box = freud.box.Box.square(boxSize)
+        L = 16.0
+        box = freud.box.Box.square(L)
         points = np.array([[-1.0, 0.0, 0.0], [1.0, 0.0, 0.0]],
                           dtype=np.float32)
         angles = np.array([0.0, 0.0], dtype=np.float32)
@@ -546,8 +546,8 @@ class TestPMFTXY(unittest.TestCase):
 
     def test_query_args_nn(self):
         """Test that using nn based query args works."""
-        boxSize = 8
-        box = freud.box.Box.square(boxSize)
+        L = 8
+        box = freud.box.Box.square(L)
         points = np.array([[0, 0, 0]],
                           dtype=np.float32)
         query_points = np.array([[1.1, 0.0, 0.0],
@@ -594,8 +594,8 @@ class TestPMFTXY(unittest.TestCase):
 
     def test_quaternions(self):
         """Test that using quaternions as angles works."""
-        boxSize = 8
-        box = freud.box.Box.square(boxSize)
+        L = 8
+        box = freud.box.Box.square(L)
         points = np.array([[0, 0, 0]],
                           dtype=np.float32)
         query_points = np.array([[1.1, 0.0, 0.0],
@@ -632,8 +632,8 @@ class TestPMFTXY(unittest.TestCase):
     def test_orientation_with_query_points(self):
         """The orientations should be associated with the query points if they
         are provided."""
-        boxSize = 8
-        box = freud.box.Box.square(boxSize)
+        L = 8
+        box = freud.box.Box.square(L)
         # Don't place the points at exactly distances of 0/1 apart to avoid any
         # ambiguity when the distances fall on the bin boundaries.
         points = np.array([[0.1, 0.1, 0]],
@@ -696,8 +696,8 @@ class TestPMFTXY(unittest.TestCase):
         """The orientations should be associated with the query points if they
         are provided. Ensure that this works when the number of points and
         query points differ."""
-        boxSize = 8
-        box = freud.box.Box.square(boxSize)
+        L = 8
+        box = freud.box.Box.square(L)
         # Don't place the points at exactly distances of 0/1 apart to avoid any
         # ambiguity when the distances fall on the bin boundaries.
         points = np.array([[0.1, 0.1, 0], [0.89, 0.89, 0]],
@@ -756,8 +756,8 @@ class TestPMFTXY(unittest.TestCase):
 
 class TestPMFTXYZ(unittest.TestCase):
     def test_box(self):
-        boxSize = 25.0
-        box = freud.box.Box.cube(boxSize)
+        L = 25.0
+        box = freud.box.Box.cube(L)
         points = np.array([[-1.0, 0.0, 0.0], [1.0, 0.0, 0.0]],
                           dtype=np.float32)
         orientations = np.array([[1, 0, 0, 0], [1, 0, 0, 0]], dtype=np.float32)
@@ -772,10 +772,10 @@ class TestPMFTXYZ(unittest.TestCase):
         myPMFT.compute(system=(box, points), query_orientations=orientations,
                        query_points=points,
                        equiv_orientations=equiv_orientations, reset=False)
-        npt.assert_equal(myPMFT.box, freud.box.Box.cube(boxSize))
+        npt.assert_equal(myPMFT.box, freud.box.Box.cube(L))
 
         # Ensure expected errors are raised
-        box = freud.box.Box.square(boxSize)
+        box = freud.box.Box.square(L)
         with self.assertRaises(ValueError):
             myPMFT.compute((box, points), orientations, points,
                            orientations, reset=False)
@@ -822,8 +822,8 @@ class TestPMFTXYZ(unittest.TestCase):
         npt.assert_equal(nbinsZ, myPMFT.nbins[2])
 
     def test_attribute_access(self):
-        boxSize = 25.0
-        box = freud.box.Box.cube(boxSize)
+        L = 25.0
+        box = freud.box.Box.cube(L)
         points = np.array([[-1.0, 0.0, 0.0], [1.0, 0.0, 0.0]],
                           dtype=np.float32)
         orientations = np.array([[1, 0, 0, 0], [1, 0, 0, 0]], dtype=np.float32)
@@ -856,8 +856,8 @@ class TestPMFTXYZ(unittest.TestCase):
         myPMFT.box
 
     def test_two_particles(self):
-        boxSize = 25.0
-        box = freud.box.Box.cube(boxSize)
+        L = 25.0
+        box = freud.box.Box.cube(L)
         points = np.array([[-1.0, 0.0, 0.0], [1.0, 0.0, 0.0]],
                           dtype=np.float32)
         query_orientations = np.array([[1, 0, 0, 0], [1, 0, 0, 0]],
@@ -946,8 +946,8 @@ class TestPMFTXYZ(unittest.TestCase):
 
     def test_query_args_nn(self):
         """Test that using nn based query args works."""
-        boxSize = 8
-        box = freud.box.Box.cube(boxSize)
+        L = 8
+        box = freud.box.Box.cube(L)
         points = np.array([[0, 0, 0]],
                           dtype=np.float32)
         query_points = np.array([[1.1, 0.0, 0.0],
@@ -991,8 +991,8 @@ class TestPMFTXYZ(unittest.TestCase):
     def test_orientation_with_query_points(self):
         """The orientations should be associated with the query points if they
         are provided."""
-        boxSize = 8
-        box = freud.box.Box.cube(boxSize)
+        L = 8
+        box = freud.box.Box.cube(L)
         # Don't place the points at exactly distances of 0/1 apart to avoid any
         # ambiguity when the distances fall on the bin boundaries.
         points = np.array([[0.1, 0.1, 0]],
@@ -1056,8 +1056,8 @@ class TestPMFTXYZ(unittest.TestCase):
         """The orientations should be associated with the query points if they
         are provided. Ensure that this works when the number of points and
         query points differ."""
-        boxSize = 8
-        box = freud.box.Box.cube(boxSize)
+        L = 8
+        box = freud.box.Box.cube(L)
         # Don't place the points at exactly distances of 0/1 apart to avoid any
         # ambiguity when the distances fall on the bin boundaries.
         points = np.array([[0.1, 0.1, 0], [0.89, 0.89, 0]],

--- a/tests/test_pmft.py
+++ b/tests/test_pmft.py
@@ -530,7 +530,7 @@ class TestPMFTXY(unittest.TestCase):
         points, query_points = util.make_alternating_lattice(
             lattice_size, 0.01, 2)
 
-        orientations = np.array([0]*len(points))
+        query_orientations = np.array([0]*len(query_points))
 
         r_max = np.sqrt(x_max**2 + y_max**2)
         test_set = util.make_raw_query_nlist_test_set(
@@ -539,7 +539,7 @@ class TestPMFTXY(unittest.TestCase):
         for nq, neighbors in test_set:
             pmft = freud.pmft.PMFTXY(x_max, y_max, nbins)
             pmft.compute(
-                nq, orientations, query_points, neighbors)
+                nq, query_orientations, query_points, neighbors)
 
             self.assertEqual(np.count_nonzero(np.isinf(pmft.pmft) == 0), 12)
             self.assertEqual(len(np.unique(pmft.pmft)), 2)
@@ -561,7 +561,7 @@ class TestPMFTXY(unittest.TestCase):
         max_width = 3
         nbins = 3
         pmft = freud.pmft.PMFTXY(max_width, max_width, nbins)
-        pmft.compute((box, points), angles, query_points,
+        pmft.compute((box, points), query_angles, query_points,
                      neighbors={'mode': 'nearest', 'num_neighbors': 1})
         # Now every point in query_points will find the origin as a neighbor.
         npt.assert_array_equal(
@@ -570,7 +570,7 @@ class TestPMFTXY(unittest.TestCase):
              [1, 0, 1],
              [0, 1, 0]])
         # Now there will be only one neighbor for the single point.
-        pmft.compute((box, query_points), query_angles, points,
+        pmft.compute((box, query_points), angles, points,
                      neighbors={'mode': 'nearest', 'num_neighbors': 1})
         npt.assert_array_equal(
             pmft.bin_counts,
@@ -612,7 +612,7 @@ class TestPMFTXY(unittest.TestCase):
         max_width = 3
         nbins = 3
         pmft = freud.pmft.PMFTXY(max_width, max_width, nbins)
-        pmft.compute((box, points), orientations, query_points,
+        pmft.compute((box, points), query_orientations, query_points,
                      neighbors={'mode': 'nearest', 'num_neighbors': 1})
         # Now every point in query_points will find the origin as a neighbor.
         npt.assert_array_equal(
@@ -621,7 +621,7 @@ class TestPMFTXY(unittest.TestCase):
              [1, 0, 1],
              [0, 1, 0]])
         # Now there will be only one neighbor for the single point.
-        pmft.compute((box, query_points), query_orientations, points,
+        pmft.compute((box, query_points), orientations, points,
                      neighbors={'mode': 'nearest', 'num_neighbors': 1})
         npt.assert_array_equal(
             pmft.bin_counts,

--- a/tests/test_pmft.py
+++ b/tests/test_pmft.py
@@ -16,11 +16,11 @@ class TestPMFTR12(unittest.TestCase):
         points = np.array([[-1.0, 0.0, 0.0], [1.0, 0.0, 0.0]],
                           dtype=np.float32)
         angles = np.array([0.0, 0.0], dtype=np.float32)
-        maxR = 5.23
-        nbinsR = 10
-        nbinsT1 = 20
-        nbinsT2 = 30
-        myPMFT = freud.pmft.PMFTR12(maxR, (nbinsR, nbinsT1, nbinsT2))
+        max_r = 5.23
+        nbins_r = 10
+        nbins_t1 = 20
+        nbins_t2 = 30
+        myPMFT = freud.pmft.PMFTR12(max_r, (nbins_r, nbins_t1, nbins_t2))
         myPMFT.compute((box, points), angles, points, angles, reset=False)
         npt.assert_equal(myPMFT.box, freud.box.Box.square(L))
 
@@ -30,42 +30,42 @@ class TestPMFTR12(unittest.TestCase):
             myPMFT.compute((box, points), angles, reset=False)
 
     def test_bins(self):
-        maxR = 5.23
-        nbinsR = 10
-        nbinsT1 = 20
-        nbinsT2 = 30
-        dr = (maxR / float(nbinsR))
-        dT1 = (2.0 * np.pi / float(nbinsT1))
-        dT2 = (2.0 * np.pi / float(nbinsT2))
+        max_r = 5.23
+        nbins_r = 10
+        nbins_t1 = 20
+        nbins_t2 = 30
+        dr = (max_r / float(nbins_r))
+        dT1 = (2.0 * np.pi / float(nbins_t1))
+        dT2 = (2.0 * np.pi / float(nbins_t2))
 
         # make sure the radius for each bin is generated correctly
-        listR = np.zeros(nbinsR, dtype=np.float32)
-        listT1 = np.zeros(nbinsT1, dtype=np.float32)
-        listT2 = np.zeros(nbinsT2, dtype=np.float32)
+        listR = np.zeros(nbins_r, dtype=np.float32)
+        listT1 = np.zeros(nbins_t1, dtype=np.float32)
+        listT2 = np.zeros(nbins_t2, dtype=np.float32)
 
-        listR = np.array([dr*(i+1/2) for i in range(nbinsR) if
-                          dr*(i+1/2) < maxR])
+        listR = np.array([dr*(i+1/2) for i in range(nbins_r) if
+                          dr*(i+1/2) < max_r])
 
-        for i in range(nbinsT1):
+        for i in range(nbins_t1):
             t = float(i) * dT1
             nextt = float(i + 1) * dT1
             listT1[i] = ((t + nextt) / 2.0)
 
-        for i in range(nbinsT2):
+        for i in range(nbins_t2):
             t = float(i) * dT2
             nextt = float(i + 1) * dT2
             listT2[i] = ((t + nextt) / 2.0)
 
-        myPMFT = freud.pmft.PMFTR12(maxR, (nbinsR, nbinsT1, nbinsT2))
+        myPMFT = freud.pmft.PMFTR12(max_r, (nbins_r, nbins_t1, nbins_t2))
 
         # Compare expected bins to the info from pmft
         npt.assert_allclose(myPMFT.bin_centers[0], listR, atol=1e-3)
         npt.assert_allclose(myPMFT.bin_centers[1], listT1, atol=1e-3)
         npt.assert_allclose(myPMFT.bin_centers[2], listT2, atol=1e-3)
 
-        npt.assert_equal(nbinsR, myPMFT.nbins[0])
-        npt.assert_equal(nbinsT1, myPMFT.nbins[1])
-        npt.assert_equal(nbinsT2, myPMFT.nbins[2])
+        npt.assert_equal(nbins_r, myPMFT.nbins[0])
+        npt.assert_equal(nbins_t1, myPMFT.nbins[1])
+        npt.assert_equal(nbins_t2, myPMFT.nbins[2])
 
     def test_attribute_access(self):
         L = 16.0
@@ -75,10 +75,10 @@ class TestPMFTR12(unittest.TestCase):
         points.flags['WRITEABLE'] = False
         angles = np.array([0.0, np.pi/2], dtype=np.float32)
         angles.flags['WRITEABLE'] = False
-        maxR = 5.23
+        max_r = 5.23
         nbins = 10
 
-        myPMFT = freud.pmft.PMFTR12(maxR, nbins)
+        myPMFT = freud.pmft.PMFTR12(max_r, nbins)
 
         with self.assertRaises(AttributeError):
             myPMFT.bin_counts
@@ -108,13 +108,13 @@ class TestPMFTR12(unittest.TestCase):
         points.flags['WRITEABLE'] = False
         angles = np.array([0.0, np.pi/2], dtype=np.float32)
         angles.flags['WRITEABLE'] = False
-        maxR = 5.23
-        nbinsR = 10
-        nbinsT1 = 20
-        nbinsT2 = 30
-        dr = (maxR / float(nbinsR))
-        dT1 = (2.0 * np.pi / float(nbinsT1))
-        dT2 = (2.0 * np.pi / float(nbinsT2))
+        max_r = 5.23
+        nbins_r = 10
+        nbins_t1 = 20
+        nbins_t2 = 30
+        dr = (max_r / float(nbins_r))
+        dT1 = (2.0 * np.pi / float(nbins_t1))
+        dT2 = (2.0 * np.pi / float(nbins_t2))
 
         # calculation for array idxs
         def get_bin(query_point, point, query_point_angle, point_angle):
@@ -128,7 +128,7 @@ class TestPMFTR12(unittest.TestCase):
                 ((query_point_angle - delta_t2) % (2. * np.pi)) / dT2)
             return np.array([r_bin, t1_bin, t2_bin], dtype=np.int32)
 
-        correct_bin_counts = np.zeros(shape=(nbinsR, nbinsT1, nbinsT2),
+        correct_bin_counts = np.zeros(shape=(nbins_r, nbins_t1, nbins_t2),
                                       dtype=np.int32)
         bins = get_bin(points[0], points[1], angles[0], angles[1])
         correct_bin_counts[bins[0], bins[1], bins[2]] = 1
@@ -136,11 +136,11 @@ class TestPMFTR12(unittest.TestCase):
         correct_bin_counts[bins[0], bins[1], bins[2]] = 1
         absoluteTolerance = 0.1
 
-        r_max = maxR
+        r_max = max_r
         test_set = util.make_raw_query_nlist_test_set(
             box, points, points, 'ball', r_max, 0, True)
         for nq, neighbors in test_set:
-            myPMFT = freud.pmft.PMFTR12(maxR, (nbinsR, nbinsT1, nbinsT2))
+            myPMFT = freud.pmft.PMFTR12(max_r, (nbins_r, nbins_t1, nbins_t2))
             myPMFT.compute(nq, angles, neighbors=neighbors, reset=False)
             npt.assert_allclose(myPMFT.bin_counts, correct_bin_counts,
                                 atol=absoluteTolerance)
@@ -153,9 +153,9 @@ class TestPMFTR12(unittest.TestCase):
                                 atol=absoluteTolerance)
 
     def test_repr(self):
-        maxR = 5.23
+        max_r = 5.23
         nbins = 10
-        myPMFT = freud.pmft.PMFTR12(maxR, nbins)
+        myPMFT = freud.pmft.PMFTR12(max_r, nbins)
         self.assertEqual(str(myPMFT), str(eval(repr(myPMFT))))
 
     def test_points_ne_query_points(self):
@@ -189,12 +189,12 @@ class TestPMFTXYT(unittest.TestCase):
         points = np.array([[-1.0, 0.0, 0.0], [1.0, 0.0, 0.0]],
                           dtype=np.float32)
         angles = np.array([0.0, 0.0], dtype=np.float32)
-        maxX = 3.6
-        maxY = 4.2
-        nbinsX = 20
-        nbinsY = 30
-        nbinsT = 40
-        myPMFT = freud.pmft.PMFTXYT(maxX, maxY, (nbinsX, nbinsY, nbinsT))
+        max_x = 3.6
+        max_y = 4.2
+        nbins_x = 20
+        nbins_y = 30
+        nbins_t = 40
+        myPMFT = freud.pmft.PMFTXYT(max_x, max_y, (nbins_x, nbins_y, nbins_t))
         myPMFT.compute((box, points), angles, points, angles, reset=False)
         npt.assert_equal(myPMFT.box, freud.box.Box.square(L))
 
@@ -204,45 +204,45 @@ class TestPMFTXYT(unittest.TestCase):
             myPMFT.compute((box, points), angles, points, angles, reset=False)
 
     def test_bins(self):
-        maxX = 3.6
-        maxY = 4.2
-        nbinsX = 20
-        nbinsY = 30
-        nbinsT = 40
-        dx = (2.0 * maxX / float(nbinsX))
-        dy = (2.0 * maxY / float(nbinsY))
-        dT = (2.0 * np.pi / float(nbinsT))
+        max_x = 3.6
+        max_y = 4.2
+        nbins_x = 20
+        nbins_y = 30
+        nbins_t = 40
+        dx = (2.0 * max_x / float(nbins_x))
+        dy = (2.0 * max_y / float(nbins_y))
+        dT = (2.0 * np.pi / float(nbins_t))
 
         # make sure the center for each bin is generated correctly
-        listX = np.zeros(nbinsX, dtype=np.float32)
-        listY = np.zeros(nbinsY, dtype=np.float32)
-        listT = np.zeros(nbinsT, dtype=np.float32)
+        listX = np.zeros(nbins_x, dtype=np.float32)
+        listY = np.zeros(nbins_y, dtype=np.float32)
+        listT = np.zeros(nbins_t, dtype=np.float32)
 
-        for i in range(nbinsX):
+        for i in range(nbins_x):
             x = float(i) * dx
             nextX = float(i + 1) * dx
-            listX[i] = -maxX + ((x + nextX) / 2.0)
+            listX[i] = -max_x + ((x + nextX) / 2.0)
 
-        for i in range(nbinsY):
+        for i in range(nbins_y):
             y = float(i) * dy
             nextY = float(i + 1) * dy
-            listY[i] = -maxY + ((y + nextY) / 2.0)
+            listY[i] = -max_y + ((y + nextY) / 2.0)
 
-        for i in range(nbinsT):
+        for i in range(nbins_t):
             t = float(i) * dT
             nextt = float(i + 1) * dT
             listT[i] = ((t + nextt) / 2.0)
 
-        myPMFT = freud.pmft.PMFTXYT(maxX, maxY, (nbinsX, nbinsY, nbinsT))
+        myPMFT = freud.pmft.PMFTXYT(max_x, max_y, (nbins_x, nbins_y, nbins_t))
 
         # Compare expected bins to the info from pmft
         npt.assert_allclose(myPMFT.bin_centers[0], listX, atol=1e-3)
         npt.assert_allclose(myPMFT.bin_centers[1], listY, atol=1e-3)
         npt.assert_allclose(myPMFT.bin_centers[2], listT, atol=1e-3)
 
-        npt.assert_equal(nbinsX, myPMFT.nbins[0])
-        npt.assert_equal(nbinsY, myPMFT.nbins[1])
-        npt.assert_equal(nbinsT, myPMFT.nbins[2])
+        npt.assert_equal(nbins_x, myPMFT.nbins[0])
+        npt.assert_equal(nbins_y, myPMFT.nbins[1])
+        npt.assert_equal(nbins_t, myPMFT.nbins[2])
 
     def test_attribute_access(self):
         L = 16.0
@@ -250,11 +250,11 @@ class TestPMFTXYT(unittest.TestCase):
         points = np.array([[-1.0, 0.0, 0.0], [1.0, 0.1, 0.0]],
                           dtype=np.float32)
         angles = np.array([0.0, np.pi/2], dtype=np.float32)
-        maxX = 3.6
-        maxY = 4.2
+        max_x = 3.6
+        max_y = 4.2
         nbins = 20
 
-        myPMFT = freud.pmft.PMFTXYT(maxX, maxY, nbins)
+        myPMFT = freud.pmft.PMFTXYT(max_x, max_y, nbins)
 
         with self.assertRaises(AttributeError):
             myPMFT.bin_counts
@@ -282,28 +282,28 @@ class TestPMFTXYT(unittest.TestCase):
         points = np.array([[-1.0, 0.0, 0.0], [1.0, 0.1, 0.0]],
                           dtype=np.float32)
         angles = np.array([0.0, np.pi/2], dtype=np.float32)
-        maxX = 3.6
-        maxY = 4.2
-        nbinsX = 20
-        nbinsY = 30
-        nbinsT = 40
-        dx = (2.0 * maxX / float(nbinsX))
-        dy = (2.0 * maxY / float(nbinsY))
-        dT = (2.0 * np.pi / float(nbinsT))
+        max_x = 3.6
+        max_y = 4.2
+        nbins_x = 20
+        nbins_y = 30
+        nbins_t = 40
+        dx = (2.0 * max_x / float(nbins_x))
+        dy = (2.0 * max_y / float(nbins_y))
+        dT = (2.0 * np.pi / float(nbins_t))
 
         # calculation for array idxs
         def get_bin(query_point, point, query_point_angle, point_angle):
             r_ij = point - query_point
             orientation = rowan.from_axis_angle([0, 0, 1], -point_angle)
             rot_r_ij = rowan.rotate(orientation, r_ij)
-            xy_bins = np.floor((rot_r_ij[:2] + [maxX, maxY]) /
+            xy_bins = np.floor((rot_r_ij[:2] + [max_x, max_y]) /
                                [dx, dy]).astype(np.int32)
             angle_bin = np.floor(
                 ((query_point_angle - np.arctan2(-r_ij[1], -r_ij[0])) %
                  (2. * np.pi)) / dT).astype(np.int32)
             return [xy_bins[0], xy_bins[1], angle_bin]
 
-        correct_bin_counts = np.zeros(shape=(nbinsX, nbinsY, nbinsT),
+        correct_bin_counts = np.zeros(shape=(nbins_x, nbins_y, nbins_t),
                                       dtype=np.int32)
         bins = get_bin(points[0], points[1], angles[0], angles[1])
         correct_bin_counts[bins[0], bins[1], bins[2]] = 1
@@ -311,11 +311,12 @@ class TestPMFTXYT(unittest.TestCase):
         correct_bin_counts[bins[0], bins[1], bins[2]] = 1
         absoluteTolerance = 0.1
 
-        r_max = np.sqrt(maxX**2 + maxY**2)
+        r_max = np.sqrt(max_x**2 + max_y**2)
         test_set = util.make_raw_query_nlist_test_set(
             box, points, points, 'ball', r_max, 0, True)
         for nq, neighbors in test_set:
-            myPMFT = freud.pmft.PMFTXYT(maxX, maxY, (nbinsX, nbinsY, nbinsT))
+            myPMFT = freud.pmft.PMFTXYT(max_x, max_y,
+                                        (nbins_x, nbins_y, nbins_t))
             myPMFT.compute(nq, angles, neighbors=neighbors, reset=False)
             npt.assert_allclose(myPMFT.bin_counts, correct_bin_counts,
                                 atol=absoluteTolerance)
@@ -328,10 +329,10 @@ class TestPMFTXYT(unittest.TestCase):
                                 atol=absoluteTolerance)
 
     def test_repr(self):
-        maxX = 3.0
-        maxY = 4.0
+        max_x = 3.0
+        max_y = 4.0
         nbins = 20
-        myPMFT = freud.pmft.PMFTXYT(maxX, maxY, nbins)
+        myPMFT = freud.pmft.PMFTXYT(max_x, max_y, nbins)
         self.assertEqual(str(myPMFT), str(eval(repr(myPMFT))))
 
     def test_points_ne_query_points(self):
@@ -375,11 +376,11 @@ class TestPMFTXY(unittest.TestCase):
         points = np.array([[-1.0, 0.0, 0.0], [1.0, 0.0, 0.0]],
                           dtype=np.float32)
         angles = np.array([0.0, 0.0], dtype=np.float32)
-        maxX = 3.6
-        maxY = 4.2
-        nbinsX = 100
-        nbinsY = 110
-        myPMFT = freud.pmft.PMFTXY(maxX, maxY, (nbinsX, nbinsY))
+        max_x = 3.6
+        max_y = 4.2
+        nbins_x = 100
+        nbins_y = 110
+        myPMFT = freud.pmft.PMFTXY(max_x, max_y, (nbins_x, nbins_y))
         myPMFT.compute((box, points), angles, points, reset=False)
         npt.assert_equal(myPMFT.box, freud.box.Box.square(L))
 
@@ -389,35 +390,35 @@ class TestPMFTXY(unittest.TestCase):
             myPMFT.compute((box, points), angles, points, reset=False)
 
     def test_bins(self):
-        maxX = 3.6
-        maxY = 4.2
-        nbinsX = 20
-        nbinsY = 30
-        dx = (2.0 * maxX / float(nbinsX))
-        dy = (2.0 * maxY / float(nbinsY))
+        max_x = 3.6
+        max_y = 4.2
+        nbins_x = 20
+        nbins_y = 30
+        dx = (2.0 * max_x / float(nbins_x))
+        dy = (2.0 * max_y / float(nbins_y))
 
         # make sure the center for each bin is generated correctly
-        listX = np.zeros(nbinsX, dtype=np.float32)
-        listY = np.zeros(nbinsY, dtype=np.float32)
+        listX = np.zeros(nbins_x, dtype=np.float32)
+        listY = np.zeros(nbins_y, dtype=np.float32)
 
-        for i in range(nbinsX):
+        for i in range(nbins_x):
             x = float(i) * dx
             nextX = float(i + 1) * dx
-            listX[i] = -maxX + ((x + nextX) / 2.0)
+            listX[i] = -max_x + ((x + nextX) / 2.0)
 
-        for i in range(nbinsY):
+        for i in range(nbins_y):
             y = float(i) * dy
             nextY = float(i + 1) * dy
-            listY[i] = -maxY + ((y + nextY) / 2.0)
+            listY[i] = -max_y + ((y + nextY) / 2.0)
 
-        myPMFT = freud.pmft.PMFTXY(maxX, maxY, (nbinsX, nbinsY))
+        myPMFT = freud.pmft.PMFTXY(max_x, max_y, (nbins_x, nbins_y))
 
         # Compare expected bins to the info from pmft
         npt.assert_allclose(myPMFT.bin_centers[0], listX, atol=1e-3)
         npt.assert_allclose(myPMFT.bin_centers[1], listY, atol=1e-3)
 
-        npt.assert_equal(nbinsX, myPMFT.nbins[0])
-        npt.assert_equal(nbinsY, myPMFT.nbins[1])
+        npt.assert_equal(nbins_x, myPMFT.nbins[0])
+        npt.assert_equal(nbins_y, myPMFT.nbins[1])
 
     def test_attribute_access(self):
         L = 16.0
@@ -425,11 +426,11 @@ class TestPMFTXY(unittest.TestCase):
         points = np.array([[-1.0, 0.0, 0.0], [1.0, 0.0, 0.0]],
                           dtype=np.float32)
         angles = np.array([0.0, 0.0], dtype=np.float32)
-        maxX = 3.6
-        maxY = 4.2
+        max_x = 3.6
+        max_y = 4.2
         nbins = 100
 
-        myPMFT = freud.pmft.PMFTXY(maxX, maxY, nbins)
+        myPMFT = freud.pmft.PMFTXY(max_x, max_y, nbins)
 
         with self.assertRaises(AttributeError):
             myPMFT.bin_counts
@@ -457,18 +458,18 @@ class TestPMFTXY(unittest.TestCase):
         points = np.array([[-1.0, 0.0, 0.0], [1.0, 0.0, 0.0]],
                           dtype=np.float32)
         angles = np.array([0.0, 0.0], dtype=np.float32)
-        maxX = 3.6
-        maxY = 4.2
-        nbinsX = 100
-        nbinsY = 110
-        dx = (2.0 * maxX / float(nbinsX))
-        dy = (2.0 * maxY / float(nbinsY))
+        max_x = 3.6
+        max_y = 4.2
+        nbins_x = 100
+        nbins_y = 110
+        dx = (2.0 * max_x / float(nbins_x))
+        dy = (2.0 * max_y / float(nbins_y))
 
-        correct_bin_counts = np.zeros(shape=(nbinsX, nbinsY), dtype=np.int32)
+        correct_bin_counts = np.zeros(shape=(nbins_x, nbins_y), dtype=np.int32)
 
         # calculation for array idxs
         def get_bin(query_point, point):
-            return np.floor((query_point - point + [maxX, maxY, 0]) /
+            return np.floor((query_point - point + [max_x, max_y, 0]) /
                             [dx, dy, 1]).astype(np.int32)[:2]
 
         bins = get_bin(points[0], points[1])
@@ -477,11 +478,11 @@ class TestPMFTXY(unittest.TestCase):
         correct_bin_counts[bins[0], bins[1]] = 1
         absoluteTolerance = 0.1
 
-        r_max = np.sqrt(maxX**2 + maxY**2)
+        r_max = np.sqrt(max_x**2 + max_y**2)
         test_set = util.make_raw_query_nlist_test_set(
             box, points, points, 'ball', r_max, 0, True)
         for nq, neighbors in test_set:
-            myPMFT = freud.pmft.PMFTXY(maxX, maxY, (nbinsX, nbinsY))
+            myPMFT = freud.pmft.PMFTXY(max_x, max_y, (nbins_x, nbins_y))
             myPMFT.compute(nq, angles, neighbors=neighbors, reset=False)
             npt.assert_allclose(myPMFT.bin_counts, correct_bin_counts,
                                 atol=absoluteTolerance)
@@ -494,10 +495,10 @@ class TestPMFTXY(unittest.TestCase):
                                 atol=absoluteTolerance)
 
     def test_repr(self):
-        maxX = 3.0
-        maxY = 4.0
+        max_x = 3.0
+        max_y = 4.0
         nbins = 100
-        myPMFT = freud.pmft.PMFTXY(maxX, maxY, nbins)
+        myPMFT = freud.pmft.PMFTXY(max_x, max_y, nbins)
         self.assertEqual(str(myPMFT), str(eval(repr(myPMFT))))
 
     def test_repr_png(self):
@@ -506,11 +507,11 @@ class TestPMFTXY(unittest.TestCase):
         points = np.array([[-1.0, 0.0, 0.0], [1.0, 0.0, 0.0]],
                           dtype=np.float32)
         angles = np.array([0.0, 0.0], dtype=np.float32)
-        maxX = 3.6
-        maxY = 4.2
-        nbinsX = 100
-        nbinsY = 110
-        myPMFT = freud.pmft.PMFTXY(maxX, maxY, (nbinsX, nbinsY))
+        max_x = 3.6
+        max_y = 4.2
+        nbins_x = 100
+        nbins_y = 110
+        myPMFT = freud.pmft.PMFTXY(max_x, max_y, (nbins_x, nbins_y))
 
         with self.assertRaises(AttributeError):
             myPMFT.plot()
@@ -762,13 +763,14 @@ class TestPMFTXYZ(unittest.TestCase):
                           dtype=np.float32)
         orientations = np.array([[1, 0, 0, 0], [1, 0, 0, 0]], dtype=np.float32)
         equiv_orientations = np.array([[1, 0, 0, 0]], dtype=np.float32)
-        maxX = 5.23
-        maxY = 6.23
-        maxZ = 7.23
-        nbinsX = 100
-        nbinsY = 110
-        nbinsZ = 120
-        myPMFT = freud.pmft.PMFTXYZ(maxX, maxY, maxZ, (nbinsX, nbinsY, nbinsZ))
+        max_x = 5.23
+        max_y = 6.23
+        max_z = 7.23
+        nbins_x = 100
+        nbins_y = 110
+        nbins_z = 120
+        myPMFT = freud.pmft.PMFTXYZ(max_x, max_y, max_z,
+                                    (nbins_x, nbins_y, nbins_z))
         myPMFT.compute(system=(box, points), query_orientations=orientations,
                        query_points=points,
                        equiv_orientations=equiv_orientations, reset=False)
@@ -781,45 +783,46 @@ class TestPMFTXYZ(unittest.TestCase):
                            orientations, reset=False)
 
     def test_bins(self):
-        maxX = 5.23
-        maxY = 6.23
-        maxZ = 7.23
-        nbinsX = 100
-        nbinsY = 110
-        nbinsZ = 120
-        dx = (2.0 * maxX / float(nbinsX))
-        dy = (2.0 * maxY / float(nbinsY))
-        dz = (2.0 * maxZ / float(nbinsZ))
+        max_x = 5.23
+        max_y = 6.23
+        max_z = 7.23
+        nbins_x = 100
+        nbins_y = 110
+        nbins_z = 120
+        dx = (2.0 * max_x / float(nbins_x))
+        dy = (2.0 * max_y / float(nbins_y))
+        dz = (2.0 * max_z / float(nbins_z))
 
-        listX = np.zeros(nbinsX, dtype=np.float32)
-        listY = np.zeros(nbinsY, dtype=np.float32)
-        listZ = np.zeros(nbinsZ, dtype=np.float32)
+        listX = np.zeros(nbins_x, dtype=np.float32)
+        listY = np.zeros(nbins_y, dtype=np.float32)
+        listZ = np.zeros(nbins_z, dtype=np.float32)
 
-        for i in range(nbinsX):
+        for i in range(nbins_x):
             x = float(i) * dx
             nextX = float(i + 1) * dx
-            listX[i] = -maxX + ((x + nextX) / 2.0)
+            listX[i] = -max_x + ((x + nextX) / 2.0)
 
-        for i in range(nbinsY):
+        for i in range(nbins_y):
             y = float(i) * dy
             nextY = float(i + 1) * dy
-            listY[i] = -maxY + ((y + nextY) / 2.0)
+            listY[i] = -max_y + ((y + nextY) / 2.0)
 
-        for i in range(nbinsZ):
+        for i in range(nbins_z):
             z = float(i) * dz
             nextZ = float(i + 1) * dz
-            listZ[i] = -maxZ + ((z + nextZ) / 2.0)
+            listZ[i] = -max_z + ((z + nextZ) / 2.0)
 
-        myPMFT = freud.pmft.PMFTXYZ(maxX, maxY, maxZ, (nbinsX, nbinsY, nbinsZ))
+        myPMFT = freud.pmft.PMFTXYZ(max_x, max_y, max_z,
+                                    (nbins_x, nbins_y, nbins_z))
 
         # Compare expected bins to the info from pmft
         npt.assert_allclose(myPMFT.bin_centers[0], listX, atol=1e-3)
         npt.assert_allclose(myPMFT.bin_centers[1], listY, atol=1e-3)
         npt.assert_allclose(myPMFT.bin_centers[2], listZ, atol=1e-3)
 
-        npt.assert_equal(nbinsX, myPMFT.nbins[0])
-        npt.assert_equal(nbinsY, myPMFT.nbins[1])
-        npt.assert_equal(nbinsZ, myPMFT.nbins[2])
+        npt.assert_equal(nbins_x, myPMFT.nbins[0])
+        npt.assert_equal(nbins_y, myPMFT.nbins[1])
+        npt.assert_equal(nbins_z, myPMFT.nbins[2])
 
     def test_attribute_access(self):
         L = 25.0
@@ -827,12 +830,12 @@ class TestPMFTXYZ(unittest.TestCase):
         points = np.array([[-1.0, 0.0, 0.0], [1.0, 0.0, 0.0]],
                           dtype=np.float32)
         orientations = np.array([[1, 0, 0, 0], [1, 0, 0, 0]], dtype=np.float32)
-        maxX = 5.23
-        maxY = 6.23
-        maxZ = 7.23
-        nbinsX = nbinsY = nbinsZ = 100
+        max_x = 5.23
+        max_y = 6.23
+        max_z = 7.23
+        nbins_x = nbins_y = nbins_z = 100
 
-        myPMFT = freud.pmft.PMFTXYZ(maxX, maxY, maxZ, nbinsX)
+        myPMFT = freud.pmft.PMFTXYZ(max_x, max_y, max_z, nbins_x)
 
         with self.assertRaises(AttributeError):
             myPMFT.bin_counts
@@ -847,8 +850,8 @@ class TestPMFTXYZ(unittest.TestCase):
         myPMFT.bin_counts
         myPMFT.pmft
         myPMFT.box
-        npt.assert_equal(myPMFT.bin_counts.shape, (nbinsX, nbinsY, nbinsZ))
-        npt.assert_equal(myPMFT.pmft.shape, (nbinsX, nbinsY, nbinsZ))
+        npt.assert_equal(myPMFT.bin_counts.shape, (nbins_x, nbins_y, nbins_z))
+        npt.assert_equal(myPMFT.pmft.shape, (nbins_x, nbins_y, nbins_z))
 
         myPMFT.compute((box, points), orientations)
         myPMFT.bin_counts
@@ -862,22 +865,22 @@ class TestPMFTXYZ(unittest.TestCase):
                           dtype=np.float32)
         query_orientations = np.array([[1, 0, 0, 0], [1, 0, 0, 0]],
                                       dtype=np.float32)
-        maxX = 5.23
-        maxY = 6.23
-        maxZ = 7.23
-        nbinsX = 100
-        nbinsY = 110
-        nbinsZ = 120
-        dx = (2.0 * maxX / float(nbinsX))
-        dy = (2.0 * maxY / float(nbinsY))
-        dz = (2.0 * maxZ / float(nbinsZ))
+        max_x = 5.23
+        max_y = 6.23
+        max_z = 7.23
+        nbins_x = 100
+        nbins_y = 110
+        nbins_z = 120
+        dx = (2.0 * max_x / float(nbins_x))
+        dy = (2.0 * max_y / float(nbins_y))
+        dz = (2.0 * max_z / float(nbins_z))
 
-        correct_bin_counts = np.zeros(shape=(nbinsX, nbinsY, nbinsZ),
+        correct_bin_counts = np.zeros(shape=(nbins_x, nbins_y, nbins_z),
                                       dtype=np.int32)
 
         # calculation for array idxs
         def get_bin(query_point, point):
-            return np.floor((query_point - point + [maxX, maxY, maxZ]) /
+            return np.floor((query_point - point + [max_x, max_y, max_z]) /
                             [dx, dy, dz]).astype(np.int32)
 
         bins = get_bin(points[0], points[1])
@@ -886,12 +889,12 @@ class TestPMFTXYZ(unittest.TestCase):
         correct_bin_counts[bins[0], bins[1], bins[2]] = 1
         absoluteTolerance = 0.1
 
-        r_max = np.sqrt(maxX**2 + maxY**2 + maxZ**2)
+        r_max = np.sqrt(max_x**2 + max_y**2 + max_z**2)
         test_set = util.make_raw_query_nlist_test_set(
             box, points, points, 'ball', r_max, 0, True)
         for nq, neighbors in test_set:
             myPMFT = freud.pmft.PMFTXYZ(
-                maxX, maxY, maxZ, (nbinsX, nbinsY, nbinsZ))
+                max_x, max_y, max_z, (nbins_x, nbins_y, nbins_z))
             myPMFT.compute(nq, query_orientations, neighbors=neighbors,
                            reset=False)
             npt.assert_allclose(myPMFT.bin_counts, correct_bin_counts,
@@ -935,13 +938,14 @@ class TestPMFTXYZ(unittest.TestCase):
         npt.assert_equal(infcheck_shift, 1)
 
     def test_repr(self):
-        maxX = 5.23
-        maxY = 6.23
-        maxZ = 7.23
-        nbinsX = 100
-        nbinsY = 110
-        nbinsZ = 120
-        myPMFT = freud.pmft.PMFTXYZ(maxX, maxY, maxZ, (nbinsX, nbinsY, nbinsZ))
+        max_x = 5.23
+        max_y = 6.23
+        max_z = 7.23
+        nbins_x = 100
+        nbins_y = 110
+        nbins_z = 120
+        myPMFT = freud.pmft.PMFTXYZ(max_x, max_y, max_z,
+                                    (nbins_x, nbins_y, nbins_z))
         self.assertEqual(str(myPMFT), str(eval(repr(myPMFT))))
 
     def test_query_args_nn(self):

--- a/tests/test_pmft.py
+++ b/tests/test_pmft.py
@@ -761,6 +761,7 @@ class TestPMFTXYZ(unittest.TestCase):
         points = np.array([[-1.0, 0.0, 0.0], [1.0, 0.0, 0.0]],
                           dtype=np.float32)
         orientations = np.array([[1, 0, 0, 0], [1, 0, 0, 0]], dtype=np.float32)
+        face_orientations = np.array([[1, 0, 0, 0]], dtype=np.float32)
         maxX = 5.23
         maxY = 6.23
         maxZ = 7.23
@@ -769,8 +770,8 @@ class TestPMFTXYZ(unittest.TestCase):
         nbinsZ = 120
         myPMFT = freud.pmft.PMFTXYZ(maxX, maxY, maxZ, (nbinsX, nbinsY, nbinsZ))
         myPMFT.compute(system=(box, points), query_orientations=orientations,
-                       query_points=points, face_orientations=orientations,
-                       reset=False)
+                       query_points=points,
+                       face_orientations=face_orientations, reset=False)
         npt.assert_equal(myPMFT.box, freud.box.Box.cube(boxSize))
 
         # Ensure expected errors are raised
@@ -905,20 +906,8 @@ class TestPMFTXYZ(unittest.TestCase):
                            face_orientations=face_orientations)
             npt.assert_allclose(myPMFT.bin_counts, correct_bin_counts,
                                 atol=absoluteTolerance)
-            # Test face_orientations, shape (1, N_faces, 4)
-            face_orientations = np.array([[[1., 0., 0., 0.]]])
-            myPMFT.compute(nq, query_orientations, neighbors=neighbors,
-                           face_orientations=face_orientations)
-            npt.assert_allclose(myPMFT.bin_counts, correct_bin_counts,
-                                atol=absoluteTolerance)
-            # Test face_orientations, shape (N_particles, N_faces, 4)
-            face_orientations = np.array([[[1., 0., 0., 0.]],
-                                          [[1., 0., 0., 0.]]])
-            myPMFT.compute(nq, query_orientations, neighbors=neighbors,
-                           face_orientations=face_orientations)
-            npt.assert_allclose(myPMFT.bin_counts, correct_bin_counts,
-                                atol=absoluteTolerance)
 
+            # Test without face orientations.
             myPMFT.compute(nq, query_orientations, neighbors=neighbors)
             npt.assert_allclose(myPMFT.bin_counts, correct_bin_counts,
                                 atol=absoluteTolerance)
@@ -976,7 +965,7 @@ class TestPMFTXYZ(unittest.TestCase):
         max_width = 3
         nbins = 3
         pmft = freud.pmft.PMFTXYZ(max_width, max_width, max_width, nbins)
-        pmft.compute((box, points), angles, query_points,
+        pmft.compute((box, points), query_angles, query_points,
                      neighbors={'mode': 'nearest', 'num_neighbors': 1})
 
         # Now every point in query_points will find the origin as a neighbor.
@@ -992,7 +981,7 @@ class TestPMFTXYZ(unittest.TestCase):
               [0, 1, 0],
               [0, 0, 0]]])
 
-        pmft.compute((box, query_points), query_angles, points,
+        pmft.compute((box, query_points), angles, points,
                      neighbors={'mode': 'nearest', 'num_neighbors': 1})
         # The only nonzero bin is the right-center bin (zero distance in y, z)
         self.assertEqual(pmft.bin_counts[2, 1, 1], 1)

--- a/tests/test_pmft.py
+++ b/tests/test_pmft.py
@@ -903,7 +903,7 @@ class TestPMFTXYZ(unittest.TestCase):
             npt.assert_allclose(myPMFT.bin_counts, correct_bin_counts,
                                 atol=absoluteTolerance)
 
-            # Test equiv_orientations, shape (N_faces, 4)
+            # Test equiv_orientations, shape (num_equiv_orientations, 4)
             equiv_orientations = np.array([[1., 0., 0., 0.]])
             myPMFT.compute(nq, query_orientations, neighbors=neighbors,
                            equiv_orientations=equiv_orientations)

--- a/tests/test_pmft.py
+++ b/tests/test_pmft.py
@@ -709,7 +709,7 @@ class TestPMFTXY(unittest.TestCase):
 
         def points_to_set(bin_counts):
             """Extract set of unique occupied bins from pmft bin counts."""
-            return set(list(zip(*np.asarray(np.where(bin_counts)).tolist())))
+            return set(zip(*np.asarray(np.where(bin_counts)).tolist()))
 
         max_width = 3
         cells_per_unit_length = 4
@@ -1071,7 +1071,7 @@ class TestPMFTXYZ(unittest.TestCase):
 
         def points_to_set(bin_counts):
             """Extract set of unique occupied bins from pmft bin counts."""
-            return set(list(zip(*np.asarray(np.where(bin_counts)).tolist())))
+            return set(zip(*np.asarray(np.where(bin_counts)).tolist()))
 
         max_width = 3
         cells_per_unit_length = 4

--- a/tests/test_pmft.py
+++ b/tests/test_pmft.py
@@ -761,7 +761,7 @@ class TestPMFTXYZ(unittest.TestCase):
         points = np.array([[-1.0, 0.0, 0.0], [1.0, 0.0, 0.0]],
                           dtype=np.float32)
         orientations = np.array([[1, 0, 0, 0], [1, 0, 0, 0]], dtype=np.float32)
-        face_orientations = np.array([[1, 0, 0, 0]], dtype=np.float32)
+        equiv_orientations = np.array([[1, 0, 0, 0]], dtype=np.float32)
         maxX = 5.23
         maxY = 6.23
         maxZ = 7.23
@@ -771,7 +771,7 @@ class TestPMFTXYZ(unittest.TestCase):
         myPMFT = freud.pmft.PMFTXYZ(maxX, maxY, maxZ, (nbinsX, nbinsY, nbinsZ))
         myPMFT.compute(system=(box, points), query_orientations=orientations,
                        query_points=points,
-                       face_orientations=face_orientations, reset=False)
+                       equiv_orientations=equiv_orientations, reset=False)
         npt.assert_equal(myPMFT.box, freud.box.Box.cube(boxSize))
 
         # Ensure expected errors are raised
@@ -900,10 +900,10 @@ class TestPMFTXYZ(unittest.TestCase):
             npt.assert_allclose(myPMFT.bin_counts, correct_bin_counts,
                                 atol=absoluteTolerance)
 
-            # Test face_orientations, shape (N_faces, 4)
-            face_orientations = np.array([[1., 0., 0., 0.]])
+            # Test equiv_orientations, shape (N_faces, 4)
+            equiv_orientations = np.array([[1., 0., 0., 0.]])
             myPMFT.compute(nq, query_orientations, neighbors=neighbors,
-                           face_orientations=face_orientations)
+                           equiv_orientations=equiv_orientations)
             npt.assert_allclose(myPMFT.bin_counts, correct_bin_counts,
                                 atol=absoluteTolerance)
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above. -->

## Description
This PR fixes a handful of related bugs and make some additional changes as well.
Bugs fixed (with added tests):

- PMFTXY and PMFTXYZ correctly check that the size of `query_orientations` matches the number of `query_points`, not the number of points in the `system`.
- PMFTXY and PMFTXYZ correctly index into the `query_orientations` with `neighbor_bond.query_point_idx` on the C++ side.
- The `face_orientations` in PMFTXYZ are no longer dependent on the number of `system` points.

Changes:

- The `face_orientations` are now identical for all `query_points`. *This is a breaking change*, but a sensible one since it's nonsensical to average a PMFT over shapes with different symmetries.
- `flake8` now ignores pep8-naming changes. This change is completely unrelated but was necessary to enable commits with flake8 hooks enabled.


## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- Replace ??? with the issue number that this pull request resolves, if applicable. -->
Resolves: #540 

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to
     see how your changes affect other areas of the code, etc. -->

New tests were added with different numbers of `points` and `query_points` with nontrivial orientations.

## Screenshots
<!-- (if appropriate) -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds or improves functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!-- Put an `x` in all the boxes that apply. If you're unsure about any of
     these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/glotzerlab/freud/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] I have updated the documentation (if relevant).
- [x] I have added tests that cover my changes (if relevant).
- [ ] All new and existing tests passed.
- [x] I have updated the [credits](https://github.com/glotzerlab/freud/blob/master/doc/source/reference/credits.rst).
- [x] I have updated the [Changelog](https://github.com/glotzerlab/freud/blob/master/ChangeLog.md).
