### PR TITLE
Fix Voronoi distances

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -10,6 +10,9 @@ and this project adheres to
 * NeighborQuery objects can now create NeighborLists with neighbors sorted by bond distance.
 * LocalDescriptors `compute` takes an optional maximum number of neighbors to compute for each particle.
 
+### Fixed
+* Corrected calculation of neighbor distances in the Voronoi NeighborList.
+
 ## v2.1.0 - 2019-12-19
 
 ### Added

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,7 +13,7 @@ build_script:
   - conda config --set always_yes yes --set changeps1 no
   - conda config --add channels conda-forge
   - conda update -q conda
-  - conda install pip cython garnett gsd matplotlib mdanalysis numpy rowan scipy sympy tbb tbb-devel
+  - conda install pip cython==0.29.13 garnett==0.5.0 gsd==1.9.2 matplotlib>=3.0.0 mdanalysis==0.20.1 numpy==1.17.2 rowan==1.2.2 scipy=1.3.1 sympy==1.4 tbb tbb-devel
   - "set TBB_INCLUDE=%MINICONDA%\\Library\\include"
   - "set TBB_LINK=%MINICONDA%\\Library\\lib"
   - python --version

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,7 +13,7 @@ build_script:
   - conda config --set always_yes yes --set changeps1 no
   - conda config --add channels conda-forge
   - conda update -q conda
-  - conda install pip cython==0.29.13 garnett==0.5.0 gsd==1.9.2 matplotlib>=3.0.0 mdanalysis==0.20.1 numpy==1.17.2 rowan==1.2.2 scipy=1.3.1 sympy==1.4 tbb tbb-devel
+  - conda install pip cython==0.29.13 garnett==0.5.0 gsd==1.10.0 matplotlib>=3.0.0 mdanalysis==0.20.1 numpy==1.17.2 rowan==1.2.2 scipy=1.3.1 sympy==1.4 tbb tbb-devel
   - "set TBB_INCLUDE=%MINICONDA%\\Library\\include"
   - "set TBB_LINK=%MINICONDA%\\Library\\lib"
   - python --version

--- a/cpp/box/Box.h
+++ b/cpp/box/Box.h
@@ -405,8 +405,8 @@ public:
     vec3<float> getNearestPlaneDistance() const
     {
         vec3<float> dist;
-        dist.x = m_L.x / sqrt(1.0f + m_xy * m_xy + (m_xy * m_yz - m_xz) * (m_xy * m_yz - m_xz));
-        dist.y = m_L.y / sqrt(1.0f + m_yz * m_yz);
+        dist.x = m_L.x / std::sqrt(1.0f + m_xy * m_xy + (m_xy * m_yz - m_xz) * (m_xy * m_yz - m_xz));
+        dist.y = m_L.y / std::sqrt(1.0f + m_yz * m_yz);
         dist.z = m_L.z;
 
         return dist;

--- a/cpp/environment/LocalBondProjection.cc
+++ b/cpp/environment/LocalBondProjection.cc
@@ -81,7 +81,7 @@ void LocalBondProjection::compute(const locality::NeighborQuery* nq, const quat<
                 // rotate bond vector into the local frame of particle p
                 local_bond = rotate(conj(orientations[j]), local_bond);
                 // store the length of this local bond
-                float local_bond_len = sqrt(dot(local_bond, local_bond));
+                float local_bond_len = std::sqrt(dot(local_bond, local_bond));
 
                 for (unsigned int k = 0; k < n_proj; k++)
                 {

--- a/cpp/environment/LocalDescriptors.cc
+++ b/cpp/environment/LocalDescriptors.cc
@@ -111,7 +111,7 @@ void LocalDescriptors::compute(const locality::NeighborQuery* nq, const vec3<flo
                 const vec3<float> bond_ij(dot(rotation_0, r_ij), dot(rotation_1, r_ij),
                                           dot(rotation_2, r_ij));
 
-                const float magR(sqrt(r_sq));
+                const float magR(std::sqrt(r_sq));
                 float theta(atan2(bond_ij.y, bond_ij.x)); // theta in [-pi..pi] initially
                 if (theta < 0)
                     theta += float(2 * M_PI);      // move theta into [0..2*pi]

--- a/cpp/environment/Registration.h
+++ b/cpp/environment/Registration.h
@@ -376,7 +376,7 @@ public:
         }
 
         m = vec_map;
-        return sqrt(rmsd / double(points.rows()));
+        return std::sqrt(rmsd / double(points.rows()));
     }
 
 private:

--- a/cpp/locality/AABBQuery.cc
+++ b/cpp/locality/AABBQuery.cc
@@ -183,7 +183,7 @@ NeighborBond AABBQueryBallIterator::next()
                         // Check ii exclusion before including the pair.
                         if (r_sq < r_max_sq && r_sq >= r_min_sq)
                         {
-                            return NeighborBond(m_query_point_idx, j, sqrt(r_sq));
+                            return NeighborBond(m_query_point_idx, j, std::sqrt(r_sq));
                         }
                     }
                 }

--- a/cpp/locality/LinkCell.cc
+++ b/cpp/locality/LinkCell.cc
@@ -510,7 +510,7 @@ NeighborBond LinkCellQueryBallIterator::next()
 
             if (r_sq < r_max_sq && r_sq >= r_min_sq)
             {
-                return NeighborBond(m_query_point_idx, j, sqrt(r_sq));
+                return NeighborBond(m_query_point_idx, j, std::sqrt(r_sq));
             }
         }
 
@@ -594,7 +594,7 @@ NeighborBond LinkCellQueryIterator::next()
                     const vec3<float> r_ij(m_neighbor_query->getBox().wrap((*m_linkcell)[j] - m_query_point));
                     const float r_sq(dot(r_ij, r_ij));
                     if (r_sq < r_max_sq && r_sq >= r_min_sq)
-                        m_current_neighbors.emplace_back(m_query_point_idx, j, sqrt(r_sq));
+                        m_current_neighbors.emplace_back(m_query_point_idx, j, std::sqrt(r_sq));
                 }
             }
 

--- a/cpp/locality/Voronoi.cc
+++ b/cpp/locality/Voronoi.cc
@@ -118,7 +118,7 @@ void Voronoi::compute(const freud::locality::NeighborQuery* nq)
 
             // Save polytope vertices in system coordinates
             std::vector<vec3<double>> system_vertices;
-            vec3<double> query_point_system_coords((*nq)[query_point_id]);
+            const vec3<double> query_point_system_coords((*nq)[query_point_id]);
             for (auto vertex_iter = relative_vertices.begin(); vertex_iter != relative_vertices.end();
                  vertex_iter++)
             {
@@ -131,25 +131,24 @@ void Voronoi::compute(const freud::locality::NeighborQuery* nq)
 
             size_t neighbor_counter(0);
             for (auto neighbor_iterator = neighbors.begin(); neighbor_iterator != neighbors.end();
-                 neighbor_iterator++)
+                 neighbor_iterator++, neighbor_counter++)
             {
-                const int point_id = *neighbor_iterator;
-                const float weight(face_areas[neighbor_counter]);
-
                 // Get the normal to the current face
                 const vec3<double> normal(normals[3 * neighbor_counter], normals[3 * neighbor_counter + 1],
                                           normals[3 * neighbor_counter + 2]);
 
-                // Compute the distance from query_point to point.
-                vec3<double> point_system_coords((*nq)[point_id]);
-                const vec3<float> rij = box.wrap(point_system_coords - query_point_system_coords);
-                const float distance(std::sqrt(dot(rij, rij)));
-
-                neighbor_counter++;
-
                 // Ignore bonds in 2D systems that point up or down
                 if (box.is2D() && std::abs(normal.z) > 0)
                     continue;
+
+                // Fetch neighbor information
+                const int point_id = *neighbor_iterator;
+                const float weight(face_areas[neighbor_counter]);
+                const vec3<double> point_system_coords((*nq)[point_id]);
+
+                // Compute the distance from query_point to point.
+                const vec3<float> rij = box.wrap(point_system_coords - query_point_system_coords);
+                const float distance(std::sqrt(dot(rij, rij)));
 
                 bonds.push_back(NeighborBond(query_point_id, point_id, distance, weight));
             }

--- a/cpp/order/Cubatic.cc
+++ b/cpp/order/Cubatic.cc
@@ -171,7 +171,7 @@ template<typename T> quat<float> Cubatic::calcRandomQuaternion(T& dist, float an
     float theta = 2.0 * M_PI * dist();
     float phi = acos(2.0 * dist() - 1.0);
     vec3<float> axis = vec3<float>(cosf(theta) * sinf(phi), sinf(theta) * sinf(phi), cosf(phi));
-    float axis_norm = sqrt(dot(axis, axis));
+    float axis_norm = std::sqrt(dot(axis, axis));
     axis /= axis_norm;
     float angle = angle_multiplier * dist();
     return quat<float>::fromAxisAngle(axis, angle);

--- a/cpp/util/VectorMath.h
+++ b/cpp/util/VectorMath.h
@@ -783,25 +783,25 @@ template<class Real> inline quat<Real>::quat(const rotmat3<Real>& r)
 
     if (tr > Real(0.0))
     {
-        Real S = sqrt(tr + Real(1.0)) * Real(2.0);
+        Real S = std::sqrt(tr + Real(1.0)) * Real(2.0);
         s = Real(0.25) * S;
         v = vec3<Real>((r.row2.y - r.row1.z) / S, (r.row0.z - r.row2.x) / S, (r.row1.x - r.row0.y) / S);
     }
     else if ((r.row0.x > r.row1.y) && (r.row0.x > r.row2.z))
     {
-        Real S = sqrt(Real(1.0) + r.row0.x - r.row1.y - r.row2.z) * Real(2.0);
+        Real S = std::sqrt(Real(1.0) + r.row0.x - r.row1.y - r.row2.z) * Real(2.0);
         s = (r.row2.y - r.row1.z) / S;
         v = vec3<Real>(Real(0.25) * S, (r.row0.y + r.row1.x) / S, (r.row0.z + r.row2.x) / S);
     }
     else if (r.row1.y > r.row2.z)
     {
-        Real S = sqrt(Real(1.0) + r.row1.y - r.row0.x - r.row2.z) * Real(2.0);
+        Real S = std::sqrt(Real(1.0) + r.row1.y - r.row0.x - r.row2.z) * Real(2.0);
         s = (r.row0.z - r.row2.x) / S;
         v = vec3<Real>((r.row0.y + r.row1.x) / S, Real(0.25) * S, (r.row1.z + r.row2.y) / S);
     }
     else
     {
-        Real S = sqrt(Real(1.0) + r.row2.z - r.row0.x - r.row1.y) * Real(2.0);
+        Real S = std::sqrt(Real(1.0) + r.row2.z - r.row0.x - r.row1.y) * Real(2.0);
         s = (r.row1.x - r.row0.y) / S;
         v = vec3<Real>((r.row0.z + r.row2.x) / S, (r.row1.z + r.row2.y) / S, Real(0.25) * S);
     }

--- a/doc/source/reference/credits.rst
+++ b/doc/source/reference/credits.rst
@@ -97,6 +97,7 @@ Bradley Dice - **Lead developer**
 * Implemented periodic center of mass computations in C++.
 * Revised docs about query modes.
 * Implemented smarter heuristics in Voronoi for voro++ block sizes, resulting in significant performance gains for large systems.
+* Corrected calculation of neighbor distances in the Voronoi NeighborList.
 
 Eric Harper, University of Michigan - **Former lead developer**
 

--- a/requirements-testing.txt
+++ b/requirements-testing.txt
@@ -2,7 +2,7 @@ coverage==4.5.4
 cython==0.29.13
 garnett==0.5.0
 GitPython==3.0.2
-gsd==1.9.2
+gsd==1.10.0
 matplotlib>=3.0.0
 MDAnalysis==0.20.1
 numpy==1.17.2

--- a/tests/test_locality_Voronoi.py
+++ b/tests/test_locality_Voronoi.py
@@ -15,9 +15,16 @@ class TestVoronoi(unittest.TestCase):
         vor = freud.locality.Voronoi()
         vor.compute((box, points))
 
+        # Verify the polytopes and volumes
         npt.assert_equal(len(vor.polytopes), len(points))
         npt.assert_equal(len(vor.volumes), len(points))
         npt.assert_almost_equal(np.sum(vor.volumes), box.volume)
+
+        # Verify the neighbor distances
+        wrapped_distances = np.linalg.norm(box.wrap(
+            points[vor.nlist.point_indices] -
+            points[vor.nlist.query_point_indices]), axis=-1)
+        npt.assert_allclose(wrapped_distances, vor.nlist.distances)
 
     def test_basic_3d(self):
         # Test that voronoi tessellations of random systems have the same
@@ -28,9 +35,16 @@ class TestVoronoi(unittest.TestCase):
         vor = freud.locality.Voronoi()
         vor.compute((box, points))
 
+        # Verify the polytopes and volumes
         npt.assert_equal(len(vor.polytopes), len(points))
         npt.assert_equal(len(vor.volumes), len(points))
         npt.assert_almost_equal(np.sum(vor.volumes), box.volume)
+
+        # Verify the neighbor distances
+        wrapped_distances = np.linalg.norm(box.wrap(
+            points[vor.nlist.point_indices] -
+            points[vor.nlist.query_point_indices]), axis=-1)
+        npt.assert_allclose(wrapped_distances, vor.nlist.distances)
 
     def test_voronoi_tess_2d(self):
         # Test that the voronoi polytope works for a 2D system
@@ -56,6 +70,12 @@ class TestVoronoi(unittest.TestCase):
         npt.assert_almost_equal(
             vor.nlist.weights[vor.nlist.query_point_indices == 4], 1)
 
+        # Verify the neighbor distances
+        wrapped_distances = np.linalg.norm(box.wrap(
+            points[vor.nlist.point_indices] -
+            points[vor.nlist.query_point_indices]), axis=-1)
+        npt.assert_allclose(wrapped_distances, vor.nlist.distances)
+
         # Double the points (still inside the box) and test again
         points *= 2
         vor.compute((box, points))
@@ -67,6 +87,12 @@ class TestVoronoi(unittest.TestCase):
         npt.assert_almost_equal(np.sum(vor.volumes), box.volume)
         npt.assert_almost_equal(
             vor.nlist.weights[vor.nlist.query_point_indices == 4], 2)
+
+        # Verify the neighbor distances
+        wrapped_distances = np.linalg.norm(box.wrap(
+            points[vor.nlist.point_indices] -
+            points[vor.nlist.query_point_indices]), axis=-1)
+        npt.assert_allclose(wrapped_distances, vor.nlist.distances)
 
     def test_voronoi_tess_3d(self):
         # Test that the voronoi polytope works for a 3D system
@@ -101,6 +127,12 @@ class TestVoronoi(unittest.TestCase):
         npt.assert_almost_equal(
             vor.nlist.weights[vor.nlist.query_point_indices == 13], 1)
 
+        # Verify the neighbor distances
+        wrapped_distances = np.linalg.norm(box.wrap(
+            points[vor.nlist.point_indices] -
+            points[vor.nlist.query_point_indices]), axis=-1)
+        npt.assert_allclose(wrapped_distances, vor.nlist.distances)
+
         # Double the points (still inside the box) and test again
         points *= 2
         vor.compute((box, points))
@@ -114,6 +146,12 @@ class TestVoronoi(unittest.TestCase):
         npt.assert_almost_equal(np.sum(vor.volumes), box.volume)
         npt.assert_almost_equal(
             vor.nlist.weights[vor.nlist.query_point_indices == 13], 4)
+
+        # Verify the neighbor distances
+        wrapped_distances = np.linalg.norm(box.wrap(
+            points[vor.nlist.point_indices] -
+            points[vor.nlist.query_point_indices]), axis=-1)
+        npt.assert_allclose(wrapped_distances, vor.nlist.distances)
 
     def test_voronoi_neighbors_wrapped(self):
         # Test that voronoi neighbors in the first shell are correct for a
@@ -138,9 +176,15 @@ class TestVoronoi(unittest.TestCase):
             unique_indices, counts = np.unique(nlist.query_point_indices,
                                                return_counts=True)
 
-            # Every particle should have six neighbors
+            # Every particle should have the specified number of neighbors
             npt.assert_equal(counts, neighbors)
             npt.assert_almost_equal(np.sum(vor.volumes), box.volume)
+
+            # Verify the neighbor distances
+            wrapped_distances = np.linalg.norm(box.wrap(
+                points[vor.nlist.point_indices] -
+                points[vor.nlist.query_point_indices]), axis=-1)
+            npt.assert_allclose(wrapped_distances, vor.nlist.distances)
 
     def test_voronoi_weights_fcc(self):
         # Test that voronoi neighbor weights are computed properly for 3D FCC
@@ -168,6 +212,12 @@ class TestVoronoi(unittest.TestCase):
         npt.assert_allclose(vor.compute((box, points)).volumes,
                             np.full(len(vor.polytopes), 2.),
                             atol=1e-5)
+
+        # Verify the neighbor distances
+        wrapped_distances = np.linalg.norm(box.wrap(
+            points[vor.nlist.point_indices] -
+            points[vor.nlist.query_point_indices]), axis=-1)
+        npt.assert_allclose(wrapped_distances, vor.nlist.distances)
 
     def test_nlist_symmetric(self):
         # Test that the voronoi neighborlist is symmetric


### PR DESCRIPTION
## Description
It appears that distance calculations in the Voronoi neighborlist were not always correct. This PR rewrites that logic to compute distances based on the wrapped interparticle vector.

## Motivation and Context
Resolves an issue found by @klywang.

## How Has This Been Tested?
Added tests for Voronoi NeighborList distances.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds or improves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!-- Put an `x` in all the boxes that apply. If you're unsure about any of
     these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/glotzerlab/freud/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] I have updated the documentation (if relevant).
- [x] I have added tests that cover my changes (if relevant).
- [x] All new and existing tests passed.
- [x] I have updated the [credits](https://github.com/glotzerlab/freud/blob/master/doc/source/reference/credits.rst).
- [x] I have updated the [Changelog](https://github.com/glotzerlab/freud/blob/master/ChangeLog.md).
