### PR TITLE
Replace undef min/max with a preprocessor definition.

### DIFF
--- a/cpp/environment/AngularSeparation.cc
+++ b/cpp/environment/AngularSeparation.cc
@@ -5,11 +5,6 @@
 #include "NeighborComputeFunctional.h"
 #include "utils.h"
 
-#if defined _WIN32
-#undef min // std::min clashes with a Windows header
-#undef max // std::max clashes with a Windows header
-#endif
-
 /*! \file AngularSeparation.cc
     \brief Compute the angular separation for each particle.
 */

--- a/cpp/environment/MatchEnv.cc
+++ b/cpp/environment/MatchEnv.cc
@@ -9,11 +9,6 @@
 #include "NeighborBond.h"
 #include "NeighborComputeFunctional.h"
 
-#if defined _WIN32
-#undef min // std::min clashes with a Windows header
-#undef max // std::max clashes with a Windows header
-#endif
-
 namespace freud { namespace environment {
 
 /*****************

--- a/cpp/locality/AABB.h
+++ b/cpp/locality/AABB.h
@@ -14,8 +14,6 @@
 
 #if defined _WIN32
 #define CACHE_ALIGN __declspec(align(32))
-#undef min // std::min clashes with a Windows header
-#undef max // std::max clashes with a Windows header
 #else
 #define CACHE_ALIGN __attribute__((aligned(32)))
 #endif

--- a/cpp/locality/LinkCell.cc
+++ b/cpp/locality/LinkCell.cc
@@ -7,11 +7,6 @@
 
 #include "LinkCell.h"
 
-#if defined _WIN32
-#undef min // std::min clashes with a Windows header
-#undef max // std::max clashes with a Windows header
-#endif
-
 /*! \file LinkCell.cc
     \brief Build a cell list from a set of points.
 */

--- a/cpp/order/RotationalAutocorrelation.cc
+++ b/cpp/order/RotationalAutocorrelation.cc
@@ -10,12 +10,6 @@
     \brief Implements the RotationalAutocorrelation class.
 */
 
-// Avoid known stdlib clashes with Windows headers.
-#if defined _WIN32
-#undef min
-#undef max
-#endif
-
 namespace freud { namespace order {
 
 // This function wraps exponentiation for complex numbers to avoid

--- a/cpp/order/Wigner3j.cc
+++ b/cpp/order/Wigner3j.cc
@@ -6,11 +6,6 @@
 
 #include "Wigner3j.h"
 
-#if defined _WIN32
-#undef min // std::min clashes with a Windows header
-#undef max // std::max clashes with a Windows header
-#endif
-
 /*! \file Wigner3j.cc
  *  \brief Stores and reduces over Wigner 3j coefficients for l from 0 to 20
  */

--- a/cpp/util/utils.h
+++ b/cpp/util/utils.h
@@ -7,11 +7,6 @@
 #include <tbb/blocked_range.h>
 #include <tbb/blocked_range2d.h>
 
-#if defined _WIN32
-#undef min // std::min clashes with a Windows header
-#undef max // std::max clashes with a Windows header
-#endif
-
 namespace freud { namespace util {
 
 //! Clip v if it is outside the range [lo, hi].

--- a/setup.py
+++ b/setup.py
@@ -188,9 +188,14 @@ directives = {
 }
 macros = [
     ('NPY_NO_DEPRECATED_API', 'NPY_1_10_API_VERSION'),
-    ('VOROPP_VERBOSE', '1'),     # To keep voro++ quieter
-    ('_USE_MATH_DEFINES', '1'),  # Force Windows to define M_PI in <cmath>
+    ('VOROPP_VERBOSE', '1'),  # Keeps voro++ outputs quiet
 ]
+
+if platform.system() == 'Windows':
+    macros.extend([
+        ('_USE_MATH_DEFINES', '1'),  # Force Windows to define M_PI in <cmath>
+        ('NOMINMAX', '1'),  # Prevent Windows from defining min/max as macros
+    ])
 
 # Decide whether or not to compile with coverage support
 if args.use_coverage:


### PR DESCRIPTION
## Description
This fixes an issue I saw on one of my Windows computers. I'm not sure what's different about this system but it doesn't seem to work with the `#undef min` / `#undef max` approach. Preventing that Windows macro from being defined with the `NOMINMAX` preprocessor flag seems to work fine.

## Motivation and Context
Fixes issue with Windows build.

## How Has This Been Tested?
Built locally, tests pass.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds or improves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!-- Put an `x` in all the boxes that apply. If you're unsure about any of
     these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/glotzerlab/freud/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] I have updated the documentation (if relevant).
- [ ] I have added tests that cover my changes (if relevant).
- [x] All new and existing tests passed.
- [ ] I have updated the [credits](https://github.com/glotzerlab/freud/blob/master/doc/source/reference/credits.rst).
- [ ] I have updated the [Changelog](https://github.com/glotzerlab/freud/blob/master/ChangeLog.md).
