### PR TITLE
Fix parameter checking for Cubatic.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -16,6 +16,7 @@ and this project adheres to
 
 ### Fixed
 * Histogram bin locations are computed in a more numerically stable way.
+* Improved error handling of Cubatic input parameters.
 
 ## v2.2.0 - 2020-02-24
 

--- a/cpp/order/Cubatic.h
+++ b/cpp/order/Cubatic.h
@@ -66,6 +66,11 @@ public:
     //! Compute the cubatic order parameter
     void compute(quat<float>* orientations, unsigned int num_orientations);
 
+    unsigned int getNumParticles() const
+    {
+        return m_n;
+    }
+
     //! Get a reference to the last computed cubatic order parameter
     float getCubaticOrderParameter() const
     {
@@ -87,9 +92,9 @@ public:
         return m_cubatic_tensor;
     }
 
-    unsigned int getNumParticles() const
+    quat<float> getCubaticOrientation() const
     {
-        return m_n;
+        return m_cubatic_orientation;
     }
 
     float getTInitial() const
@@ -107,9 +112,9 @@ public:
         return m_scale;
     }
 
-    quat<float> getCubaticOrientation() const
+    unsigned int getNReplicates() const
     {
-        return m_cubatic_orientation;
+        return m_n_replicates;
     }
 
     unsigned int getSeed() const
@@ -161,11 +166,12 @@ private:
      */
     template<typename T> quat<float> calcRandomQuaternion(T& dist, float angle_multiplier = 1.0) const;
 
-    float m_t_initial;         //!< Initial temperature for simulated annealing.
-    float m_t_final;           //!< Final temperature for simulated annealing.
-    float m_scale;             //!< Scaling factor to reduce temperature.
-    unsigned int m_n;          //!< Last number of points computed.
-    unsigned int m_replicates; //!< Number of replicates.
+    float m_t_initial;           //!< Initial temperature for simulated annealing.
+    float m_t_final;             //!< Final temperature for simulated annealing.
+    float m_scale;               //!< Scaling factor to reduce temperature.
+    unsigned int m_n_replicates; //!< Number of replicates.
+    unsigned int m_seed;         //!< Random seed.
+    unsigned int m_n;            //!< Last number of points computed.
 
     float m_cubatic_order_parameter;   //!< The value of the order parameter.
     quat<float> m_cubatic_orientation; //!< The cubatic orientation.
@@ -177,7 +183,6 @@ private:
     util::ManagedArray<float>
         m_global_tensor; //!< The system-averaged homogeneous tensor encoding all particle orientations.
     util::ManagedArray<float> m_cubatic_tensor; //!< The output tensor computed via simulated annealing.
-    unsigned int m_seed;                        //!< Random seed.
 
     vec3<float> m_system_vectors[3]; //!< The global coordinate system, always use a simple Euclidean basis.
 };

--- a/doc/source/reference/credits.rst
+++ b/doc/source/reference/credits.rst
@@ -100,6 +100,7 @@ Bradley Dice - **Lead developer**
 * Corrected calculation of neighbor distances in the Voronoi NeighborList.
 * Added finite tolerance to ensure stability of 2D Voronoi NeighborList computations.
 * Improved stability of Histogram bin calculations.
+* Improved error handling of Cubatic input parameters.
 
 Eric Harper, University of Michigan - **Former lead developer**
 

--- a/freud/_order.pxd
+++ b/freud/_order.pxd
@@ -25,10 +25,11 @@ cdef extern from "Cubatic.h" namespace "freud::order":
         const freud.util.ManagedArray[float] &getParticleOrderParameter() const
         const freud.util.ManagedArray[float] &getGlobalTensor() const
         const freud.util.ManagedArray[float] &getCubaticTensor() const
+        quat[float] getCubaticOrientation() const
         float getTInitial() const
         float getTFinal() const
         float getScale() const
-        quat[float] getCubaticOrientation() const
+        unsigned int getNReplicates() const
         unsigned int getSeed() const
 
 

--- a/freud/order.pyx
+++ b/freud/order.pyx
@@ -50,28 +50,13 @@ cdef class Cubatic(_Compute):
             (Default value = :code:`None`).
     """  # noqa: E501
     cdef freud._order.Cubatic * thisptr
-    cdef n_replicates
-    cdef seed
 
     def __cinit__(self, t_initial, t_final, scale, n_replicates=1, seed=None):
-        # run checks
-        if (t_final >= t_initial):
-            raise ValueError("t_final must be less than t_initial")
-        if (scale >= 1.0):
-            raise ValueError("scale must be less than 1")
         if seed is None:
             seed = int(time.time())
-        elif not isinstance(seed, int):
-            try:
-                seed = int(seed)
-            except (OverflowError, TypeError, ValueError):
-                logger.warning("The supplied seed could not be used. "
-                               "Using current time as seed.")
-                seed = int(time.time())
 
         self.thisptr = new freud._order.Cubatic(
             t_initial, t_final, scale, n_replicates, seed)
-        self.n_replicates = n_replicates
 
     def __dealloc__(self):
         del self.thisptr
@@ -107,6 +92,11 @@ cdef class Cubatic(_Compute):
     def scale(self):
         """float: The scale."""
         return self.thisptr.getScale()
+
+    @property
+    def n_replicates(self):
+        """unsigned int: Number of replicate simulated annealing runs."""
+        return self.thisptr.getNReplicates()
 
     @property
     def seed(self):

--- a/tests/test_order_Cubatic.py
+++ b/tests/test_order_Cubatic.py
@@ -96,6 +96,31 @@ class TestCubatic(unittest.TestCase):
             op_max, 0.2,
             err_msg="per particle order parameter value is too high")
 
+    def test_valid_inputs(self):
+        with self.assertRaises(ValueError):
+            # t_initial must be greater than t_final
+            freud.order.Cubatic(
+                t_initial=0.001,
+                t_final=5.0,
+                scale=0.95,
+                n_replicates=10)
+
+        with self.assertRaises(ValueError):
+            # t_final must be greater than 1e-6
+            freud.order.Cubatic(
+                t_initial=5.0,
+                t_final=1e-7,
+                scale=0.95,
+                n_replicates=10)
+
+        with self.assertRaises(ValueError):
+            # scale must be less than 1
+            freud.order.Cubatic(
+                t_initial=5.0,
+                t_final=0.001,
+                scale=1.1,
+                n_replicates=10)
+
     def test_repr(self):
         cubatic = freud.order.Cubatic(5.0, 0.001, 0.95, 10)
         self.assertEqual(str(cubatic), str(eval(repr(cubatic))))

--- a/tests/test_order_Cubatic.py
+++ b/tests/test_order_Cubatic.py
@@ -118,7 +118,15 @@ class TestCubatic(unittest.TestCase):
             freud.order.Cubatic(
                 t_initial=5.0,
                 t_final=0.001,
-                scale=1.1,
+                scale=1,
+                n_replicates=10)
+
+        with self.assertRaises(ValueError):
+            # scale must be greater than 0
+            freud.order.Cubatic(
+                t_initial=5.0,
+                t_final=0.001,
+                scale=0,
                 n_replicates=10)
 
     def test_repr(self):


### PR DESCRIPTION
## Description
I noticed some issues in Cubatic while looking at some unrelated code. I have resolved the following issues:
- `n_replicates` was not accessible via a C++ getter, and was being saved as a Python property, contrary to how all other parameters are handled.
- `seed` was `cdef`'d and conflicted with the property `seed`. This led to inconsistent behavior for `cubatic.seed` depending on whether a seed was provided or left as the default.
- The error handling for input parameters `t_initial`, `t_final`, and `scale` was duplicated between Python and C++ and it wasn't even consistent between the two. All error handling is now done in C++.
- The `seed` value could be provided as any type, and non-integer types would throw a warning and use the system time instead. Invalid seeds _should_ raise an error, rather than using system time and being non-reproducible for invalid-but-consistent seeds (e.g. seeds provided as a string). That is now enforced through Cython's knowledge of parameter types.
- I also did some minor re-ordering so that the pxd and C++ files were more in line with each other.

## Motivation and Context
Improves usability and testability of Cubatic.

## How Has This Been Tested?
Expanded testing of error handling in Cubatic.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds or improves functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have read the [**CONTRIBUTING**](https://github.com/glotzerlab/freud/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] I have updated the documentation (if relevant).
- [x] I have added tests that cover my changes (if relevant).
- [x] All new and existing tests passed.
- [x] I have updated the [credits](https://github.com/glotzerlab/freud/blob/master/doc/source/reference/credits.rst).
- [x] I have updated the [Changelog](https://github.com/glotzerlab/freud/blob/master/ChangeLog.md).
