### PR TITLE
Minor refactors for v2.2.

### DIFF
--- a/cpp/box/Box.h
+++ b/cpp/box/Box.h
@@ -41,8 +41,8 @@ namespace freud { namespace box {
 class Box
 {
 public:
-    //! Construct a box of length 0.
-    Box() // Lest you think of removing this, it's needed by the DCDLoader. No touching.
+    //! Nullary constructor for Cython
+    Box()
     {
         m_2d = false; // Assign before calling setL!
         setL(0, 0, 0);
@@ -50,7 +50,7 @@ public:
         m_xy = m_xz = m_yz = 0;
     }
 
-    //! Construct a cubic box
+    //! Construct a square/cubic box
     Box(float L, bool _2d = false)
     {
         m_2d = _2d; // Assign before calling setL!
@@ -427,7 +427,6 @@ public:
     //! Set the periodic flags
     /*! \param periodic Flags to set
      *  \post Period flags are set to \a periodic
-     *  \note It is invalid to set 1 for a periodic dimension where lo != -hi. This error is not checked for.
      */
     void setPeriodic(vec3<bool> periodic)
     {

--- a/cpp/box/Box.h
+++ b/cpp/box/Box.h
@@ -296,24 +296,11 @@ public:
      */
     vec3<float> wrap(const vec3<float>& v) const
     {
-        vec3<float> tmp = makeFractional(v);
-        tmp.x = fmod(tmp.x, 1.0f);
-        tmp.y = fmod(tmp.y, 1.0f);
-        tmp.z = fmod(tmp.z, 1.0f);
-        // handle negative mod
-        if (tmp.x < 0)
-        {
-            tmp.x += 1;
-        }
-        if (tmp.y < 0)
-        {
-            tmp.y += 1;
-        }
-        if (tmp.z < 0)
-        {
-            tmp.z += 1;
-        }
-        return makeAbsolute(tmp);
+        vec3<float> v_frac = makeFractional(v);
+        v_frac.x = util::modulusPositive(v_frac.x, 1.0f);
+        v_frac.y = util::modulusPositive(v_frac.y, 1.0f);
+        v_frac.z = util::modulusPositive(v_frac.z, 1.0f);
+        return makeAbsolute(v_frac);
     }
 
     //! Wrap vectors back into the box in place
@@ -379,7 +366,7 @@ public:
     }
 
     //! Subtract center of mass from vectors
-    /*! \param vecs Vectors to center, updated to the minimum image obeying the periodic settings
+    /*! \param vecs Vectors to center
      *  \param Nvecs Number of vectors
      *  \param masses Optional array of masses, of length Nvecs
      */

--- a/cpp/density/GaussianDensity.cc
+++ b/cpp/density/GaussianDensity.cc
@@ -105,11 +105,11 @@ void GaussianDensity::compute(const freud::locality::NeighborQuery* nq)
                         {
                             // Evaluate the gaussian ...
                             const float x_gaussian
-                                = A * exp((-1.0f) * (delta.x * delta.x) / (2.0f * sigmasq));
+                                = A * std::exp((-1.0f) * (delta.x * delta.x) / (2.0f * sigmasq));
                             const float y_gaussian
-                                = A * exp((-1.0f) * (delta.y * delta.y) / (2.0f * sigmasq));
+                                = A * std::exp((-1.0f) * (delta.y * delta.y) / (2.0f * sigmasq));
                             const float z_gaussian
-                                = A * exp((-1.0f) * (delta.z * delta.z) / (2.0f * sigmasq));
+                                = A * std::exp((-1.0f) * (delta.z * delta.z) / (2.0f * sigmasq));
 
                             // Assure that out of range indices are corrected for storage
                             // in the array i.e. bin -1 is actually bin 29 for nbins = 30

--- a/cpp/environment/AngularSeparation.cc
+++ b/cpp/environment/AngularSeparation.cc
@@ -19,7 +19,7 @@ namespace freud { namespace environment {
 float computeSeparationAngle(const quat<float> ref_q, const quat<float> q)
 {
     quat<float> R = q * conj(ref_q);
-    float theta = float(2.0 * acos(util::clamp(R.s, -1, 1)));
+    float theta = float(2.0 * std::acos(util::clamp(R.s, -1, 1)));
     return theta;
 }
 

--- a/cpp/environment/BondOrder.cc
+++ b/cpp/environment/BondOrder.cc
@@ -44,7 +44,7 @@ BondOrder::BondOrder(unsigned int n_bins_theta, unsigned int n_bins_phi, BondOrd
         for (unsigned int j = 0; j < n_bins_phi; j++)
         {
             float phi = (float) j * dp;
-            float sa = dt * (cos(phi) - cos(phi + dp));
+            float sa = dt * (std::cos(phi) - std::cos(phi + dp));
             m_sa_array(i, j) = sa;
         }
     }

--- a/cpp/environment/BondOrder.cc
+++ b/cpp/environment/BondOrder.cc
@@ -111,12 +111,7 @@ void BondOrder::accumulate(const locality::NeighborQuery* neighbor_query, quat<f
                           // most physics textbooks do it. get theta (azimuthal angle), phi (polar
                           // angle)
                           float theta = std::atan2(v.y, v.x); //-Pi..Pi
-
-                          theta = fmod(theta, constants::TWO_PI);
-                          while (theta < 0)
-                          {
-                              theta += constants::TWO_PI;
-                          }
+                          theta = modulusPositive(theta, constants::TWO_PI);
 
                           // NOTE that the below has replaced the commented out expression for phi.
                           float phi = std::acos(v.z / std::sqrt(dot(v, v))); // 0..Pi

--- a/cpp/environment/BondOrder.cc
+++ b/cpp/environment/BondOrder.cc
@@ -111,7 +111,7 @@ void BondOrder::accumulate(const locality::NeighborQuery* neighbor_query, quat<f
                           // most physics textbooks do it. get theta (azimuthal angle), phi (polar
                           // angle)
                           float theta = std::atan2(v.y, v.x); //-Pi..Pi
-                          theta = modulusPositive(theta, constants::TWO_PI);
+                          theta = util::modulusPositive(theta, constants::TWO_PI);
 
                           // NOTE that the below has replaced the commented out expression for phi.
                           float phi = std::acos(v.z / std::sqrt(dot(v, v))); // 0..Pi

--- a/cpp/environment/LocalDescriptors.cc
+++ b/cpp/environment/LocalDescriptors.cc
@@ -112,10 +112,10 @@ void LocalDescriptors::compute(const locality::NeighborQuery* nq, const vec3<flo
                                           dot(rotation_2, r_ij));
 
                 const float magR(std::sqrt(r_sq));
-                float theta(atan2(bond_ij.y, bond_ij.x)); // theta in [-pi..pi] initially
+                float theta(std::atan2(bond_ij.y, bond_ij.x)); // theta in [-pi..pi] initially
                 if (theta < 0)
                     theta += float(2 * M_PI);      // move theta into [0..2*pi]
-                float phi(acos(bond_ij.z / magR)); // phi in [0..pi]
+                float phi(std::acos(bond_ij.z / magR)); // phi in [0..pi]
 
                 // catch cases where bond_ij.z/magR falls outside [-1, 1]
                 // due to numerical issues

--- a/cpp/locality/LinkCell.cc
+++ b/cpp/locality/LinkCell.cc
@@ -349,11 +349,11 @@ vec3<unsigned int> LinkCell::getCellCoord(const vec3<float> p) const
 {
     vec3<float> alpha = m_box.makeFractional(p);
     vec3<unsigned int> c;
-    c.x = (unsigned int) floorf(alpha.x * float(m_celldim.x));
+    c.x = (unsigned int) std::floor(alpha.x * float(m_celldim.x));
     c.x %= m_celldim.x;
-    c.y = (unsigned int) floorf(alpha.y * float(m_celldim.y));
+    c.y = (unsigned int) std::floor(alpha.y * float(m_celldim.y));
     c.y %= m_celldim.y;
-    c.z = (unsigned int) floorf(alpha.z * float(m_celldim.z));
+    c.z = (unsigned int) std::floor(alpha.z * float(m_celldim.z));
     c.z %= m_celldim.z;
     return c;
 }
@@ -564,7 +564,7 @@ NeighborBond LinkCellQueryIterator::next()
     {
         min_plane_distance = std::min(min_plane_distance, plane_distance.z);
     }
-    unsigned int max_range = ceil(min_plane_distance / (2 * m_linkcell->getCellWidth())) + 1;
+    unsigned int max_range = std::ceil(min_plane_distance / (2 * m_linkcell->getCellWidth())) + 1;
 
     vec3<unsigned int> point_cell(m_linkcell->getCellCoord(m_query_point));
     const unsigned int point_cell_index = m_linkcell->getCellIndex(

--- a/cpp/locality/LinkCell.h
+++ b/cpp/locality/LinkCell.h
@@ -242,9 +242,6 @@ public:
     querySingle(const vec3<float> query_point, unsigned int query_point_idx, QueryArgs args) const;
 
 private:
-    //! Rounding helper function.
-    static unsigned int roundDown(unsigned int v, unsigned int m);
-
     //! Helper function to compute cell neighbors
     const std::vector<unsigned int>& computeCellNeighbors(unsigned int cell) const;
 

--- a/cpp/locality/LinkCell.h
+++ b/cpp/locality/LinkCell.h
@@ -159,7 +159,7 @@ private:
 
  *  The cell coordinate (i,j,k) itself is computed like so:
  *  \code
- *  i = floorf((x + Lx/2) / w) % Nw
+ *  i = std::floor((x + Lx/2) / w) % Nw
  *  \endcode
  *  and so on for j, k (y, z). Call getCellCoord() to do this computation for
  *  an arbitrary point.

--- a/cpp/locality/PeriodicBuffer.cc
+++ b/cpp/locality/PeriodicBuffer.cc
@@ -32,13 +32,13 @@ void PeriodicBuffer::compute(const freud::locality::NeighborQuery* neighbor_quer
 
     if (use_images)
     {
-        images = vec3<int>(ceil(buff.x), ceil(buff.y), ceil(buff.z));
+        images = vec3<int>(std::ceil(buff.x), std::ceil(buff.y), std::ceil(buff.z));
         m_buffer_box = freud::box::Box((1 + images.x) * L.x, (1 + images.y) * L.y, (1 + images.z) * L.z, xy,
                                        xz, yz, is2D);
     }
     else
     {
-        images = vec3<int>(ceil(buff.x / L.x), ceil(buff.y / L.y), ceil(buff.z / L.z));
+        images = vec3<int>(std::ceil(buff.x / L.x), std::ceil(buff.y / L.y), std::ceil(buff.z / L.z));
         m_buffer_box
             = freud::box::Box(L.x + 2 * buff.x, L.y + 2 * buff.y, L.z + 2 * buff.z, xy, xz, yz, is2D);
     }

--- a/cpp/order/Cubatic.cc
+++ b/cpp/order/Cubatic.cc
@@ -169,8 +169,8 @@ float Cubatic::calcCubaticOrderParameter(const tensor4& cubatic_tensor, const te
 template<typename T> quat<float> Cubatic::calcRandomQuaternion(T& dist, float angle_multiplier) const
 {
     float theta = 2.0 * M_PI * dist();
-    float phi = acos(2.0 * dist() - 1.0);
-    vec3<float> axis = vec3<float>(cosf(theta) * sinf(phi), sinf(theta) * sinf(phi), cosf(phi));
+    float phi = std::acos(2.0 * dist() - 1.0);
+    vec3<float> axis = vec3<float>(std::cos(theta) * std::sin(phi), std::sin(theta) * std::sin(phi), std::cos(phi));
     float axis_norm = std::sqrt(dot(axis, axis));
     axis /= axis_norm;
     float angle = angle_multiplier * dist();

--- a/cpp/order/Cubatic.cc
+++ b/cpp/order/Cubatic.cc
@@ -296,7 +296,7 @@ void Cubatic::compute(quat<float>* orientations, unsigned int num_orientations)
                                   else
                                   {
                                       float boltzmann_factor
-                                          = exp(-(cubatic_order_parameter - new_order_parameter) / t_current);
+                                          = std::exp(-(cubatic_order_parameter - new_order_parameter) / t_current);
                                       if (boltzmann_factor >= dist())
                                       {
                                           cubatic_tensor = new_cubatic_tensor;

--- a/cpp/order/HexaticTranslational.cc
+++ b/cpp/order/HexaticTranslational.cc
@@ -46,8 +46,8 @@ void Hexatic::compute(const freud::locality::NeighborList* nlist,
 {
     computeGeneral(
         [this](const vec3<float>& delta) {
-            const float psi_ij = atan2f(delta.y, delta.x);
-            return exp(std::complex<float>(0, m_k * psi_ij));
+            const float psi_ij = std::atan2(delta.y, delta.x);
+            return std::exp(std::complex<float>(0, m_k * psi_ij));
         },
         nlist, points, qargs);
 }

--- a/cpp/pmft/PMFTR12.cc
+++ b/cpp/pmft/PMFTR12.cc
@@ -72,16 +72,8 @@ void PMFTR12::accumulate(const locality::NeighborQuery* neighbor_query, float* o
                           float t1 = orientations[neighbor_bond.point_idx] - d_theta1;
                           float t2 = query_orientations[neighbor_bond.query_point_idx] - d_theta2;
                           // make sure that t1, t2 are bounded between 0 and 2PI
-                          t1 = fmod(t1, constants::TWO_PI);
-                          if (t1 < 0)
-                          {
-                              t1 += constants::TWO_PI;
-                          }
-                          t2 = fmod(t2, constants::TWO_PI);
-                          if (t2 < 0)
-                          {
-                              t2 += constants::TWO_PI;
-                          }
+                          t1 = modulusPositive(t1, constants::TWO_PI);
+                          t2 = modulusPositive(t2, constants::TWO_PI);
                           m_local_histograms(neighbor_bond.distance, t1, t2);
                       });
 }

--- a/cpp/pmft/PMFTR12.cc
+++ b/cpp/pmft/PMFTR12.cc
@@ -67,8 +67,8 @@ void PMFTR12::accumulate(const locality::NeighborQuery* neighbor_query, float* o
                       [=](const freud::locality::NeighborBond& neighbor_bond) {
                           vec3<float> delta(bondVector(neighbor_bond, neighbor_query, query_points));
                           // calculate angles
-                          float d_theta1 = atan2(delta.y, delta.x);
-                          float d_theta2 = atan2(-delta.y, -delta.x);
+                          float d_theta1 = std::atan2(delta.y, delta.x);
+                          float d_theta2 = std::atan2(-delta.y, -delta.x);
                           float t1 = orientations[neighbor_bond.point_idx] - d_theta1;
                           float t2 = query_orientations[neighbor_bond.query_point_idx] - d_theta2;
                           // make sure that t1, t2 are bounded between 0 and 2PI

--- a/cpp/pmft/PMFTR12.cc
+++ b/cpp/pmft/PMFTR12.cc
@@ -4,6 +4,7 @@
 #include <stdexcept>
 
 #include "PMFTR12.h"
+#include "utils.h"
 
 /*! \file PMFTR12.cc
     \brief Routines for computing potential of mean force and torque in R12 coordinates
@@ -72,8 +73,8 @@ void PMFTR12::accumulate(const locality::NeighborQuery* neighbor_query, float* o
                           float t1 = orientations[neighbor_bond.point_idx] - d_theta1;
                           float t2 = query_orientations[neighbor_bond.query_point_idx] - d_theta2;
                           // make sure that t1, t2 are bounded between 0 and 2PI
-                          t1 = modulusPositive(t1, constants::TWO_PI);
-                          t2 = modulusPositive(t2, constants::TWO_PI);
+                          t1 = util::modulusPositive(t1, constants::TWO_PI);
+                          t2 = util::modulusPositive(t2, constants::TWO_PI);
                           m_local_histograms(neighbor_bond.distance, t1, t2);
                       });
 }

--- a/cpp/pmft/PMFTXYT.cc
+++ b/cpp/pmft/PMFTXYT.cc
@@ -62,7 +62,7 @@ void PMFTXYT::accumulate(const locality::NeighborQuery* neighbor_query, float* o
                               = rotmat2<float>::fromAngle(-orientations[neighbor_bond.point_idx]);
                           vec2<float> rotVec = myMat * myVec;
                           // calculate angle
-                          float d_theta = atan2(-delta.y, -delta.x);
+                          float d_theta = std::atan2(-delta.y, -delta.x);
                           float t = query_orientations[neighbor_bond.query_point_idx] - d_theta;
                           // make sure that t is bounded between 0 and 2PI
                           t = fmod(t, constants::TWO_PI);

--- a/cpp/pmft/PMFTXYT.cc
+++ b/cpp/pmft/PMFTXYT.cc
@@ -1,8 +1,10 @@
 // Copyright (c) 2010-2019 The Regents of the University of Michigan
 // This file is from the freud project, released under the BSD 3-Clause License.
 
-#include "PMFTXYT.h"
 #include <stdexcept>
+
+#include "PMFTXYT.h"
+#include "utils.h"
 
 /*! \file PMFTXYT.cc
     \brief Routines for computing potential of mean force and torque in XYT coordinates
@@ -65,7 +67,7 @@ void PMFTXYT::accumulate(const locality::NeighborQuery* neighbor_query, float* o
                           float d_theta = std::atan2(-delta.y, -delta.x);
                           float t = query_orientations[neighbor_bond.query_point_idx] - d_theta;
                           // make sure that t is bounded between 0 and 2PI
-                          t = modulusPositive(t, constants::TWO_PI);
+                          t = util::modulusPositive(t, constants::TWO_PI);
                           m_local_histograms(rotVec.x, rotVec.y, t);
                       });
 }

--- a/cpp/pmft/PMFTXYT.cc
+++ b/cpp/pmft/PMFTXYT.cc
@@ -65,12 +65,7 @@ void PMFTXYT::accumulate(const locality::NeighborQuery* neighbor_query, float* o
                           float d_theta = std::atan2(-delta.y, -delta.x);
                           float t = query_orientations[neighbor_bond.query_point_idx] - d_theta;
                           // make sure that t is bounded between 0 and 2PI
-                          t = fmod(t, constants::TWO_PI);
-                          if (t < 0)
-                          {
-                              t += constants::TWO_PI;
-                          }
-
+                          t = modulusPositive(t, constants::TWO_PI);
                           m_local_histograms(rotVec.x, rotVec.y, t);
                       });
 }

--- a/cpp/util/utils.h
+++ b/cpp/util/utils.h
@@ -17,6 +17,17 @@ inline float clamp(float v, float lo, float hi)
     return std::max(lo, std::min(v, hi));
 }
 
+//! Modulus operation always resulting in a positive value
+/*! \param a dividend
+    \param b divisor
+    \returns the remainder of a/b, between min(0, b) and max(0, b)
+    \note This is the same behavior of the modulus operator % in Python (but not C++)
+*/
+template<class Scalar> inline Scalar modulusPositive(Scalar a, Scalar b)
+{
+    return std::fmod(std::fmod(a, b) + b, b);
+}
+
 //! Wrapper for for-loop to allow the execution in parallel or not.
 /*! \param parallel If true, run body in parallel.
  *  \param begin Beginning index.

--- a/cpp/util/utils.h
+++ b/cpp/util/utils.h
@@ -2,6 +2,7 @@
 #define UTILS_H
 
 #include <algorithm>
+#include <cmath>
 #include <tbb/tbb.h>
 
 #if defined _WIN32
@@ -18,9 +19,9 @@ inline float clamp(float v, float lo, float hi)
 }
 
 //! Modulus operation always resulting in a positive value
-/*! \param a dividend
-    \param b divisor
-    \returns the remainder of a/b, between min(0, b) and max(0, b)
+/*! \param a Dividend.
+    \param b Divisor.
+    \returns The remainder of a/b, between min(0, b) and max(0, b)
     \note This is the same behavior of the modulus operator % in Python (but not C++)
 */
 template<class Scalar> inline Scalar modulusPositive(Scalar a, Scalar b)

--- a/freud/box.pyx
+++ b/freud/box.pyx
@@ -733,6 +733,10 @@ cdef class Box:
 
 
 cdef BoxFromCPP(const freud._box.Box & cppbox):
-    return Box(cppbox.getLx(), cppbox.getLy(), cppbox.getLz(),
-               cppbox.getTiltFactorXY(), cppbox.getTiltFactorXZ(),
-               cppbox.getTiltFactorYZ(), cppbox.is2D())
+    b = Box(cppbox.getLx(), cppbox.getLy(), cppbox.getLz(),
+            cppbox.getTiltFactorXY(), cppbox.getTiltFactorXZ(),
+            cppbox.getTiltFactorYZ(), cppbox.is2D())
+    b.periodic = [cppbox.getPeriodicX(),
+                  cppbox.getPeriodicY(),
+                  cppbox.getPeriodicZ()]
+    return b

--- a/freud/box.pyx
+++ b/freud/box.pyx
@@ -14,13 +14,10 @@ import logging
 import freud.util
 
 from freud.util cimport vec3
-from cython.operator cimport dereference
 from cpython.object cimport Py_EQ, Py_NE
-from freud.util cimport _Compute
 
 cimport freud._box
 cimport numpy as np
-cimport freud.locality
 
 logger = logging.getLogger(__name__)
 

--- a/freud/cluster.pyx
+++ b/freud/cluster.pyx
@@ -14,12 +14,10 @@ import freud.util
 from cython.operator cimport dereference
 from freud.util cimport _Compute
 from freud.locality cimport _PairCompute
-from freud.util cimport vec3, uint
 
 cimport freud._cluster
-cimport freud.box, freud.locality
+cimport freud.locality
 cimport freud.util
-
 cimport numpy as np
 
 # numpy must be initialized. When using numpy from C or Cython you must

--- a/freud/density.pyx
+++ b/freud/density.pyx
@@ -19,9 +19,10 @@ from freud.util cimport vec3
 from collections.abc import Sequence
 
 cimport freud._density
-cimport freud.box, freud.locality
-cimport numpy as np
+cimport freud.box
+cimport freud.locality
 cimport freud.util
+cimport numpy as np
 
 # numpy must be initialized. When using numpy from C or Cython you must
 # _always_ do that, or you will have segfaults

--- a/freud/environment.pyx
+++ b/freud/environment.pyx
@@ -16,14 +16,13 @@ from freud.errors import NO_DEFAULT_QUERY_ARGS_MESSAGE
 from freud.util cimport _Compute
 from freud.locality cimport _PairCompute, _SpatialHistogram
 from freud.util cimport vec3, quat
-from libcpp.vector cimport vector
 from libcpp.map cimport map
 from cython.operator cimport dereference
+
 cimport freud.box
 cimport freud._environment
 cimport freud.locality
 cimport freud.util
-
 cimport numpy as np
 
 # numpy must be initialized. When using numpy from C or Cython you must

--- a/freud/interface.pyx
+++ b/freud/interface.pyx
@@ -10,13 +10,9 @@ import numpy as np
 
 from freud.util cimport _Compute
 from freud.locality cimport _PairCompute
-from freud.util cimport vec3
-from cython.operator cimport dereference
 import freud.locality
 
 cimport freud.locality
-cimport freud.box
-
 cimport numpy as np
 
 # numpy must be initialized. When using numpy from C or Cython you must

--- a/freud/locality.pyx
+++ b/freud/locality.pyx
@@ -8,11 +8,8 @@ locate points based on their proximity to other points.
 import copy
 import freud.util
 import inspect
-import itertools
 import logging
 import numpy as np
-import sys
-import warnings
 from freud.errors import NO_DEFAULT_QUERY_ARGS_MESSAGE
 
 from libcpp cimport bool as cbool

--- a/freud/order.pyx
+++ b/freud/order.pyx
@@ -10,7 +10,6 @@ harmonics of the bond order diagram, which are the spherical analogue of
 Fourier Transforms.
 """
 
-import warnings
 import numpy as np
 import time
 import freud.locality
@@ -23,9 +22,7 @@ from cython.operator cimport dereference
 
 cimport freud._order
 cimport freud.locality
-cimport freud.box
 cimport freud.util
-
 cimport numpy as np
 
 logger = logging.getLogger(__name__)

--- a/freud/pmft.pyx
+++ b/freud/pmft.pyx
@@ -40,7 +40,6 @@ refer to the supplementary information of :cite:`vanAnders:2014aa`.
 
 import numpy as np
 import freud.locality
-import warnings
 import rowan
 
 from freud.util cimport _Compute
@@ -50,7 +49,6 @@ from cython.operator cimport dereference
 
 cimport freud._pmft
 cimport freud.locality
-cimport freud.box
 
 cimport numpy as np
 

--- a/freud/util.pyx
+++ b/freud/util.pyx
@@ -11,7 +11,6 @@ from cython.operator cimport dereference
 from libcpp.vector cimport vector
 
 cimport numpy as np
-cimport freud.box
 
 # numpy must be initialized. When using numpy from C or Cython you must
 # _always_ do that, or you will have segfaults


### PR DESCRIPTION
## Description
This is a minor cleanup of several parts of freud that I've put on the back burner for a while.

- All cmath functions are now called via `std::func()` instead of `func()` for clarity (and to ensure we get the right function).
- I added a `util::modulusPositive` method to reduce the many instances of modular division followed by conditionally adding the divisor back if the result is negative.
- Python boxes created from C++ objects will now retain their periodic flags. Even though those flags don't do anything yet, the flags were lost when passing through C++ and back to Python.
- Unused imports were removed from Cython files. This should speed up builds a bit, by cutting out unused interdependence between Cython modules.

## Motivation and Context
Cleanup of existing code.

## How Has This Been Tested?
Existing tests pass.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds or improves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have read the [**CONTRIBUTING**](https://github.com/glotzerlab/freud/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] I have updated the documentation (if relevant).
- [x] I have added tests that cover my changes (if relevant).
- [x] All new and existing tests passed.
- [ ] I have updated the [credits](https://github.com/glotzerlab/freud/blob/master/doc/source/reference/credits.rst).
- [ ] I have updated the [Changelog](https://github.com/glotzerlab/freud/blob/master/ChangeLog.md).
