### PR TITLE
Disallow NeighborQuery with zero points.

### DIFF
--- a/cpp/locality/LinkCell.cc
+++ b/cpp/locality/LinkCell.cc
@@ -299,11 +299,6 @@ const vec3<unsigned int> LinkCell::computeDimensions(const box::Box& box, float 
 
 void LinkCell::computeCellList(const vec3<float>* points, unsigned int n_points)
 {
-    if (n_points == 0)
-    {
-        throw std::runtime_error("Cannot generate a cell list of 0 particles.");
-    }
-
     // determine the number of cells and allocate memory
     unsigned int Nc = getNumCells();
     m_cell_list.prepare(n_points + Nc);

--- a/cpp/locality/NeighborQuery.h
+++ b/cpp/locality/NeighborQuery.h
@@ -86,7 +86,7 @@ public:
         : m_box(box), m_points(points), m_n_points(n_points)
     {
         // Reject systems with 0 particles
-        if (n_points == 0)
+        if (m_n_points == 0)
         {
             throw std::invalid_argument("Cannot create a NeighborQuery with 0 particles.");
         }

--- a/cpp/locality/NeighborQuery.h
+++ b/cpp/locality/NeighborQuery.h
@@ -85,6 +85,12 @@ public:
     NeighborQuery(const box::Box& box, const vec3<float>* points, unsigned int n_points)
         : m_box(box), m_points(points), m_n_points(n_points)
     {
+        // Reject systems with 0 particles
+        if (n_points == 0)
+        {
+            throw std::invalid_argument("Cannot create a NeighborQuery with 0 particles.");
+        }
+
         // For 2D systems, check if any z-coordinates are outside some tolerance of z=0
         if (m_box.is2D())
         {

--- a/tests/test_locality_NeighborQuery.py
+++ b/tests/test_locality_NeighborQuery.py
@@ -35,7 +35,7 @@ class NeighborQueryTest(object):
             "subclass of NeighborQuery in a separate subclass of "
             "unittest.TestCase")
 
-    def test_query_create(self):
+    def test_query_validate_points(self):
         L = 10  # Box Dimensions
         r_max = 2.01  # Cutoff radius
         box = freud.box.Box.cube(L)

--- a/tests/test_locality_NeighborQuery.py
+++ b/tests/test_locality_NeighborQuery.py
@@ -40,9 +40,10 @@ class NeighborQueryTest(object):
         r_max = 2.01  # Cutoff radius
         box = freud.box.Box.cube(L)
 
-        # Create an empty NeighborQuery
-        points = np.zeros(shape=(0, 3), dtype=np.float32)
-        self.build_query_object(box, points, r_max)
+        # It's not allowed to have an empty NeighborQuery
+        with self.assertRaises(ValueError):
+            points = np.zeros(shape=(0, 3), dtype=np.float32)
+            self.build_query_object(box, points, r_max)
 
         # Create a NeighborQuery with one point
         points = np.zeros(shape=(1, 3), dtype=np.float32)

--- a/tests/test_locality_NeighborQuery.py
+++ b/tests/test_locality_NeighborQuery.py
@@ -55,6 +55,14 @@ class NeighborQueryTest(object):
             points = np.zeros(shape=(3), dtype=np.float32)
             self.build_query_object(box, points, r_max)
 
+        # It's not allowed to have an array without shape (N, 3)
+        with self.assertRaises(ValueError):
+            points = np.zeros(shape=(1, 2), dtype=np.float32)
+            self.build_query_object(box, points, r_max)
+        with self.assertRaises(ValueError):
+            points = np.zeros(shape=(1, 4), dtype=np.float32)
+            self.build_query_object(box, points, r_max)
+
         # Create a NeighborQuery with one point
         points = np.zeros(shape=(1, 3), dtype=np.float32)
         self.build_query_object(box, points, r_max)

--- a/tests/test_locality_NeighborQuery.py
+++ b/tests/test_locality_NeighborQuery.py
@@ -35,6 +35,23 @@ class NeighborQueryTest(object):
             "subclass of NeighborQuery in a separate subclass of "
             "unittest.TestCase")
 
+    def test_query_create(self):
+        L = 10  # Box Dimensions
+        r_max = 2.01  # Cutoff radius
+        box = freud.box.Box.cube(L)
+
+        # Create an empty NeighborQuery
+        points = np.zeros(shape=(0, 3), dtype=np.float32)
+        self.build_query_object(box, points, r_max)
+
+        # Create a NeighborQuery with one point
+        points = np.zeros(shape=(1, 3), dtype=np.float32)
+        self.build_query_object(box, points, r_max)
+
+        # Create a NeighborQuery with ten points
+        points = np.zeros(shape=(10, 3), dtype=np.float32)
+        self.build_query_object(box, points, r_max)
+
     def test_query_ball(self):
         L = 10  # Box Dimensions
         r_max = 2.01  # Cutoff radius

--- a/tests/test_locality_NeighborQuery.py
+++ b/tests/test_locality_NeighborQuery.py
@@ -41,8 +41,18 @@ class NeighborQueryTest(object):
         box = freud.box.Box.cube(L)
 
         # It's not allowed to have an empty NeighborQuery
+        for empty_points in (
+            [],
+            [[]],
+            np.zeros(0, dtype=np.float32),
+            np.zeros(shape=(0, 3), dtype=np.float32)
+        ):
+            with self.assertRaises(ValueError):
+                self.build_query_object(box, empty_points, r_max)
+
+        # It's not allowed to have one point as a 1D array
         with self.assertRaises(ValueError):
-            points = np.zeros(shape=(0, 3), dtype=np.float32)
+            points = np.zeros(shape=(3), dtype=np.float32)
             self.build_query_object(box, points, r_max)
 
         # Create a NeighborQuery with one point


### PR DESCRIPTION
## Description
freud disallowed LinkCell objects with zero points. @tcmoore3 reported an issue in #591 that AABBQuery objects constructed with zero points would cause a segfault. This PR disallows the construction of any NeighborQuery (LinkCell or AABBQuery) with zero points by moving that check from LinkCell to NeighborQuery.

It may be possible to allow the creation of NeighborQuery objects with no points, but it would require some refactoring of both LinkCell and AABBQuery to support that.

## Motivation and Context
Resolves: #591.

## How Has This Been Tested?
New tests added for NeighborQuery creation with various kinds of valid/invalid points.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds or improves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have read the [**CONTRIBUTING**](https://github.com/glotzerlab/freud/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] I have updated the documentation (if relevant).
- [x] I have added tests that cover my changes (if relevant).
- [x] All new and existing tests passed.
- [ ] I have updated the [credits](https://github.com/glotzerlab/freud/blob/master/doc/source/reference/credits.rst).
- [ ] I have updated the [Changelog](https://github.com/glotzerlab/freud/blob/master/ChangeLog.md).