### PR TITLE
Add weighted feature to Hexatic.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -10,6 +10,7 @@ and this project adheres to
 * Support for garnett 0.7.
 * Custom NeighborLists can be created from a set of points using `from_points`. Distances will be calculated automatically.
 * The Box class has methods `compute_distances` and `compute_all_distances` to calculate distances between arrays of points and query points.
+* Hexatic can now compute 2D Minkowski Structure Metrics, using `weighted=True` along with a Voronoi NeighborList.
 
 ### Changed
 * Cython is now a required dependency (not optional). Cythonized `.cpp` files have been removed.

--- a/cpp/order/HexaticTranslational.cc
+++ b/cpp/order/HexaticTranslational.cc
@@ -53,8 +53,8 @@ void Hexatic::compute(const freud::locality::NeighborList* nlist,
 {
     computeGeneral(
         [this](const vec3<float>& delta) {
-            const float psi_ij = std::atan2(delta.y, delta.x);
-            return std::exp(std::complex<float>(0, m_k * psi_ij));
+            const float theta_ij = std::atan2(delta.y, delta.x);
+            return std::exp(std::complex<float>(0, m_k * theta_ij));
         },
         nlist, points, qargs);
 }

--- a/cpp/order/HexaticTranslational.cc
+++ b/cpp/order/HexaticTranslational.cc
@@ -22,22 +22,29 @@ void HexaticTranslational<T>::computeGeneral(Func func, const freud::locality::N
     freud::locality::loopOverNeighborsIterator(
         points, points->getPoints(), Np, qargs, nlist,
         [=](size_t i, std::shared_ptr<freud::locality::NeighborPerPointIterator> ppiter) {
-            const vec3<float> ref = (*points)[i];
+            float total_weight(0);
+            const vec3<float> ref((*points)[i]);
 
             for (freud::locality::NeighborBond nb = ppiter->next(); !ppiter->end(); nb = ppiter->next())
             {
                 // Compute vector from query_point to point
                 const vec3<float> delta = box.wrap((*points)[nb.point_idx] - ref);
+                const float weight(m_weighted ? nb.weight : 1.0);
 
                 // Compute psi for this vector
-                m_psi_array[i] += func(delta);
+                m_psi_array[i] += weight * func(delta);
+                total_weight += weight;
             }
-
-            m_psi_array[i] /= std::complex<float>(m_k);
+            if (m_weighted)
+            {
+                m_psi_array[i] /= std::complex<float>(total_weight);
+            } else {
+                m_psi_array[i] /= std::complex<float>(m_k);
+            }
         });
 }
 
-Hexatic::Hexatic(unsigned int k) : HexaticTranslational<unsigned int>(k) {}
+Hexatic::Hexatic(unsigned int k, bool weighted) : HexaticTranslational<unsigned int>(k, weighted) {}
 
 Hexatic::~Hexatic() {}
 
@@ -52,7 +59,7 @@ void Hexatic::compute(const freud::locality::NeighborList* nlist,
         nlist, points, qargs);
 }
 
-Translational::Translational(float k) : HexaticTranslational<float>(k) {}
+Translational::Translational(float k, bool weighted) : HexaticTranslational<float>(k, weighted) {}
 
 Translational::~Translational() {}
 

--- a/cpp/order/HexaticTranslational.h
+++ b/cpp/order/HexaticTranslational.h
@@ -26,7 +26,7 @@ template<typename T> class HexaticTranslational
 {
 public:
     //! Constructor
-    HexaticTranslational(T k) : m_k(k) {}
+    HexaticTranslational(T k, bool weighted = false) : m_k(k), m_weighted(weighted) {}
 
     //! Destructor
     virtual ~HexaticTranslational() {}
@@ -34,6 +34,11 @@ public:
     T getK() const
     {
         return m_k;
+    }
+
+    bool isWeighted() const
+    {
+        return m_weighted;
     }
 
     //! Get a reference to the order parameter array
@@ -48,25 +53,9 @@ protected:
     void computeGeneral(Func func, const freud::locality::NeighborList* nlist,
                         const freud::locality::NeighborQuery* points, freud::locality::QueryArgs qargs);
 
-    const T m_k;
+    const T m_k;     //!< The symmetry order for Hexatic, or normalization for Translational
+    const bool m_weighted; //!< Whether to use neighbor weights in computing the order parameter (default false)
     util::ManagedArray<std::complex<float>> m_psi_array; //!< psi array computed
-};
-
-//! Compute the translational order parameter for a set of points
-/*!
- */
-class Translational : public HexaticTranslational<float>
-{
-public:
-    //! Constructor
-    Translational(float k = 6);
-
-    //! Destructor
-    ~Translational();
-
-    //! Compute the translational order parameter
-    void compute(const freud::locality::NeighborList* nlist, const freud::locality::NeighborQuery* points,
-                 freud::locality::QueryArgs qargs);
 };
 
 //! Compute the hexatic order parameter for a set of points
@@ -76,12 +65,29 @@ class Hexatic : public HexaticTranslational<unsigned int>
 {
 public:
     //! Constructor
-    Hexatic(unsigned int k = 6);
+    Hexatic(unsigned int k = 6, bool weighted = false);
 
     //! Destructor
     ~Hexatic();
 
     //! Compute the hexatic order parameter
+    void compute(const freud::locality::NeighborList* nlist, const freud::locality::NeighborQuery* points,
+                 freud::locality::QueryArgs qargs);
+};
+
+//! Compute the translational order parameter for a set of points
+/*!
+ */
+class Translational : public HexaticTranslational<float>
+{
+public:
+    //! Constructor
+    Translational(float k = 6, bool weighted = false);
+
+    //! Destructor
+    ~Translational();
+
+    //! Compute the translational order parameter
     void compute(const freud::locality::NeighborList* nlist, const freud::locality::NeighborQuery* points,
                  freud::locality::QueryArgs qargs);
 };

--- a/doc/source/reference/credits.rst
+++ b/doc/source/reference/credits.rst
@@ -101,6 +101,7 @@ Bradley Dice - **Lead developer**
 * Added finite tolerance to ensure stability of 2D Voronoi NeighborList computations.
 * Improved stability of Histogram bin calculations.
 * Improved error handling of Cubatic input parameters.
+* Added 2D Minkowski Structure Metrics to Hexatic, enabled by using ``weighted=True`` along with a Voronoi NeighborList.
 
 Eric Harper, University of Michigan - **Former lead developer**
 

--- a/freud/_order.pxd
+++ b/freud/_order.pxd
@@ -49,22 +49,22 @@ cdef extern from "Nematic.h" namespace "freud::order":
 
 cdef extern from "HexaticTranslational.h" namespace "freud::order":
     cdef cppclass Hexatic:
-        Hexatic(unsigned int)
-        const freud._box.Box & getBox() const
+        Hexatic(unsigned int, bool)
         void compute(const freud._locality.NeighborList*,
                      const freud._locality.NeighborQuery*,
                      freud._locality.QueryArgs) except +
         const freud.util.ManagedArray[float complex] &getOrder()
         unsigned int getK()
+        bool isWeighted() const
 
     cdef cppclass Translational:
-        Translational(float)
-        const freud._box.Box & getBox() const,
+        Translational(float, bool)
         void compute(const freud._locality.NeighborList*,
                      const freud._locality.NeighborQuery*,
                      freud._locality.QueryArgs) except +
         const freud.util.ManagedArray[float complex] &getOrder() const
         float getK() const
+        bool isWeighted() const
 
 
 cdef extern from "Steinhardt.h" namespace "freud::order":

--- a/freud/data.py
+++ b/freud/data.py
@@ -147,10 +147,10 @@ class UnitCell(object):
 
     @classmethod
     def fcc(cls):
-        """Create a face-centered cubic crystal.
+        """Create a face-centered cubic (fcc) unit cell.
 
         Returns:
-            :class:`~.UnitCell`: An fcc unit cell.
+            :class:`~.UnitCell`: A face-centered cubic unit cell.
         """
         fractions = np.array([[.5, .5, 0],
                               [.5, 0, .5],
@@ -160,10 +160,10 @@ class UnitCell(object):
 
     @classmethod
     def bcc(cls):
-        """Create a body-centered cubic crystal.
+        """Create a body-centered cubic (bcc) unit cell.
 
         Returns:
-            :class:`~.UnitCell`: A bcc unit cell.
+            :class:`~.UnitCell`: A body-centered cubic unit cell.
         """
         fractions = np.array([[.5, .5, .5],
                               [0, 0, 0]])
@@ -171,23 +171,33 @@ class UnitCell(object):
 
     @classmethod
     def sc(cls):
-        """Create a simple cubic crystal.
+        """Create a simple cubic (sc) unit cell.
 
         Returns:
-            :class:`~.UnitCell`: An sc unit cell.
+            :class:`~.UnitCell`: A simple cubic unit cell.
         """
         fractions = np.array([[0, 0, 0]])
         return cls([1, 1, 1], fractions)
 
     @classmethod
     def square(cls):
-        """Create a square crystal.
+        """Create a square unit cell.
 
         Returns:
             :class:`~.UnitCell`: A square unit cell.
         """
         fractions = np.array([[0, 0, 0]])
         return cls([1, 1], fractions)
+
+    @classmethod
+    def hex(cls):
+        """Create a hexagonal unit cell.
+
+        Returns:
+            :class:`~.UnitCell`: A hexagonal unit cell.
+        """
+        fractions = np.array([[0, 0, 0], [0.5, 0.5, 0]])
+        return cls([1, np.sqrt(3)], fractions)
 
 
 def make_random_system(box_size, num_points, is2D=False, seed=None):

--- a/freud/order.pyx
+++ b/freud/order.pyx
@@ -568,7 +568,7 @@ cdef class Steinhardt(_PairCompute):
             average=',ave' if self.average else '')
 
         return freud.plot.histogram_plot(
-            self.order,
+            self.particle_order,
             title="Steinhardt Order Parameter " + xlabel,
             xlabel=xlabel,
             ylabel=r"Number of particles",

--- a/freud/order.pyx
+++ b/freud/order.pyx
@@ -255,11 +255,16 @@ cdef class Hexatic(_PairCompute):
     Args:
         k (unsigned int, optional):
             Symmetry of order parameter. (Default value = :code:`6`).
+        weighted (bool, optional):
+            Determines whether to use neighbor weights in the computation of
+            spherical harmonics over neighbors. If enabled and used with a
+            Voronoi neighbor list, this results in the Minkowski Structure
+            Metrics :math:`q'_l`. (Default value = :code:`False`)
     """  # noqa: E501
     cdef freud._order.Hexatic * thisptr
 
-    def __cinit__(self, k=6):
-        self.thisptr = new freud._order.Hexatic(k)
+    def __cinit__(self, k=6, weighted=False):
+        self.thisptr = new freud._order.Hexatic(k, weighted)
 
     def __dealloc__(self):
         del self.thisptr
@@ -310,6 +315,11 @@ cdef class Hexatic(_PairCompute):
         """unsigned int: Symmetry of the order parameter."""
         return self.thisptr.getK()
 
+    @property
+    def weighted(self):
+        """bool: Whether neighbor weights were used in the computation."""
+        return self.thisptr.isWeighted()
+
     def __repr__(self):
         return "freud.order.{cls}(k={k})".format(
             cls=type(self).__name__, k=self.k)
@@ -329,7 +339,7 @@ cdef class Translational(_PairCompute):
     cdef freud._order.Translational * thisptr
 
     def __cinit__(self, k=6.0):
-        self.thisptr = new freud._order.Translational(k)
+        self.thisptr = new freud._order.Translational(k, False)
 
     def __dealloc__(self):
         del self.thisptr
@@ -451,7 +461,7 @@ cdef class Steinhardt(_PairCompute):
 
     @property
     def average(self):
-        """bool: Whether the the averaged Steinhardt order parameter was
+        """bool: Whether the averaged Steinhardt order parameter was
         calculated."""
         return self.thisptr.isAverage()
 
@@ -463,8 +473,7 @@ cdef class Steinhardt(_PairCompute):
 
     @property
     def weighted(self):
-        """bool: Whether neighbor weights were used in the computation of
-        spherical harmonics over neighbors."""
+        """bool: Whether neighbor weights were used in the computation."""
         return self.thisptr.isWeighted()
 
     @property

--- a/freud/order.pyx
+++ b/freud/order.pyx
@@ -324,6 +324,36 @@ cdef class Hexatic(_PairCompute):
         return "freud.order.{cls}(k={k}, weighted={weighted})".format(
             cls=type(self).__name__, k=self.k, weighted=self.weighted)
 
+    def plot(self, ax=None):
+        """Plot order parameter distribution.
+
+        Args:
+            ax (:class:`matplotlib.axes.Axes`, optional): Axis to plot on. If
+                :code:`None`, make a new figure and axis.
+                (Default value = :code:`None`)
+
+        Returns:
+            (:class:`matplotlib.axes.Axes`): Axis with the plot.
+        """
+        import freud.plot
+        xlabel = r"$\left|\psi{prime}_{k}\right|$".format(
+            prime='\'' if self.weighted else '',
+            k=self.k)
+
+        return freud.plot.histogram_plot(
+            np.absolute(self.particle_order),
+            title="Hexatic Order Parameter " + xlabel,
+            xlabel=xlabel,
+            ylabel=r"Number of particles",
+            ax=ax)
+
+    def _repr_png_(self):
+        try:
+            import freud.plot
+            return freud.plot._ax_to_bytes(self.plot())
+        except (AttributeError, ImportError):
+            return None
+
 
 cdef class Translational(_PairCompute):
     R"""Compute the translational order parameter for each particle.

--- a/freud/order.pyx
+++ b/freud/order.pyx
@@ -321,8 +321,8 @@ cdef class Hexatic(_PairCompute):
         return self.thisptr.isWeighted()
 
     def __repr__(self):
-        return "freud.order.{cls}(k={k})".format(
-            cls=type(self).__name__, k=self.k)
+        return "freud.order.{cls}(k={k}, weighted={weighted})".format(
+            cls=type(self).__name__, k=self.k, weighted=self.weighted)
 
 
 cdef class Translational(_PairCompute):

--- a/freud/order.pyx
+++ b/freud/order.pyx
@@ -246,7 +246,7 @@ cdef class Hexatic(_PairCompute):
     The parameter :math:`k` governs the symmetry of the order parameter and
     typically matches the number of neighbors to be found for each particle.
     The quantity :math:`\phi_{ij}` is the angle between the
-    vector :math:`r_{ij}` and :math:`\left( 1,0 \right)`.
+    vector :math:`r_{ij}` and :math:`\left(1, 0\right)`.
 
     .. note::
         **2D:** :class:`freud.order.Hexatic` is only defined for 2D systems.
@@ -258,8 +258,8 @@ cdef class Hexatic(_PairCompute):
         weighted (bool, optional):
             Determines whether to use neighbor weights in the computation of
             spherical harmonics over neighbors. If enabled and used with a
-            Voronoi neighbor list, this results in the Minkowski Structure
-            Metrics :math:`q'_l`. (Default value = :code:`False`)
+            Voronoi neighbor list, this results in the 2D Minkowski Structure
+            Metrics :math:`\psi'_k`. (Default value = :code:`False`)
     """  # noqa: E501
     cdef freud._order.Hexatic * thisptr
 
@@ -443,7 +443,7 @@ cdef class Steinhardt(_PairCompute):
         weighted (bool, optional):
             Determines whether to use neighbor weights in the computation of
             spherical harmonics over neighbors. If enabled and used with a
-            Voronoi neighbor list, this results in the Minkowski Structure
+            Voronoi neighbor list, this results in the 3D Minkowski Structure
             Metrics :math:`q'_l`. (Default value = :code:`False`)
         wl_normalize (bool, optional):
             Determines whether to normalize the :math:`w_l` version

--- a/freud/plot.py
+++ b/freud/plot.py
@@ -7,7 +7,7 @@ import numpy as np
 import warnings
 
 try:
-    from matplotlib.figure import Figure
+    import matplotlib.pyplot as plt
     from matplotlib.backends.backend_agg import FigureCanvasAgg
 except ImportError:
     raise ImportError('matplotlib must be installed for freud.plot.')
@@ -81,7 +81,7 @@ def box_plot(box, title=None, ax=None, image=[0, 0, 0], *args, **kwargs):
     box = freud.box.Box.from_box(box)
 
     if ax is None:
-        fig = Figure()
+        fig = plt.figure()
         if box.is2D:
             ax = fig.subplots()
         else:
@@ -142,7 +142,7 @@ def system_plot(system, title=None, ax=None, *args, **kwargs):
     system = freud.locality.NeighborQuery.from_system(system)
 
     if ax is None:
-        fig = Figure()
+        fig = plt.figure()
         if system.box.is2D:
             ax = fig.subplots()
         else:
@@ -190,7 +190,7 @@ def bar_plot(x, height, title=None, xlabel=None, ylabel=None, ax=None):
         :class:`matplotlib.axes.Axes`: Axes object with the diagram.
     """
     if ax is None:
-        fig = Figure()
+        fig = plt.figure()
         ax = fig.subplots()
 
     ax.bar(x=x, height=height)
@@ -245,7 +245,7 @@ def line_plot(x, y, title=None, xlabel=None, ylabel=None, ax=None):
         :class:`matplotlib.axes.Axes`: Axes object with the diagram.
     """
     if ax is None:
-        fig = Figure()
+        fig = plt.figure()
         ax = fig.subplots()
 
     ax.plot(x, y)
@@ -271,7 +271,7 @@ def histogram_plot(values, title=None, xlabel=None, ylabel=None, ax=None):
         :class:`matplotlib.axes.Axes`: Axes object with the diagram.
     """
     if ax is None:
-        fig = Figure()
+        fig = plt.figure()
         ax = fig.subplots()
 
     ax.hist(values)
@@ -299,7 +299,7 @@ def pmft_plot(pmft, ax=None):
 
     # Plot figures
     if ax is None:
-        fig = Figure()
+        fig = plt.figure()
         ax = fig.subplots()
 
     pmft_arr = np.copy(pmft.PMFT)
@@ -348,7 +348,7 @@ def density_plot(density, box, ax=None):
     from matplotlib.colorbar import Colorbar
 
     if ax is None:
-        fig = Figure()
+        fig = plt.figure()
         ax = fig.subplots()
 
     xlims = (-box.Lx/2, box.Lx/2)
@@ -398,7 +398,7 @@ def voronoi_plot(box, polytopes, ax=None, color_by_sides=True, cmap=None):
     from matplotlib.colorbar import Colorbar
 
     if ax is None:
-        fig = Figure()
+        fig = plt.figure()
         ax = fig.subplots()
 
     # Draw Voronoi polytopes

--- a/tests/test_box_Box.py
+++ b/tests/test_box_Box.py
@@ -2,8 +2,10 @@ import numpy as np
 import numpy.testing as npt
 import freud
 from collections import namedtuple
+import matplotlib
 import unittest
 import warnings
+matplotlib.use('agg')
 
 
 class TestBox(unittest.TestCase):

--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -1,10 +1,11 @@
 import numpy as np
 import numpy.testing as npt
 import freud
+import matplotlib
 import unittest
 import util
-
 from test_managedarray import TestManagedArray
+matplotlib.use('agg')
 
 
 class TestCluster(unittest.TestCase):

--- a/tests/test_density_CorrelationFunction.py
+++ b/tests/test_density_CorrelationFunction.py
@@ -1,14 +1,15 @@
 import numpy as np
 import numpy.testing as npt
 import freud
+import matplotlib
 import unittest
 import util
-
 from test_managedarray import TestManagedArray
+matplotlib.use('agg')
 
 
 class TestCorrelationFunction(unittest.TestCase):
-    def test_generateR(self):
+    def test_generate_bins(self):
         r_max = 5
         dr = 0.1
         bins = round(r_max / dr)

--- a/tests/test_density_GaussianDensity.py
+++ b/tests/test_density_GaussianDensity.py
@@ -1,8 +1,10 @@
 import numpy as np
 import numpy.testing as npt
 import freud
+import matplotlib
 import unittest
 import util
+matplotlib.use('agg')
 
 
 class TestDensity(unittest.TestCase):

--- a/tests/test_density_RDF.py
+++ b/tests/test_density_RDF.py
@@ -1,10 +1,11 @@
 import numpy as np
 import numpy.testing as npt
 import freud
+import matplotlib
 import unittest
 import util
-
 from test_managedarray import TestManagedArray
+matplotlib.use('agg')
 
 
 class TestRDF(unittest.TestCase):

--- a/tests/test_environment_MatchEnv.py
+++ b/tests/test_environment_MatchEnv.py
@@ -1,8 +1,10 @@
 import numpy as np
 import numpy.testing as npt
 import freud
+import matplotlib
 import unittest
 import os
+matplotlib.use('agg')
 
 
 class TestCluster(unittest.TestCase):

--- a/tests/test_locality_NeighborQuery.py
+++ b/tests/test_locality_NeighborQuery.py
@@ -1,11 +1,12 @@
 import numpy as np
 import numpy.testing as npt
 import freud
+import matplotlib
 from collections import Counter
 import itertools
 import unittest
-
 import util
+matplotlib.use('agg')
 
 """
 Define helper functions for getting the neighbors of a point. Note that

--- a/tests/test_locality_Voronoi.py
+++ b/tests/test_locality_Voronoi.py
@@ -1,8 +1,10 @@
 import numpy as np
 import numpy.testing as npt
 import freud
+import matplotlib
 import unittest
 from util import sort_rounded_xyz_array
+matplotlib.use('agg')
 
 
 class TestVoronoi(unittest.TestCase):

--- a/tests/test_msd_MSD.py
+++ b/tests/test_msd_MSD.py
@@ -1,7 +1,9 @@
 import numpy as np
 import numpy.testing as npt
 import freud
+import matplotlib
 import unittest
+matplotlib.use('agg')
 
 
 class TestMSD(unittest.TestCase):

--- a/tests/test_order_Hexatic.py
+++ b/tests/test_order_Hexatic.py
@@ -1,8 +1,10 @@
 import numpy.testing as npt
 import numpy as np
 import freud
+import matplotlib
 import unittest
 import util
+matplotlib.use('agg')
 
 
 class TestHexatic(unittest.TestCase):
@@ -99,6 +101,19 @@ class TestHexatic(unittest.TestCase):
 
         hop = freud.order.Hexatic(7, weighted=True)
         self.assertEqual(str(hop), str(eval(repr(hop))))
+
+    def test_repr_png(self):
+        boxlen = 10
+        N = 500
+        box, points = freud.data.make_random_system(boxlen, N, is2D=True)
+        hop = freud.order.Hexatic()
+        with self.assertRaises(AttributeError):
+            hop.plot()
+        self.assertEqual(hop._repr_png_(), None)
+
+        hop.compute((box, points))
+        hop._repr_png_()
+        hop.plot()
 
 
 if __name__ == '__main__':

--- a/tests/test_order_Hexatic.py
+++ b/tests/test_order_Hexatic.py
@@ -80,12 +80,30 @@ class TestHexatic(unittest.TestCase):
         hop.compute(system=(box, points), neighbors=voro.nlist)
         npt.assert_allclose(np.absolute(hop.particle_order), 0., atol=1e-4)
 
-        # Ensure that \psi'_k is between 0 and 1
-        for k in range(2, 10):
-            hop = freud.order.Hexatic(k=1, weighted=True)
+        for k in range(0, 12):
+            # Ensure that \psi'_k is between 0 and 1
+            hop = freud.order.Hexatic(k=k, weighted=True)
             hop.compute(system=(box, points), neighbors=voro.nlist)
             order = np.absolute(hop.particle_order)
             assert (order >= 0).all() and (order <= 1).all()
+
+            # Perform an explicit calculation in NumPy to verify results
+            psi_k_weighted = np.zeros(len(points), dtype=np.complex)
+            total_weights = np.zeros(len(points))
+            rijs = box.wrap(points[voro.nlist.point_indices] -
+                            points[voro.nlist.query_point_indices])
+            thetas = np.arctan2(rijs[:, 1], rijs[:, 0])
+            total_weights, _ = np.histogram(
+                voro.nlist.query_point_indices,
+                bins=len(points),
+                weights=voro.nlist.weights)
+            psi_k_weighted, _ = np.histogram(
+                voro.nlist.query_point_indices,
+                bins=len(points),
+                weights=voro.nlist.weights * np.exp(thetas * k * 1.0j))
+            psi_k_weighted /= total_weights
+
+            npt.assert_allclose(hop.particle_order, psi_k_weighted, atol=1e-5)
 
     def test_weighted_square(self):
         unitcell = freud.data.UnitCell.square()

--- a/tests/test_order_Hexatic.py
+++ b/tests/test_order_Hexatic.py
@@ -63,7 +63,7 @@ class TestHexatic(unittest.TestCase):
 
             npt.assert_allclose(hop.particle_order[0], 1. + 0.j, atol=1e-1)
 
-    def test_weighted(self):
+    def test_weighted_random(self):
         boxlen = 10
         N = 500
         box, points = freud.data.make_random_system(boxlen, N, is2D=True)
@@ -86,6 +86,38 @@ class TestHexatic(unittest.TestCase):
             hop.compute(system=(box, points), neighbors=voro.nlist)
             order = np.absolute(hop.particle_order)
             assert (order >= 0).all() and (order <= 1).all()
+
+    def test_weighted_square(self):
+        unitcell = freud.data.UnitCell.square()
+        box, points = unitcell.generate_system(num_replicas=10)
+        voro = freud.locality.Voronoi()
+        voro.compute(system=(box, points))
+
+        # Ensure that \psi'_4 is 1
+        hop = freud.order.Hexatic(k=4, weighted=True)
+        hop.compute(system=(box, points), neighbors=voro.nlist)
+        npt.assert_allclose(np.absolute(hop.particle_order), 1., atol=1e-5)
+
+        # Ensure that \psi'_6 is 0
+        hop = freud.order.Hexatic(k=6, weighted=True)
+        hop.compute(system=(box, points), neighbors=voro.nlist)
+        npt.assert_allclose(np.absolute(hop.particle_order), 0., atol=1e-5)
+
+    def test_weighted_hex(self):
+        unitcell = freud.data.UnitCell.hex()
+        box, points = unitcell.generate_system(num_replicas=10)
+        voro = freud.locality.Voronoi()
+        voro.compute(system=(box, points))
+
+        # Ensure that \psi'_6 is 1
+        hop = freud.order.Hexatic(k=6, weighted=True)
+        hop.compute(system=(box, points), neighbors=voro.nlist)
+        npt.assert_allclose(np.absolute(hop.particle_order), 1., atol=1e-5)
+
+        # Ensure that \psi'_4 is 0
+        hop = freud.order.Hexatic(k=4, weighted=True)
+        hop.compute(system=(box, points), neighbors=voro.nlist)
+        npt.assert_allclose(np.absolute(hop.particle_order), 0., atol=1e-5)
 
     def test_3d_box(self):
         boxlen = 10

--- a/tests/test_order_SolidLiquid.py
+++ b/tests/test_order_SolidLiquid.py
@@ -1,6 +1,8 @@
 import numpy.testing as npt
 import freud
+import matplotlib
 import unittest
+matplotlib.use('agg')
 
 
 class TestSolidLiquid(unittest.TestCase):

--- a/tests/test_order_Steinhardt.py
+++ b/tests/test_order_Steinhardt.py
@@ -1,9 +1,11 @@
 import numpy as np
 import numpy.testing as npt
 import freud
+import matplotlib
 import rowan
 import unittest
 import util
+matplotlib.use('agg')
 
 # Validated against manual calculation and pyboo
 PERFECT_FCC_Q6 = 0.57452416
@@ -290,6 +292,20 @@ class TestSteinhardt(unittest.TestCase):
         # Use non-default arguments for all parameters
         comp = freud.order.Steinhardt(6, average=True, wl=True, weighted=True)
         self.assertEqual(str(comp), str(eval(repr(comp))))
+
+    def test_repr_png(self):
+        L = 5
+        num_points = 100
+        box, points = freud.data.make_random_system(L, num_points, seed=0)
+        st = freud.order.Steinhardt(6)
+
+        with self.assertRaises(AttributeError):
+            st.plot()
+        self.assertEqual(st._repr_png_(), None)
+
+        st.compute(system=(box, points), neighbors={'r_max': 1.5})
+
+        st._repr_png_()
 
 
 if __name__ == '__main__':

--- a/tests/test_pmft.py
+++ b/tests/test_pmft.py
@@ -1,12 +1,13 @@
 import numpy as np
 import numpy.testing as npt
 import freud
+import matplotlib
 import unittest
 import warnings
 import util
 import rowan
-
 from test_managedarray import TestManagedArray
+matplotlib.use('agg')
 
 
 class TestPMFTR12(unittest.TestCase):


### PR DESCRIPTION
## Description
Adds support for weighted bonds in the Hexatic order parameter, enabling Minkowski Structure Metric computations in 2D systems. Requested by user @gabriele16.

## Motivation and Context
Resolves: #617.

## How Has This Been Tested?
(Not yet tested.)

## Screenshots
![index](https://user-images.githubusercontent.com/3943761/82232658-8809b080-98f4-11ea-9730-1bea5ff3c007.png)


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds or improves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have read the [**CONTRIBUTING**](https://github.com/glotzerlab/freud/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] I have updated the documentation (if relevant).
- [x] I have added tests that cover my changes (if relevant).
- [x] All new and existing tests passed.
- [x] I have updated the [credits](https://github.com/glotzerlab/freud/blob/master/doc/source/reference/credits.rst).
- [x] I have updated the [Changelog](https://github.com/glotzerlab/freud/blob/master/ChangeLog.md).
