### PR TITLE
Add a finite tolerance for 2D Voronoi computations.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -12,6 +12,7 @@ and this project adheres to
 
 ### Fixed
 * Corrected calculation of neighbor distances in the Voronoi NeighborList.
+* Added finite tolerance to ensure stability of 2D Voronoi NeighborList computations.
 
 ## v2.1.0 - 2019-12-19
 

--- a/cpp/locality/Voronoi.cc
+++ b/cpp/locality/Voronoi.cc
@@ -129,6 +129,7 @@ void Voronoi::compute(const freud::locality::NeighborQuery* nq)
             // Save cell volume
             m_volumes[query_point_id] = cell.volume();
 
+            // Compute cell neighbors
             size_t neighbor_counter(0);
             for (auto neighbor_iterator = neighbors.begin(); neighbor_iterator != neighbors.end();
                  neighbor_iterator++, neighbor_counter++)
@@ -137,9 +138,13 @@ void Voronoi::compute(const freud::locality::NeighborQuery* nq)
                 const vec3<double> normal(normals[3 * neighbor_counter], normals[3 * neighbor_counter + 1],
                                           normals[3 * neighbor_counter + 2]);
 
-                // Ignore bonds in 2D systems that point up or down
-                if (box.is2D() && std::abs(normal.z) > 0)
+                // Ignore bonds in 2D systems that point up or down. This check
+                // should only be dealing with bonds whose normal vectors' z
+                // components are -1, 0, or +1 (within some tolerance).
+                if (box.is2D() && std::abs(normal.z) > 1e-5)
+                {
                     continue;
+                }
 
                 // Fetch neighbor information
                 const int point_id = *neighbor_iterator;

--- a/cpp/locality/Voronoi.cc
+++ b/cpp/locality/Voronoi.cc
@@ -141,7 +141,7 @@ void Voronoi::compute(const freud::locality::NeighborQuery* nq)
                 // Ignore bonds in 2D systems that point up or down. This check
                 // should only be dealing with bonds whose normal vectors' z
                 // components are -1, 0, or +1 (within some tolerance).
-                if (box.is2D() && std::abs(normal.z) > 1e-5)
+                if (box.is2D() && std::abs(normal.z) > 0.5)
                 {
                     continue;
                 }

--- a/doc/source/reference/credits.rst
+++ b/doc/source/reference/credits.rst
@@ -98,6 +98,7 @@ Bradley Dice - **Lead developer**
 * Revised docs about query modes.
 * Implemented smarter heuristics in Voronoi for voro++ block sizes, resulting in significant performance gains for large systems.
 * Corrected calculation of neighbor distances in the Voronoi NeighborList.
+* Added finite tolerance to ensure stability of 2D Voronoi NeighborList computations.
 
 Eric Harper, University of Michigan - **Former lead developer**
 

--- a/freud/plot.py
+++ b/freud/plot.py
@@ -406,11 +406,18 @@ def voronoi_plot(box, polytopes, ax=None, color_by_sides=True, cmap=None):
 
     if color_by_sides:
         colors = np.array([len(poly) for poly in polytopes])
+        num_colors = np.ptp(colors) + 1
     else:
         colors = np.random.RandomState().permutation(np.arange(len(patches)))
+        num_colors = np.unique(colors).size
 
-    cmap = cm.get_cmap('Set1' if cmap is None else cmap,
-                       np.unique(colors).size)
+    # Ensure we have enough colors to uniquely identify the cells
+    if cmap is None:
+        if color_by_sides and num_colors <= 10:
+            cmap = 'tab10'
+        else:
+            cmap = 'tab20'
+    cmap = cm.get_cmap(cmap, num_colors)
     bounds = np.arange(np.min(colors), np.max(colors)+1)
 
     patch_collection.set_array(np.array(colors)-0.5)

--- a/freud/plot.py
+++ b/freud/plot.py
@@ -4,6 +4,7 @@
 import freud
 import io
 import numpy as np
+import warnings
 
 try:
     from matplotlib.figure import Figure
@@ -416,6 +417,10 @@ def voronoi_plot(box, polytopes, ax=None, color_by_sides=True, cmap=None):
         if color_by_sides and num_colors <= 10:
             cmap = 'tab10'
         else:
+            if num_colors > 20:
+                warnings.warn('More than 20 unique colors were requested. '
+                              'Consider providing a colormap to the cmap '
+                              'argument.', UserWarning)
             cmap = 'tab20'
     cmap = cm.get_cmap(cmap, num_colors)
     bounds = np.arange(np.min(colors), np.max(colors)+1)

--- a/tests/test_locality_Voronoi.py
+++ b/tests/test_locality_Voronoi.py
@@ -26,6 +26,19 @@ class TestVoronoi(unittest.TestCase):
             points[vor.nlist.query_point_indices]), axis=-1)
         npt.assert_allclose(wrapped_distances, vor.nlist.distances)
 
+        # Ensure every point has neighbors
+        assert np.all(vor.nlist.neighbor_counts > 0)
+
+        # Ensure neighbor list is symmetric
+        neighbors = {}
+        for i, j, w, d in zip(vor.nlist.query_point_indices,
+                              vor.nlist.point_indices,
+                              vor.nlist.weights,
+                              vor.nlist.distances):
+            neighbors[(i, j)] = (w, d)
+        for nb in neighbors:
+            assert (nb[1], nb[0]) in neighbors, (nb, neighbors[nb])
+
     def test_basic_3d(self):
         # Test that voronoi tessellations of random systems have the same
         # number of points and polytopes
@@ -219,7 +232,23 @@ class TestVoronoi(unittest.TestCase):
             points[vor.nlist.query_point_indices]), axis=-1)
         npt.assert_allclose(wrapped_distances, vor.nlist.distances)
 
-    def test_nlist_symmetric(self):
+    def test_nlist_symmetric_2d(self):
+        # Test that the voronoi neighborlist is symmetric
+        L = 10  # Box length
+        N = 40  # Number of particles
+
+        box, points = freud.data.make_random_system(L, N, is2D=True)
+        vor = freud.locality.Voronoi()
+        vor.compute((box, points))
+        nlist = vor.nlist
+
+        ijs = set(zip(nlist.query_point_indices, nlist.point_indices))
+        jis = set(zip(nlist.point_indices, nlist.query_point_indices))
+
+        # every (i, j) pair should have a corresponding (j, i) pair
+        self.assertTrue(all((j, i) in jis for (i, j) in ijs))
+
+    def test_nlist_symmetric_3d(self):
         # Test that the voronoi neighborlist is symmetric
         L = 10  # Box length
         N = 40  # Number of particles

--- a/tests/test_locality_Voronoi.py
+++ b/tests/test_locality_Voronoi.py
@@ -36,6 +36,11 @@ class TestVoronoi(unittest.TestCase):
         # Every (i, j) pair should have a corresponding (j, i) pair
         self.assertTrue(all((j, i) in jis for (i, j) in ijs))
 
+        # The number of vertices in each polygon should be equal to
+        # the number of neighbors (only valid in 2D).
+        npt.assert_equal([len(p) for p in vor.polytopes],
+                         vor.nlist.neighbor_counts)
+
     def test_random_3d(self):
         # Test that voronoi tessellations of random systems have the same
         # number of points and polytopes


### PR DESCRIPTION
## Description
I examined issue #587. The issue was caused by a condition that is being used specifically in 2D systems to filter out unwanted bonds pointing in the z-direction, resulting from the hack used to enable 2D support. I believe this is the same underlying issue reported by Austin Dulaney on the forum: https://groups.google.com/forum/#!topic/freud-users/xZxG3KL3DIw

## Motivation and Context
Since voro++ doesn't natively support 2D systems, we build a planar system in a 3D box with a z-dimension of 1. When finding neighbors, we throw out the bonds that point perpendicular to the plane. Unfortunately this procedure was failing due to issues with floating-point precision. The check was effectively skipping if `abs(z) > 0`, which resulted in undesirable behavior when the z-component was slightly above or below zero due to numerical imprecision. I added a finite tolerance that should correct the problem. This should be totally safe because the Voronoi cell's normal vectors should always be confined to the plane or pointing perpendicular to the plane. The hack for 2D support creates Voronoi cells that are all prisms.

Resolves: #587.

## How Has This Been Tested?
Tests were added for symmetric neighbor lists with 2D systems. The tests failed before fixing the bug and succeeded after fixing the bug.

## Screenshots
Bonds in Delaunay triangulation now match the Voronoi diagram (up to the tiny facets resulting from numerical imprecision).
![image](https://user-images.githubusercontent.com/3943761/74810192-81977880-52b4-11ea-97f5-0cc6a8121052.png)
Histogram of neighbor counts: this now agrees with the number of vertices (equal to the number of edges).
![image](https://user-images.githubusercontent.com/3943761/74810218-8f4cfe00-52b4-11ea-9050-c1908572a0d9.png)



## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds or improves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!-- Put an `x` in all the boxes that apply. If you're unsure about any of
     these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/glotzerlab/freud/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] I have updated the documentation (if relevant).
- [x] I have added tests that cover my changes (if relevant).
- [x] All new and existing tests passed.
- [x] I have updated the [credits](https://github.com/glotzerlab/freud/blob/master/doc/source/reference/credits.rst).
- [x] I have updated the [Changelog](https://github.com/glotzerlab/freud/blob/master/ChangeLog.md).
