### PR TITLE
Remove redundant function definition from PMFT

### DIFF
--- a/cpp/box/Box.h
+++ b/cpp/box/Box.h
@@ -15,10 +15,13 @@
     \brief Represents simulation boxes and contains helpful wrapping functions.
 */
 
-namespace freud { namespace box {
-
-// namespace-level constant 2*pi for convenient use everywhere.
+namespace freud { namespace constants {
+// Constant 2*pi for convenient use everywhere.
 constexpr float TWO_PI = 2.0 * M_PI;
+}; }; // end namespace freud::constants
+
+
+namespace freud { namespace box {
 
 //! Stores box dimensions and provides common routines for wrapping vectors back into the box
 /*! Box stores a standard HOOMD simulation box that goes from -L/2 to L/2 in each dimension, allowing Lx, Ly,
@@ -362,7 +365,7 @@ public:
 
         for (size_t i = 0; i < Nvecs; ++i)
         {
-            vec3<float> phase(TWO_PI * makeFractional(vecs[i]));
+            vec3<float> phase(constants::TWO_PI * makeFractional(vecs[i]));
             vec3<std::complex<float>> xi(std::polar(float(1.0), phase.x), std::polar(float(1.0), phase.y),
                                          std::polar(float(1.0), phase.z));
             float mass = (masses != NULL) ? masses[i] : 1.0;
@@ -372,7 +375,7 @@ public:
         xi_mean /= std::complex<float>(total_mass, 0);
 
         return wrap(makeAbsolute(vec3<float>(std::arg(xi_mean.x), std::arg(xi_mean.y), std::arg(xi_mean.z))
-                                 / TWO_PI));
+                                 / constants::TWO_PI));
     }
 
     //! Subtract center of mass from vectors

--- a/cpp/environment/BondOrder.cc
+++ b/cpp/environment/BondOrder.cc
@@ -17,9 +17,6 @@
 
 namespace freud { namespace environment {
 
-// namespace-level constant 2*pi for convenient use everywhere.
-constexpr float TWO_PI = 2.0 * M_PI;
-
 BondOrder::BondOrder(unsigned int n_bins_theta, unsigned int n_bins_phi, BondOrderMode mode)
     : BondHistogramCompute(), m_mode(mode)
 {
@@ -32,10 +29,10 @@ BondOrder::BondOrder(unsigned int n_bins_theta, unsigned int n_bins_phi, BondOrd
     /*
     0 < \theta < 2PI; 0 < \phi < PI
     */
-    float dt = TWO_PI / float(n_bins_theta);
+    float dt = constants::TWO_PI / float(n_bins_theta);
     float dp = M_PI / float(n_bins_phi);
     // this shouldn't be able to happen, but it's always better to check
-    if (dt > TWO_PI)
+    if (dt > constants::TWO_PI)
         throw std::invalid_argument("2PI must be greater than dt");
     if (dp > M_PI)
         throw std::invalid_argument("PI must be greater than dp");
@@ -52,7 +49,7 @@ BondOrder::BondOrder(unsigned int n_bins_theta, unsigned int n_bins_phi, BondOrd
         }
     }
     BHAxes axes;
-    axes.push_back(std::make_shared<util::RegularAxis>(n_bins_theta, 0, TWO_PI));
+    axes.push_back(std::make_shared<util::RegularAxis>(n_bins_theta, 0, constants::TWO_PI));
     axes.push_back(std::make_shared<util::RegularAxis>(n_bins_phi, 0, M_PI));
     m_histogram = BondHistogram(axes);
 
@@ -115,10 +112,10 @@ void BondOrder::accumulate(const locality::NeighborQuery* neighbor_query, quat<f
                           // angle)
                           float theta = std::atan2(v.y, v.x); //-Pi..Pi
 
-                          theta = fmod(theta, TWO_PI);
+                          theta = fmod(theta, constants::TWO_PI);
                           while (theta < 0)
                           {
-                              theta += TWO_PI;
+                              theta += constants::TWO_PI;
                           }
 
                           // NOTE that the below has replaced the commented out expression for phi.

--- a/cpp/locality/BondHistogramCompute.h
+++ b/cpp/locality/BondHistogramCompute.h
@@ -93,7 +93,7 @@ public:
     //! \internal
     // Wrapper to do accumulation.
     /*! \param neighbor_query NeighborQuery object to iterate over
-        \param query_points Points
+        \param query_points Query points
         \param n_query_points Number of query_points
         \param nlist Neighbor List. If not NULL, loop over it. Otherwise, use neighbor_query
            appropriately with given qargs.
@@ -110,7 +110,6 @@ public:
         m_frame_counter++;
         m_n_points = neighbor_query->getNPoints();
         m_n_query_points = n_query_points;
-        // flag to reduce
         m_reduce = true;
     }
 

--- a/cpp/pmft/PMFT.h
+++ b/cpp/pmft/PMFT.h
@@ -35,30 +35,6 @@ public:
     //! Destructor
     virtual ~PMFT() {};
 
-    //! \internal
-    // Wrapper to do accumulation.
-    /*! \param neighbor_query NeighborQuery object to iterate over
-        \param query_points Points
-        \param n_query_points Number of query_points
-        \param nlist Neighbor List. If not NULL, loop over it. Otherwise, use neighbor_query
-           appropriately with given qargs.
-        \param qargs Query arguments
-        \param cf An object with operator(NeighborBond) as input.
-    */
-    template<typename Func>
-    void accumulateGeneral(const locality::NeighborQuery* neighbor_query, const vec3<float>* query_points,
-                           unsigned int n_query_points, const locality::NeighborList* nlist,
-                           freud::locality::QueryArgs qargs, Func cf)
-    {
-        m_box = neighbor_query->getBox();
-        locality::loopOverNeighbors(neighbor_query, query_points, n_query_points, qargs, nlist, cf);
-        m_frame_counter++;
-        m_n_points = neighbor_query->getNPoints();
-        m_n_query_points = n_query_points;
-        // flag to reduce
-        m_reduce = true;
-    }
-
     template<typename JacobFactor> void reduce(JacobFactor jf)
     {
         m_pcf_array.prepare(m_histogram.shape());

--- a/cpp/pmft/PMFTR12.cc
+++ b/cpp/pmft/PMFTR12.cc
@@ -33,7 +33,7 @@ PMFTR12::PMFTR12(float r_max, unsigned int n_r, unsigned int n_t1, unsigned int 
     m_histogram = BondHistogram(axes);
     m_local_histograms = BondHistogram::ThreadLocalHistogram(m_histogram);
 
-    // calculate the jacobian array; computed as the inverse for faster use later
+    // Calculate the jacobian array; computed as the inverse for faster use later.
     m_inv_jacobian_array.prepare({n_r, n_t1, n_t2});
     std::vector<float> bins_r = m_histogram.getBinCenters()[0];
     float dr = r_max / float(n_r);
@@ -52,12 +52,10 @@ PMFTR12::PMFTR12(float r_max, unsigned int n_r, unsigned int n_t1, unsigned int 
         }
     }
 
-    // create and populate the pcf_array
+    // Create the PCF array.
     m_pcf_array.prepare({n_r, n_t1, n_t2});
 }
 
-//! \internal
-//! helper function to reduce the thread specific arrays into one array
 void PMFTR12::reduce()
 {
     PMFT::reduce([this](size_t i) { return m_inv_jacobian_array[i]; });

--- a/cpp/pmft/PMFTR12.cc
+++ b/cpp/pmft/PMFTR12.cc
@@ -11,9 +11,6 @@
 
 namespace freud { namespace pmft {
 
-// namespace-level constant 2*pi for convenient use everywhere.
-constexpr float TWO_PI = 2.0 * M_PI;
-
 PMFTR12::PMFTR12(float r_max, unsigned int n_r, unsigned int n_t1, unsigned int n_t2) : PMFT()
 {
     if (n_r < 1)
@@ -28,8 +25,8 @@ PMFTR12::PMFTR12(float r_max, unsigned int n_r, unsigned int n_t1, unsigned int 
     // Construct the Histogram object that will be used to keep track of counts of bond distances found.
     BHAxes axes;
     axes.push_back(std::make_shared<util::RegularAxis>(n_r, 0, r_max));
-    axes.push_back(std::make_shared<util::RegularAxis>(n_t1, 0, TWO_PI));
-    axes.push_back(std::make_shared<util::RegularAxis>(n_t2, 0, TWO_PI));
+    axes.push_back(std::make_shared<util::RegularAxis>(n_t1, 0, constants::TWO_PI));
+    axes.push_back(std::make_shared<util::RegularAxis>(n_t2, 0, constants::TWO_PI));
     m_histogram = BondHistogram(axes);
     m_local_histograms = BondHistogram::ThreadLocalHistogram(m_histogram);
 
@@ -37,8 +34,8 @@ PMFTR12::PMFTR12(float r_max, unsigned int n_r, unsigned int n_t1, unsigned int 
     m_inv_jacobian_array.prepare({n_r, n_t1, n_t2});
     std::vector<float> bins_r = m_histogram.getBinCenters()[0];
     float dr = r_max / float(n_r);
-    float dt1 = TWO_PI / float(n_t1);
-    float dt2 = TWO_PI / float(n_t2);
+    float dt1 = constants::TWO_PI / float(n_t1);
+    float dt2 = constants::TWO_PI / float(n_t2);
     float product = dr * dt1 * dt2;
     for (unsigned int i = 0; i < n_r; i++)
     {
@@ -75,15 +72,15 @@ void PMFTR12::accumulate(const locality::NeighborQuery* neighbor_query, float* o
                           float t1 = orientations[neighbor_bond.point_idx] - d_theta1;
                           float t2 = query_orientations[neighbor_bond.query_point_idx] - d_theta2;
                           // make sure that t1, t2 are bounded between 0 and 2PI
-                          t1 = fmod(t1, TWO_PI);
+                          t1 = fmod(t1, constants::TWO_PI);
                           if (t1 < 0)
                           {
-                              t1 += TWO_PI;
+                              t1 += constants::TWO_PI;
                           }
-                          t2 = fmod(t2, TWO_PI);
+                          t2 = fmod(t2, constants::TWO_PI);
                           if (t2 < 0)
                           {
-                              t2 += TWO_PI;
+                              t2 += constants::TWO_PI;
                           }
                           m_local_histograms(neighbor_bond.distance, t1, t2);
                       });

--- a/cpp/pmft/PMFTXY.cc
+++ b/cpp/pmft/PMFTXY.cc
@@ -11,9 +11,6 @@
 
 namespace freud { namespace pmft {
 
-// namespace-level constant 2*pi for convenient use everywhere.
-constexpr float TWO_PI = 2.0 * M_PI;
-
 PMFTXY::PMFTXY(float x_max, float y_max, unsigned int n_x, unsigned int n_y) : PMFT()
 {
     if (n_x < 1)
@@ -28,7 +25,7 @@ PMFTXY::PMFTXY(float x_max, float y_max, unsigned int n_x, unsigned int n_y) : P
     // Compute jacobian
     const float dx = 2.0 * x_max / float(n_x);
     const float dy = 2.0 * y_max / float(n_y);
-    m_jacobian = dx * dy * TWO_PI;
+    m_jacobian = dx * dy * constants::TWO_PI;
 
     // Create the PCF array.
     m_pcf_array.prepare({n_x, n_y});

--- a/cpp/pmft/PMFTXY.cc
+++ b/cpp/pmft/PMFTXY.cc
@@ -30,7 +30,7 @@ PMFTXY::PMFTXY(float x_max, float y_max, unsigned int n_x, unsigned int n_y) : P
     const float dy = 2.0 * y_max / float(n_y);
     m_jacobian = dx * dy * TWO_PI;
 
-    // create the pcf_array
+    // Create the PCF array.
     m_pcf_array.prepare({n_x, n_y});
 
     // Construct the Histogram object that will be used to keep track of counts of bond distances found.
@@ -41,17 +41,12 @@ PMFTXY::PMFTXY(float x_max, float y_max, unsigned int n_x, unsigned int n_y) : P
     m_local_histograms = BondHistogram::ThreadLocalHistogram(m_histogram);
 }
 
-//! \internal
-//! helper function to reduce the thread specific arrays into one array
 void PMFTXY::reduce()
 {
     float jacobian_factor = (float) 1.0 / m_jacobian;
     PMFT::reduce([jacobian_factor](size_t i) { return jacobian_factor; });
 }
 
-//! \internal
-/*! \brief Helper functionto direct the calculation to the correct helper class
- */
 void PMFTXY::accumulate(const locality::NeighborQuery* neighbor_query, float* query_orientations,
                         vec3<float>* query_points, unsigned int n_query_points,
                         const locality::NeighborList* nlist, freud::locality::QueryArgs qargs)

--- a/cpp/pmft/PMFTXYT.cc
+++ b/cpp/pmft/PMFTXYT.cc
@@ -32,7 +32,7 @@ PMFTXYT::PMFTXYT(float x_max, float y_max, unsigned int n_x, unsigned int n_y, u
     const float dt = TWO_PI / float(n_t);
     m_jacobian = dx * dy * dt;
 
-    // create and populate the pcf_array
+    // Create the PCF array.
     m_pcf_array.prepare({n_x, n_y, n_t});
 
     // Construct the Histogram object that will be used to keep track of counts of bond distances found.
@@ -44,8 +44,6 @@ PMFTXYT::PMFTXYT(float x_max, float y_max, unsigned int n_x, unsigned int n_y, u
     m_local_histograms = BondHistogram::ThreadLocalHistogram(m_histogram);
 }
 
-//! \internal
-//! helper function to reduce the thread specific arrays into one array
 void PMFTXYT::reduce()
 {
     float jacobian_factor = (float) 1.0 / m_jacobian;

--- a/cpp/pmft/PMFTXYT.cc
+++ b/cpp/pmft/PMFTXYT.cc
@@ -10,9 +10,6 @@
 
 namespace freud { namespace pmft {
 
-// namespace-level constant 2*pi for convenient use everywhere.
-constexpr float TWO_PI = 2.0 * M_PI;
-
 PMFTXYT::PMFTXYT(float x_max, float y_max, unsigned int n_x, unsigned int n_y, unsigned int n_t) : PMFT()
 {
     if (n_x < 1)
@@ -29,7 +26,7 @@ PMFTXYT::PMFTXYT(float x_max, float y_max, unsigned int n_x, unsigned int n_y, u
     // Compute Jacobian
     const float dx = 2.0 * x_max / float(n_x);
     const float dy = 2.0 * y_max / float(n_y);
-    const float dt = TWO_PI / float(n_t);
+    const float dt = constants::TWO_PI / float(n_t);
     m_jacobian = dx * dy * dt;
 
     // Create the PCF array.
@@ -39,7 +36,7 @@ PMFTXYT::PMFTXYT(float x_max, float y_max, unsigned int n_x, unsigned int n_y, u
     BondHistogram::Axes axes;
     axes.push_back(std::make_shared<util::RegularAxis>(n_x, -x_max, x_max));
     axes.push_back(std::make_shared<util::RegularAxis>(n_y, -y_max, y_max));
-    axes.push_back(std::make_shared<util::RegularAxis>(n_t, 0, TWO_PI));
+    axes.push_back(std::make_shared<util::RegularAxis>(n_t, 0, constants::TWO_PI));
     m_histogram = BondHistogram(axes);
     m_local_histograms = BondHistogram::ThreadLocalHistogram(m_histogram);
 }
@@ -68,10 +65,10 @@ void PMFTXYT::accumulate(const locality::NeighborQuery* neighbor_query, float* o
                           float d_theta = atan2(-delta.y, -delta.x);
                           float t = query_orientations[neighbor_bond.query_point_idx] - d_theta;
                           // make sure that t is bounded between 0 and 2PI
-                          t = fmod(t, TWO_PI);
+                          t = fmod(t, constants::TWO_PI);
                           if (t < 0)
                           {
-                              t += TWO_PI;
+                              t += constants::TWO_PI;
                           }
 
                           m_local_histograms(rotVec.x, rotVec.y, t);

--- a/cpp/pmft/PMFTXYZ.cc
+++ b/cpp/pmft/PMFTXYZ.cc
@@ -45,10 +45,11 @@ PMFTXYZ::PMFTXYZ(float x_max, float y_max, float z_max, unsigned int n_x, unsign
     const float orientation_volume = 8 * M_PI * M_PI;
     m_jacobian = dx * dy * dz * orientation_volume;
 
-    // create and populate the pcf_array
+    // Create the PCF array.
     m_pcf_array.prepare({n_x, n_y, n_z});
 
-    // Construct the Histogram object that will be used to keep track of counts of bond distances found.
+    // Construct the Histogram object that will be used to keep track of counts
+    // of bond distances found.
     BHAxes axes;
     axes.push_back(std::make_shared<util::RegularAxis>(n_x, -x_max, x_max));
     axes.push_back(std::make_shared<util::RegularAxis>(n_y, -y_max, y_max));
@@ -57,23 +58,17 @@ PMFTXYZ::PMFTXYZ(float x_max, float y_max, float z_max, unsigned int n_x, unsign
     m_local_histograms = BondHistogram::ThreadLocalHistogram(m_histogram);
 }
 
-//! \internal
-//! helper function to reduce the thread specific arrays into one array
 void PMFTXYZ::reduce()
 {
     float jacobian_factor = (float) 1.0 / m_jacobian;
     PMFT::reduce([jacobian_factor](size_t i) { return jacobian_factor; });
 }
 
-//! \internal
-/*! \brief Helper function to direct the calculation to the correct helper class
- */
 void PMFTXYZ::accumulate(const locality::NeighborQuery* neighbor_query, quat<float>* query_orientations,
                          vec3<float>* query_points, unsigned int n_query_points,
                          quat<float>* equiv_orientations, unsigned int num_equiv_orientations,
                          const locality::NeighborList* nlist, freud::locality::QueryArgs qargs)
 {
-    // precalc some values for faster computation within the loop
     neighbor_query->getBox().enforce3D();
     accumulateGeneral(neighbor_query, query_points, n_query_points, nlist, qargs,
                       [=](const freud::locality::NeighborBond& neighbor_bond) {
@@ -82,8 +77,7 @@ void PMFTXYZ::accumulate(const locality::NeighborQuery* neighbor_query, quat<flo
                           // make sure that the particles are wrapped into the box
                           vec3<float> delta(bondVector(neighbor_bond, neighbor_query, query_points));
 
-                          for (unsigned int k = 0; k < num_equiv_orientations; k++)
-                          {
+                          for (unsigned int k = 0; k < num_equiv_orientations; k++) {
                               // create point vector
                               vec3<float> v(delta);
                               // rotate the vector


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above. -->

## Description
<!-- Describe your changes in detail. -->
This PR does a bit of cleanup by

1. Removing an unnecessary redefinition of `accumulateGeneral` in `PMFT`.
2. Removing documentation in implementation (cc) files for functions documented in headers.
3. Centralizing the definition of `TWO_PI` in a `constants` namespace.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds or improves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!-- Put an `x` in all the boxes that apply. If you're unsure about any of
     these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/glotzerlab/freud/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] I have updated the documentation (if relevant).
- [x] I have added tests that cover my changes (if relevant).
- [x] All new and existing tests passed.
- [ ] I have updated the [credits](https://github.com/glotzerlab/freud/blob/master/doc/source/reference/credits.rst).
- [ ] I have updated the [Changelog](https://github.com/glotzerlab/freud/blob/master/ChangeLog.md).
