### PR TITLE
Fix/pmftxyt orientation

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -18,6 +18,7 @@ and this project adheres to
 * Histogram bin locations are computed in a more numerically stable way.
 * Improved error handling of Cubatic input parameters.
 * PMFT's are now properly normalized such that the pair correlation function tends to unity for an ideal ga.
+* PMFTXYT uses the correct orientations when points and query\_points differ.
 
 ## v2.2.0 - 2020-02-24
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -17,6 +17,7 @@ and this project adheres to
 ### Fixed
 * Histogram bin locations are computed in a more numerically stable way.
 * Improved error handling of Cubatic input parameters.
+* PMFT's are now properly normalized such that the pair correlation function tends to unity for an ideal ga.
 
 ## v2.2.0 - 2020-02-24
 

--- a/cpp/pmft/PMFT.h
+++ b/cpp/pmft/PMFT.h
@@ -60,7 +60,7 @@ protected:
      *  least one angular term, but that term should not contain a factor of
      *  2*PI since that factor is effectively divided out of the volume here.
      *
-     *  \param JacobFactor A function with one parameter (the histogram bind index) that returns the volume of the element in the histogram bin corresponding to the index.
+     *  \param JacobFactor A function with one parameter (the histogram bin index) that returns the volume of the element in the histogram bin corresponding to the index.
      */
     template<typename JacobFactor> void reduce(JacobFactor jf)
     {

--- a/cpp/pmft/PMFT.h
+++ b/cpp/pmft/PMFT.h
@@ -4,6 +4,8 @@
 #ifndef PMFT_H
 #define PMFT_H
 
+#include <tbb/tbb.h>
+
 #include "BondHistogramCompute.h"
 #include "Box.h"
 #include "Histogram.h"
@@ -33,6 +35,33 @@ public:
     //! Destructor
     virtual ~PMFT() {};
 
+    //! Get a reference to the PCF array
+    const util::ManagedArray<float>& getPCF()
+    {
+        return reduceAndReturn(m_pcf_array);
+    }
+
+protected:
+    //! Reduce the thread local histogram into the total pair correlation function.
+    /*! The pair correlation function is computed by reducing the bin counts in
+     * all of the thread local histograms and then multiplying these by the
+     * appropriate normalization factor. The normalization is nearly identical
+     * to the RDF except for the volume normalization. In the RDF, the volume
+     * normalization is simply V_shell/V_total, but in the PFMT the
+     * normalization depends on the volume element in the relevant coordinate
+     * system. This method accepts a function jf that returns the volume
+     * element corresponding to a given bin in the histogram.
+     *
+     *  **IMPORTANT NOTE**: The inv_num_dens factor in the calculation in this
+     *  function is just volume / Np, so it does not include volume elements in
+     *  the orientational degrees of freedom. This means that the corresponding
+     *  normalization factors *should not* be applied to the Jacobian factor
+     *  argument. For instance, any full-dimensional PMFT in 2D must contain at
+     *  least one angular term, but that term should not contain a factor of
+     *  2*PI since that factor is effectively divided out of the volume here.
+     *
+     *  \param JacobFactor A function with one parameter (the histogram bind index) that returns the volume of the element in the histogram bin corresponding to the index.
+     */
     template<typename JacobFactor> void reduce(JacobFactor jf)
     {
         m_pcf_array.prepare(m_histogram.shape());
@@ -47,13 +76,6 @@ public:
         });
     }
 
-    //! Get a reference to the PCF array
-    const util::ManagedArray<float>& getPCF()
-    {
-        return reduceAndReturn(m_pcf_array);
-    }
-
-protected:
     util::ManagedArray<float> m_pcf_array; //!< Array of computed pair correlation function.
 };
 

--- a/cpp/pmft/PMFTR12.cc
+++ b/cpp/pmft/PMFTR12.cc
@@ -32,17 +32,18 @@ PMFTR12::PMFTR12(float r_max, unsigned int n_r, unsigned int n_t1, unsigned int 
     m_local_histograms = BondHistogram::ThreadLocalHistogram(m_histogram);
 
     // Note: There is an additional implicit volume factor of 2*pi
-    // corresponding to the rotational degree of freedom in the system (i.e.
-    // both dt1 and dt2 technically have 2*pi in the numerator). However, this
+    // corresponding to the rotational degree of freedom of the second particle
+    // (i.e. both dt1 and dt2 technically have 2*pi in the numerator). This
     // factor is implicitly canceled out since we also do not include it in the
-    // number density computed for the system, see PMFT::reduce for more
-    // information.
+    // number density computed for the system. However, we do have to include
+    // this factor for dt1 because it is part of the real space volume for the
+    // central particle, see PMFT::reduce for more information.
     //
     // The array is computed as the inverse for faster use later.
     m_inv_jacobian_array.prepare({n_r, n_t1, n_t2});
     std::vector<float> bins_r = m_histogram.getBinCenters()[0];
     float dr = r_max / float(n_r);
-    float dt1 = 1 / float(n_t1);
+    float dt1 = constants::TWO_PI / float(n_t1);
     float dt2 = 1 / float(n_t2);
     float product = dr * dt1 * dt2;
     for (unsigned int i = 0; i < n_r; i++)

--- a/cpp/pmft/PMFTR12.cc
+++ b/cpp/pmft/PMFTR12.cc
@@ -31,12 +31,19 @@ PMFTR12::PMFTR12(float r_max, unsigned int n_r, unsigned int n_t1, unsigned int 
     m_histogram = BondHistogram(axes);
     m_local_histograms = BondHistogram::ThreadLocalHistogram(m_histogram);
 
-    // Calculate the jacobian array; computed as the inverse for faster use later.
+    // Note: There is an additional implicit volume factor of 2*pi
+    // corresponding to the rotational degree of freedom in the system (i.e.
+    // both dt1 and dt2 technically have 2*pi in the numerator). However, this
+    // factor is implicitly canceled out since we also do not include it in the
+    // number density computed for the system, see PMFT::reduce for more
+    // information.
+    //
+    // The array is computed as the inverse for faster use later.
     m_inv_jacobian_array.prepare({n_r, n_t1, n_t2});
     std::vector<float> bins_r = m_histogram.getBinCenters()[0];
     float dr = r_max / float(n_r);
-    float dt1 = constants::TWO_PI / float(n_t1);
-    float dt2 = constants::TWO_PI / float(n_t2);
+    float dt1 = 1 / float(n_t1);
+    float dt2 = 1 / float(n_t2);
     float product = dr * dt1 * dt2;
     for (unsigned int i = 0; i < n_r; i++)
     {

--- a/cpp/pmft/PMFTR12.h
+++ b/cpp/pmft/PMFTR12.h
@@ -25,11 +25,11 @@ public:
                     vec3<float>* query_points, float* query_orientations, unsigned int n_query_points,
                     const locality::NeighborList* nlist, freud::locality::QueryArgs qargs);
 
+protected:
     //! \internal
     //! helper function to reduce the thread specific arrays into one array
     virtual void reduce();
 
-private:
     util::ManagedArray<float> m_inv_jacobian_array; //!< Array of inverse jacobians for each bin
 };
 

--- a/cpp/pmft/PMFTXY.cc
+++ b/cpp/pmft/PMFTXY.cc
@@ -22,10 +22,14 @@ PMFTXY::PMFTXY(float x_max, float y_max, unsigned int n_x, unsigned int n_y) : P
     if (y_max < 0.0f)
         throw std::invalid_argument("PMFTXY requires that y_max must be positive.");
 
-    // Compute jacobian
+    // Note: There is an additional implicit volume factor of 2*pi
+    // corresponding to the one rotational degree of freedom in the system.
+    // However, this factor is implicitly canceled out since we also do not
+    // include it in the number density computed for the system, see
+    // PMFT::reduce for more information.
     const float dx = 2.0 * x_max / float(n_x);
     const float dy = 2.0 * y_max / float(n_y);
-    m_jacobian = dx * dy * constants::TWO_PI;
+    m_jacobian = dx * dy;
 
     // Create the PCF array.
     m_pcf_array.prepare({n_x, n_y});

--- a/cpp/pmft/PMFTXY.h
+++ b/cpp/pmft/PMFTXY.h
@@ -25,11 +25,11 @@ public:
                     vec3<float>* query_points, unsigned int n_query_points,
                     const locality::NeighborList* nlist, freud::locality::QueryArgs qargs);
 
+protected:
     //! \internal
     //! helper function to reduce the thread specific arrays into one array
     virtual void reduce();
 
-private:
     float m_jacobian; //!< Determinant of Jacobian, bin area
 };
 

--- a/cpp/pmft/PMFTXYT.cc
+++ b/cpp/pmft/PMFTXYT.cc
@@ -65,11 +65,11 @@ void PMFTXYT::accumulate(const locality::NeighborQuery* neighbor_query, float* o
                           // rotate interparticle vector
                           vec2<float> myVec(delta.x, delta.y);
                           rotmat2<float> myMat
-                              = rotmat2<float>::fromAngle(-orientations[neighbor_bond.point_idx]);
+                              = rotmat2<float>::fromAngle(-query_orientations[neighbor_bond.query_point_idx]);
                           vec2<float> rotVec = myMat * myVec;
                           // calculate angle
                           float d_theta = std::atan2(-delta.y, -delta.x);
-                          float t = query_orientations[neighbor_bond.query_point_idx] - d_theta;
+                          float t = orientations[neighbor_bond.point_idx] - d_theta;
                           // make sure that t is bounded between 0 and 2PI
                           t = util::modulusPositive(t, constants::TWO_PI);
                           m_local_histograms(rotVec.x, rotVec.y, t);

--- a/cpp/pmft/PMFTXYT.cc
+++ b/cpp/pmft/PMFTXYT.cc
@@ -25,10 +25,14 @@ PMFTXYT::PMFTXYT(float x_max, float y_max, unsigned int n_x, unsigned int n_y, u
     if (y_max < 0.0f)
         throw std::invalid_argument("PMFTXYT requires that y_max must be positive.");
 
-    // Compute Jacobian
+    // Note: There is an additional implicit volume factor of 2*pi
+    // corresponding to the rotational degree of freedom in the system (i.e. dt
+    // technically has 2*pi in the numerator). However, this factor is
+    // implicitly canceled out since we also do not include it in the number
+    // density computed for the system, see PMFT::reduce for more information.
     const float dx = 2.0 * x_max / float(n_x);
     const float dy = 2.0 * y_max / float(n_y);
-    const float dt = constants::TWO_PI / float(n_t);
+    const float dt = 1 / float(n_t);
     m_jacobian = dx * dy * dt;
 
     // Create the PCF array.

--- a/cpp/pmft/PMFTXYT.h
+++ b/cpp/pmft/PMFTXYT.h
@@ -25,11 +25,11 @@ public:
                     vec3<float>* query_points, float* query_orientations, unsigned int n_query_points,
                     const locality::NeighborList* nlist, freud::locality::QueryArgs qargs);
 
+protected:
     //! \internal
     //! helper function to reduce the thread specific arrays into one array
     virtual void reduce();
 
-private:
     float m_jacobian;
 };
 

--- a/cpp/pmft/PMFTXYZ.cc
+++ b/cpp/pmft/PMFTXYZ.cc
@@ -32,18 +32,21 @@ PMFTXYZ::PMFTXYZ(float x_max, float y_max, float z_max, unsigned int n_x, unsign
     const float dy = float(2.0) * y_max / float(n_y);
     const float dz = float(2.0) * z_max / float(n_z);
 
-    // To properly normalize, we must consider the 3 degrees of freedom that
-    // are implicitly integrated over by this calculation. In three dimensions,
-    // there are 6 total degrees of freedom; we are only accounting for the
-    // relative positions. The orientational degrees of freedom of the second
-    // particle constitute the other three. The total volume in our 6D
+    // Note: To properly normalize, we must consider the 3 degrees of freedom
+    // that are implicitly integrated over by this calculation. In three
+    // dimensions, there are 6 total degrees of freedom; we are only accounting
+    // for the relative positions. The orientational degrees of freedom of the
+    // second particle constitute the other three. The total volume in our 6D
     // coordinate space accounted for by these orientational degrees of freedom
-    // is 8*pi^2. To see this, consider an integral over the Euler angles as shown
-    // here https://en.wikipedia.org/wiki/3D_rotation_group#Spherical_harmonics
-    // or discussed more in depth in Representations of the Rotation and
-    // Lorentz Groups and Their Applications by Gelfand, Minlos, and Shapiro.
-    const float orientation_volume = 8 * M_PI * M_PI;
-    m_jacobian = dx * dy * dz * orientation_volume;
+    // is 8*pi^2. To see this, consider an integral over the Euler angles as
+    // shown here
+    // https://en.wikipedia.org/wiki/3D_rotation_group#Spherical_harmonics or
+    // discussed more in depth in Representations of the Rotation and Lorentz
+    // Groups and Their Applications by Gelfand, Minlos, and Shapiro.
+    // However, this factor is implicitly canceled out since we also do not
+    // include it in the number density computed for the system, see
+    // PMFT::reduce for more information.
+    m_jacobian = dx * dy * dz;
 
     // Create the PCF array.
     m_pcf_array.prepare({n_x, n_y, n_z});

--- a/cpp/pmft/PMFTXYZ.h
+++ b/cpp/pmft/PMFTXYZ.h
@@ -27,11 +27,11 @@ public:
                     unsigned int num_equiv_orientations, const locality::NeighborList* nlist,
                     freud::locality::QueryArgs qargs);
 
+protected:
     //! \internal
     //! helper function to reduce the thread specific arrays into one array
     virtual void reduce();
 
-private:
     float m_jacobian;
     vec3<float> m_shiftvec; //!< vector that points from [0,0,0] to the origin of the pmft
 };

--- a/doc/source/reference/credits.rst
+++ b/doc/source/reference/credits.rst
@@ -49,7 +49,7 @@ Vyas Ramasubramani - **Lead developer**
 * Changed correlation function to properly take the complex conjugate of inputs.
 * Wrote developer documentation for version 2.0.
 * Fixed handling of 2D systems from various data sources.
-* Fixed usage of query orientations in PMFTXY and PMFTXYZ when points and query points are not identical.
+* Fixed usage of query orientations in PMFTXY, PMFTXYT and PMFTXYZ when points and query points are not identical.
 * Refactored and standardized PMFT tests.
 
 Bradley Dice - **Lead developer**

--- a/freud/pmft.pyx
+++ b/freud/pmft.pyx
@@ -90,9 +90,8 @@ def _gen_angle_array(orientations, shape):
     orientations. It performs the conversion of quaternion inputs if needed and
     ensures that singleton arrays are treated correctly."""
 
-    return freud.util._convert_array(
-        np.atleast_1d(_quat_to_z_angle(orientations.squeeze(), shape[0])),
-        shape=shape)
+    return freud.util._convert_array(np.atleast_1d(_quat_to_z_angle(
+        np.asarray(orientations).squeeze(), shape[0])), shape=shape)
 
 
 cdef class _PMFT(_SpatialHistogram):

--- a/freud/pmft.pyx
+++ b/freud/pmft.pyx
@@ -349,12 +349,9 @@ cdef class PMFTXY(_PMFT):
     R"""Computes the PMFT :cite:`vanAnders:2014aa,van_Anders_2013` in
     coordinates :math:`x`, :math:`y`.
 
-    Since there are 3 degrees of translational and rotational freedom in 2
-    dimensions, this class is implicitly integrating out one of them.
-    Specifically, by comparison to :class:`~.PMFTXYT` we see that the missing
-    dimension is the relative orientation of the second particle. Note that
-    this degree of freedom is still accounted for in the Jacobian of this
-    calculation.
+    There are 3 degrees of translational and rotational freedom in 2
+    dimensions, so this class implicitly integrates over the rotational degree
+    of freedom of the second particle.
 
     .. note::
         **2D:** :class:`freud.pmft.PMFTXY` is only defined for 2D systems.
@@ -489,24 +486,10 @@ cdef class PMFTXYZ(_PMFT):
     R"""Computes the PMFT :cite:`vanAnders:2014aa,van_Anders_2013` in
     coordinates :math:`x`, :math:`y`, :math:`z`.
 
-    Since there are 6 degrees of translational and rotational freedom in 3
-    dimensions, this class is implicitly integrating out three of them.
-    In particular, we are disregarding the orientational degrees of freedom in
-    the system. The simplest parameterization of these degrees is using Euler
-    angles. The total volume of orientations that are implicitly integrated out
-    by this calculation can be computed by an explicit integral over the Euler
-    angles:
-
-    .. math::
-
-        \int_0^{2\pi} \int_0^\pi \int_0^{2\pi} \sin \theta d\phi d\theta
-        d\psi = 8 \pi^2
-
-    For more information on this calculation, see :cite:`gelfand1963` (the
-    equation is also reproduced without proof at
-    https://en.wikipedia.org/wiki/3D_rotation_group#Spherical_harmonics).
-    This prefactor of :math:`8 \pi^2` is accounted for in the Jacobian used to
-    compute the :class:`PMFTXYZ`.
+    There are 6 degrees of translational and rotational freedom in 3
+    dimensions, so this class is implicitly integrates out the orientational
+    degrees of freedom in the system associated with the points. All
+    calculations are done in the reference from of the query points.
 
     Args:
         x_max (float):

--- a/tests/test_pmft.py
+++ b/tests/test_pmft.py
@@ -867,7 +867,7 @@ class TestCompare(unittest.TestCase):
         # NeighborQuery objects). The denominator comes from the 8pi^2 of
         # orientational phase space in PMFTXYZ divided by the 2pi in theta
         # space in PMFTXY.
-        scale_factor = ((nbins/2)*L)/(4*np.pi)
+        scale_factor = ((nbins/2)*L)
         npt.assert_allclose(np.exp(pmft2d.pmft),
                             np.exp(pmft3d.pmft[:, :, nbins//2])*scale_factor,
                             atol=1e-6)

--- a/tests/test_pmft.py
+++ b/tests/test_pmft.py
@@ -281,9 +281,8 @@ class TestPMFTXYT(TestPMFT2D, unittest.TestCase):
 
     def get_bin(self, query_point, point, query_point_orientation,
                 point_orientation):
-
         r_ij = point - query_point
-        rot_r_ij = rowan.rotate(query_point_orientation, r_ij)
+        rot_r_ij = rowan.rotate(rowan.conjugate(query_point_orientation), r_ij)
 
         limits = np.asarray(self.limits)
         xy_bins = tuple(np.floor((
@@ -329,6 +328,33 @@ class TestPMFTXYT(TestPMFT2D, unittest.TestCase):
 
             self.assertEqual(len(np.unique(pmft.pmft)), 2)
 
+    def test_nontrivial_orientations(self):
+        """Ensure that orientations are applied to the right particles."""
+        box = self.get_cubic_box(6)
+        points = np.array([[-1.0, 0.0, 0.0]], dtype=np.float32)
+        query_points = np.array([[0.9, 0.1, 0.0]], dtype=np.float32)
+
+        for angles in ([0], [np.pi/4]):
+            for query_angles in ([0.01], [np.pi/4 + 0.01]):
+                max_width = 2
+                nbins = 4
+                self.limits = (max_width, )*2
+                self.bins = (nbins, nbins, nbins)
+
+                pmft = freud.pmft.PMFTXYT(max_width, max_width, nbins)
+                pmft.compute((box, points), angles, query_points, query_angles)
+
+                query_orientation = rowan.from_axis_angle(
+                    [0, 0, 1], query_angles[0])
+                orientation = rowan.from_axis_angle([0, 0, 1], angles[0])
+
+                self.assertEqual(
+                    tuple(np.asarray(np.where(pmft.bin_counts)).flatten()),
+                    self.get_bin(query_points[0], points[0],
+                                 query_orientation, orientation)
+                )
+                self.assertEqual(np.sum(pmft.bin_counts), 1)
+
 
 class TestPMFTXY(TestPMFT2D, unittest.TestCase):
     limits = (3.6, 4.2)
@@ -355,7 +381,7 @@ class TestPMFTXY(TestPMFT2D, unittest.TestCase):
     def get_bin(self, query_point, point, query_point_orientation,
                 point_orientation):
         r_ij = point - query_point
-        rot_r_ij = rowan.rotate(query_point_orientation, r_ij)
+        rot_r_ij = rowan.rotate(rowan.conjugate(query_point_orientation), r_ij)
 
         limits = np.asarray(self.limits)
         return tuple(np.floor((


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above. -->

## Description
<!-- Describe your changes in detail. -->
Fixes uses of orientations and query_orientations in PMFTXYT. Should be merged after #614.

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- Replace ??? with the issue number that this pull request resolves, if applicable. -->
This class is currently using the wrong set of orientations to rotate the local frame.

In debugging this, I realized that the current coordinate system makes some awkward choices, namely the theta bins are computed relative to the vector pointing from the point to the query_point. This means that if the point is oriented such that the vector corresponding to the default orientation is aligned with the r_ij vector (in the direction pointing towards the query_point), then theta is defined as 0. Not only is this choice backwards from the `bondVector` calculation in freud's `NeighborComputeFunctional`, it completely neglects the orientation of the query_point. However, this is just a convention choice, so there is no correct answer. Since this behavior has been consistent for a long time (this has not changes since pre-2.0 versions of freud), I'm inclined to just add some documentation of the definition of the angle and move forward with it as is. Does that sound right? This also affects PMFTR12, which makes some arbitrary choice about what theta1 and theta2 are, so I'll update those docstrings too if appropriate.

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to
     see how your changes affect other areas of the code, etc. -->
New test was added to validate the expected behavior.

## Screenshots
<!-- (if appropriate) -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds or improves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!-- Put an `x` in all the boxes that apply. If you're unsure about any of
     these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/glotzerlab/freud/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] I have updated the documentation (if relevant).
- [x] I have added tests that cover my changes (if relevant).
- [x] All new and existing tests passed.
- [x] I have updated the [credits](https://github.com/glotzerlab/freud/blob/master/doc/source/reference/credits.rst).
- [x] I have updated the [Changelog](https://github.com/glotzerlab/freud/blob/master/ChangeLog.md).
