### PR TITLE
Add option to limit number of neighbor bonds in LocalDescriptors

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -7,8 +7,8 @@ and this project adheres to
 ## v2.2.0
 
 ### Added
-* NeighborQuery objects can now create NeighborLists with neighbors sorted by bond distance
-* LocalDescriptors `compute` takes an optional maximum number of neighbors to compute for each particle
+* NeighborQuery objects can now create NeighborLists with neighbors sorted by bond distance.
+* LocalDescriptors `compute` takes an optional maximum number of neighbors to compute for each particle.
 
 ## v2.1.0 - 2019-12-19
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,12 @@ The format is based on
 and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## v2.2.0
+
+### Added
+* NeighborQuery objects can now create NeighborLists with neighbors sorted by bond distance
+* LocalDescriptors `compute` takes an optional maximum number of neighbors to compute for each particle
+
 ## v2.1.0 - 2019-12-19
 
 ### Added

--- a/cpp/environment/LocalDescriptors.h
+++ b/cpp/environment/LocalDescriptors.h
@@ -54,7 +54,8 @@ public:
     //! positions and the number of particles
     void compute(const locality::NeighborQuery* nq, const vec3<float>* query_points,
                  unsigned int n_query_points, const quat<float>* orientations,
-                 const freud::locality::NeighborList* nlist, locality::QueryArgs qargs);
+                 const freud::locality::NeighborList* nlist, locality::QueryArgs qargs,
+                 unsigned int max_num_neighbors=0);
 
     //! Get a reference to the last computed spherical harmonic array
     const util::ManagedArray<std::complex<float>>& getSph() const

--- a/cpp/locality/NeighborBond.h
+++ b/cpp/locality/NeighborBond.h
@@ -70,6 +70,23 @@ struct NeighborBond
         return distance < n.distance;
     }
 
+    bool less_as_distance(const NeighborBond& n) const
+    {
+        if (query_point_idx != n.query_point_idx)
+        {
+            return query_point_idx < n.query_point_idx;
+        }
+        if (distance != n.distance)
+        {
+            return distance < n.distance;
+        }
+        if (point_idx != n.point_idx)
+        {
+            return point_idx < n.point_idx;
+        }
+        return weight < n.weight;
+    }
+
     unsigned int query_point_idx; //! The query point index.
     unsigned int point_idx;       //! The reference point index.
     float distance;               //! The distance between the points.

--- a/cpp/locality/NeighborList.cc
+++ b/cpp/locality/NeighborList.cc
@@ -205,6 +205,11 @@ bool compareNeighborBond(const NeighborBond& left, const NeighborBond& right)
     return left.less_as_tuple(right);
 }
 
+bool compareNeighborDistance(const NeighborBond& left, const NeighborBond& right)
+{
+    return left.less_as_distance(right);
+}
+
 bool compareFirstNeighborPairs(const std::vector<NeighborBond>& left, const std::vector<NeighborBond>& right)
 {
     if (left.size() && right.size())

--- a/cpp/locality/NeighborList.h
+++ b/cpp/locality/NeighborList.h
@@ -150,6 +150,7 @@ private:
 };
 
 bool compareNeighborBond(const NeighborBond& left, const NeighborBond& right);
+bool compareNeighborDistance(const NeighborBond& left, const NeighborBond& right);
 bool compareFirstNeighborPairs(const std::vector<NeighborBond>& left, const std::vector<NeighborBond>& right);
 
 }; }; // end namespace freud::locality

--- a/cpp/locality/NeighborQuery.h
+++ b/cpp/locality/NeighborQuery.h
@@ -354,7 +354,7 @@ public:
      *  the primary use-case is to have this object be managed by instances
      *  of the Cython NeighborList class.
      */
-    NeighborList* toNeighborList()
+    NeighborList* toNeighborList(bool sort_by_distance=false)
     {
         typedef tbb::enumerable_thread_specific<std::vector<NeighborBond>> BondVector;
         BondVector bonds;
@@ -378,7 +378,10 @@ public:
 
         tbb::flattened2d<BondVector> flat_bonds = tbb::flatten2d(bonds);
         std::vector<NeighborBond> linear_bonds(flat_bonds.begin(), flat_bonds.end());
-        tbb::parallel_sort(linear_bonds.begin(), linear_bonds.end(), compareNeighborBond);
+        if(sort_by_distance)
+            tbb::parallel_sort(linear_bonds.begin(), linear_bonds.end(), compareNeighborDistance);
+        else
+            tbb::parallel_sort(linear_bonds.begin(), linear_bonds.end(), compareNeighborBond);
 
         unsigned int num_bonds = linear_bonds.size();
 

--- a/freud/_environment.pxd
+++ b/freud/_environment.pxd
@@ -50,7 +50,8 @@ cdef extern from "LocalDescriptors.h" namespace "freud::environment":
             const vec3[float]*, unsigned int,
             const quat[float]*,
             const freud._locality.NeighborList*,
-            freud._locality.QueryArgs) except +
+            freud._locality.QueryArgs,
+            unsigned int) except +
         const freud.util.ManagedArray[float complex] &getSph() const
         freud._locality.NeighborList * getNList()
         LocalDescriptorOrientation getMode() const

--- a/freud/_locality.pxd
+++ b/freud/_locality.pxd
@@ -55,7 +55,7 @@ cdef extern from "NeighborQuery.h" namespace "freud::locality":
         NeighborQueryIterator(NeighborQuery*, vec3[float]*, unsigned int)
         bool end()
         NeighborBond next()
-        NeighborList *toNeighborList()
+        NeighborList *toNeighborList(bool)
 
 cdef extern from "RawPoints.h" namespace "freud::locality":
 

--- a/freud/environment.pyx
+++ b/freud/environment.pyx
@@ -230,10 +230,10 @@ cdef class LocalDescriptors(_PairCompute):
     local environment.
 
     The resulting spherical harmonic array will be a complex-valued
-    array of shape `(num_bonds, num_sphs)`. Spherical harmonic
+    array of shape :code:`(num_bonds, num_sphs)`. Spherical harmonic
     calculation can be restricted to some number of nearest neighbors
-    through the `max_num_neighbors` argument; if a particle has more bonds
-    than this number, the last one or more rows of bond spherical
+    through the :code:`max_num_neighbors` argument; if a particle has more
+    bonds than this number, the last one or more rows of bond spherical
     harmonics for each particle will not be set.
 
     Args:
@@ -293,7 +293,8 @@ cdef class LocalDescriptors(_PairCompute):
                 (Default value: None).
             max_num_neighbors (unsigned int, optional):
                 Hard limit on the maximum number of neighbors to use for each
-                particle for the given neighbor-finding algorithm (default: no limit)
+                particle for the given neighbor-finding algorithm. Uses
+                all neighbors if set to 0 (Default value = 0).
         """  # noqa: E501
         cdef:
             freud.locality.NeighborQuery nq
@@ -346,8 +347,8 @@ cdef class LocalDescriptors(_PairCompute):
     def num_sphs(self):
         """unsigned int: The last number of spherical harmonics computed. This
         is equal to the number of bonds in the last computation, which is at
-        most the number of `points` multiplied by the lower of the
-        `num_neighbors` arguments passed to the last compute call or the
+        most the number of :code:`points` multiplied by the lower of the
+        :code:`num_neighbors` arguments passed to the last compute call or the
         constructor (it may be less if there are not enough neighbors for every
         particle)."""
         return self.thisptr.getNSphs()

--- a/freud/environment.pyx
+++ b/freud/environment.pyx
@@ -232,7 +232,7 @@ cdef class LocalDescriptors(_PairCompute):
     The resulting spherical harmonic array will be a complex-valued
     array of shape `(num_bonds, num_sphs)`. Spherical harmonic
     calculation can be restricted to some number of nearest neighbors
-    through the `num_neighbors` argument; if a particle has more bonds
+    through the `max_num_neighbors` argument; if a particle has more bonds
     than this number, the last one or more rows of bond spherical
     harmonics for each particle will not be set.
 
@@ -270,7 +270,7 @@ cdef class LocalDescriptors(_PairCompute):
         del self.thisptr
 
     def compute(self, system, query_points=None, orientations=None,
-                neighbors=None):
+                neighbors=None, max_num_neighbors=0):
         R"""Calculates the local descriptors of bonds from a set of source
         points to a set of destination points.
 
@@ -291,6 +291,9 @@ cdef class LocalDescriptors(_PairCompute):
                 `query arguments
                 <https://freud.readthedocs.io/en/stable/topics/querying.html>`_
                 (Default value: None).
+            max_num_neighbors (unsigned int, optional):
+                Hard limit on the maximum number of neighbors to use for each
+                particle for the given neighbor-finding algorithm (default: no limit)
         """  # noqa: E501
         cdef:
             freud.locality.NeighborQuery nq
@@ -321,7 +324,8 @@ cdef class LocalDescriptors(_PairCompute):
             nq.get_ptr(),
             <vec3[float]*> &l_query_points[0, 0], num_query_points,
             l_orientations_ptr,
-            nlist.get_ptr(), dereference(qargs.thisptr))
+            nlist.get_ptr(), dereference(qargs.thisptr),
+            max_num_neighbors)
         return self
 
     @_Compute._computed_property

--- a/freud/environment.pyx
+++ b/freud/environment.pyx
@@ -236,7 +236,7 @@ cdef class LocalDescriptors(_PairCompute):
     bonds than this number, the last one or more rows of bond spherical
     harmonics for each particle will not be set. This feature is useful for
     computing descriptors on the same system but with different subsets of
-    neighbors; a :class:`freud.locality.NeighborList` with the correct 
+    neighbors; a :class:`freud.locality.NeighborList` with the correct
     ordering can then be reused in multiple calls to `~.compute` with
     different values of `max_num_neighbors` to compute descriptors for
     different local neighborhoods with maximum efficiency.

--- a/freud/environment.pyx
+++ b/freud/environment.pyx
@@ -237,9 +237,9 @@ cdef class LocalDescriptors(_PairCompute):
     harmonics for each particle will not be set. This feature is useful for
     computing descriptors on the same system but with different subsets of
     neighbors; a :class:`freud.locality.NeighborList` with the correct
-    ordering can then be reused in multiple calls to `~.compute` with
-    different values of `max_num_neighbors` to compute descriptors for
-    different local neighborhoods with maximum efficiency.
+    ordering can then be reused in multiple calls to :meth:`~.compute`
+    with different values of `max_num_neighbors` to compute descriptors
+    for different local neighborhoods with maximum efficiency.
 
     Args:
         l_max (unsigned int):

--- a/freud/environment.pyx
+++ b/freud/environment.pyx
@@ -234,7 +234,12 @@ cdef class LocalDescriptors(_PairCompute):
     calculation can be restricted to some number of nearest neighbors
     through the :code:`max_num_neighbors` argument; if a particle has more
     bonds than this number, the last one or more rows of bond spherical
-    harmonics for each particle will not be set.
+    harmonics for each particle will not be set. This feature is useful for
+    computing descriptors on the same system but with different subsets of
+    neighbors; a :class:`freud.locality.NeighborList` with the correct 
+    ordering can then be reused in multiple calls to `~.compute` with
+    different values of `max_num_neighbors` to compute descriptors for
+    different local neighborhoods with maximum efficiency.
 
     Args:
         l_max (unsigned int):

--- a/freud/locality.pyx
+++ b/freud/locality.pyx
@@ -206,8 +206,12 @@ cdef class NeighborQueryResult:
 
         raise StopIteration
 
-    def toNeighborList(self):
+    def toNeighborList(self, sort_by_distance=False):
         """Convert query result to a freud NeighborList.
+
+        Args:
+            sort_by_distance (bool):
+                If True, sort neighboring bonds by distance instead of index
 
         Returns:
             :class:`~NeighborList`: A :mod:`freud` :class:`~NeighborList`
@@ -222,7 +226,7 @@ cdef class NeighborQueryResult:
                 dereference(self.query_args.thisptr))
 
         cdef freud._locality.NeighborList *cnlist = dereference(
-            iterator).toNeighborList()
+            iterator).toNeighborList(sort_by_distance)
         cdef NeighborList nl = _nlist_from_cnlist(cnlist)
         # Explicitly manage a manually created nlist so that it will be
         # deleted when the Python object is.

--- a/freud/locality.pyx
+++ b/freud/locality.pyx
@@ -211,8 +211,9 @@ cdef class NeighborQueryResult:
 
         Args:
             sort_by_distance (bool):
-                If True, sort neighboring bonds by distance. By default, sort
-                neighboring bonds by point index.
+                If :code:`True`, sort neighboring bonds by distance.
+                If :code:`False`, sort neighboring bonds by point index
+                (Default value = :code:`False`).
 
         Returns:
             :class:`~NeighborList`: A :mod:`freud` :class:`~NeighborList`

--- a/freud/locality.pyx
+++ b/freud/locality.pyx
@@ -211,7 +211,8 @@ cdef class NeighborQueryResult:
 
         Args:
             sort_by_distance (bool):
-                If True, sort neighboring bonds by distance instead of index
+                If True, sort neighboring bonds by distance. By default, sort
+                neighboring bonds by point index.
 
         Returns:
             :class:`~NeighborList`: A :mod:`freud` :class:`~NeighborList`

--- a/tests/test_locality_NeighborList.py
+++ b/tests/test_locality_NeighborList.py
@@ -228,6 +228,28 @@ class TestNeighborList(unittest.TestCase):
         npt.assert_equal(nlist.segments, nlist2.segments)
         npt.assert_equal(nlist.neighbor_counts, nlist2.neighbor_counts)
 
+    def test_ordering(self):
+        # default behavior sorts by (i, j, distance)
+        tuples = list(zip(self.nlist.query_point_indices,
+                          self.nlist.point_indices,
+                          self.nlist.distances))
+        sorted_tuples = list(sorted(tuples))
+
+        self.assertEqual(tuples, sorted_tuples)
+
+        # test sorting by (i, distance, j)
+        box, points = freud.data.make_random_system(self.L, self.N)
+        nq = freud.locality.AABBQuery(box, points)
+        nlist = nq.query(points,
+                         self.query_args).toNeighborList(True)
+
+        tuples = list(zip(nlist.query_point_indices,
+                          nlist.distances,
+                          nlist.point_indices))
+        sorted_tuples = list(sorted(tuples))
+
+        self.assertEqual(tuples, sorted_tuples)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_locality_NeighborList.py
+++ b/tests/test_locality_NeighborList.py
@@ -228,7 +228,7 @@ class TestNeighborList(unittest.TestCase):
         npt.assert_equal(nlist.segments, nlist2.segments)
         npt.assert_equal(nlist.neighbor_counts, nlist2.neighbor_counts)
 
-    def test_ordering(self):
+    def test_ordering_default(self):
         # default behavior sorts by (i, j, distance)
         tuples = list(zip(self.nlist.query_point_indices,
                           self.nlist.point_indices,
@@ -237,12 +237,11 @@ class TestNeighborList(unittest.TestCase):
 
         self.assertEqual(tuples, sorted_tuples)
 
-        # test sorting by (i, distance, j)
-        box, points = freud.data.make_random_system(self.L, self.N)
-        nq = freud.locality.AABBQuery(box, points)
-        nlist = nq.query(points,
-                         self.query_args).toNeighborList(True)
+    def test_ordering_distance(self):
+        nlist = self.nq.query(self.nq.points,
+                              self.query_args).toNeighborList(True)
 
+        # test sorting by (i, distance, j)
         tuples = list(zip(nlist.query_point_indices,
                           nlist.distances,
                           nlist.point_indices))


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above. -->

## Description
This PR adds back the behavior described in the LocalDescriptors documentation:

> Spherical harmonic calculation can be restricted to some number of nearest neighbors through the num_neighbors argument; if a particle has more bonds than this number, the last one or more rows of bond spherical harmonics for each particle will not be set.

Simultaneously, the PR adds the ability to sort neighbor lists by distance, which is typically required for this limiting behavior to be useful.

## Motivation and Context
Related to #580 

## How Has This Been Tested?
I'm currently testing this with an updated version of pythia.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds or improves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!-- Put an `x` in all the boxes that apply. If you're unsure about any of
     these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/glotzerlab/freud/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] I have updated the documentation (if relevant).
- [x] I have added tests that cover my changes (if relevant).
- [x] All new and existing tests passed.
- [x] I have updated the [credits](https://github.com/glotzerlab/freud/blob/master/doc/source/reference/credits.rst).
- [x] I have updated the [Changelog](https://github.com/glotzerlab/freud/blob/master/ChangeLog.md).
