### PR TITLE
Define wrapping behavior for aperiodic boxes (for aperiodic GaussianDensity).

### DIFF
--- a/cpp/box/Box.h
+++ b/cpp/box/Box.h
@@ -296,9 +296,18 @@ public:
     vec3<float> wrap(const vec3<float>& v) const
     {
         vec3<float> v_frac = makeFractional(v);
-        v_frac.x = util::modulusPositive(v_frac.x, 1.0f);
-        v_frac.y = util::modulusPositive(v_frac.y, 1.0f);
-        v_frac.z = util::modulusPositive(v_frac.z, 1.0f);
+        if (m_periodic.x)
+        {
+            v_frac.x = util::modulusPositive(v_frac.x, 1.0f);
+        }
+        if (m_periodic.y)
+        {
+            v_frac.y = util::modulusPositive(v_frac.y, 1.0f);
+        }
+        if (m_periodic.z)
+        {
+            v_frac.z = util::modulusPositive(v_frac.z, 1.0f);
+        }
         return makeAbsolute(v_frac);
     }
 

--- a/cpp/density/GaussianDensity.cc
+++ b/cpp/density/GaussianDensity.cc
@@ -53,6 +53,7 @@ void GaussianDensity::compute(const freud::locality::NeighborQuery* nq)
     const float lx = m_box.getLx();
     const float ly = m_box.getLy();
     const float lz = m_box.getLz();
+    const vec3<bool> periodic = m_box.getPeriodic();
 
     const float grid_size_x = lx / m_width.x;
     const float grid_size_y = ly / m_width.y;
@@ -93,6 +94,14 @@ void GaussianDensity::compute(const freud::locality::NeighborQuery* nq)
 
                     for (int i = bin_x - bin_cut_x; i <= bin_x + bin_cut_x; i++)
                     {
+                        // Reject bins that are outside the box in aperiodic directions
+                        if ((!periodic.x && (i < 0 || i >= int(m_width.x))) ||
+                            (!periodic.y && (j < 0 || j >= int(m_width.y))) ||
+                            (!periodic.z && (k < 0 || k >= int(m_width.z))))
+                        {
+                            continue;
+                        }
+
                         // Calculate the distance from the particle to the grid cell
                         const float dx = float((grid_size_x * i + grid_size_x / 2.0f) - point.x - lx / 2.0f);
                         vec3<float> delta = m_box.wrap(vec3<float>(dx, dy, dz));

--- a/cpp/util/utils.h
+++ b/cpp/util/utils.h
@@ -21,8 +21,8 @@ inline float clamp(float v, float lo, float hi)
 //! Modulus operation always resulting in a positive value
 /*! \param a Dividend.
     \param b Divisor.
-    \returns The remainder of a/b, between min(0, b) and max(0, b)
-    \note This is the same behavior of the modulus operator % in Python (but not C++)
+    \returns The remainder of a/b, between min(0, b) and max(0, b).
+    \note This is the same behavior of the modulus operator % in Python (but not C++).
 */
 template<class Scalar> inline Scalar modulusPositive(Scalar a, Scalar b)
 {


### PR DESCRIPTION
## Description
I am doing some analyses where I need to have an aperiodic box. I experimented with some behaviors and decided on this:
- If a box dimension is configured to be aperiodic, then it is treated as if the box is infinite in that direction when wrapping a set of input vectors.
- For a box that is aperiodic in all 3 directions, `vec = wrap(vec)` is an identity mapping. That is, particles that are outside the box won't be affected by wrapping if the box is aperiodic.
- Corollary: there is no "maximum distance" that particles can have between them if the box is aperiodic.

I have not investigated how neighbor finding is affected, since I only used this feature to enable aperiodic behavior in GaussianDensity. This PR should probably not be merged until we think about all the implications and add tests of features with aperiodic systems (or just throw runtime errors in each feature until it is officially supported with aperiodic boxes)!

## Motivation and Context
I needed an aperiodic GaussianDensity feature.

## How Has This Been Tested?
Need to write tests.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds or improves functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!-- Put an `x` in all the boxes that apply. If you're unsure about any of
     these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/glotzerlab/freud/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] I have updated the documentation (if relevant).
- [ ] I have added tests that cover my changes (if relevant).
- [ ] All new and existing tests passed.
- [ ] I have updated the [credits](https://github.com/glotzerlab/freud/blob/master/doc/source/reference/credits.rst).
- [ ] I have updated the [Changelog](https://github.com/glotzerlab/freud/blob/master/ChangeLog.md).
