### PR TITLE
Fixed Steinhardt for particles with no neighbors

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -20,6 +20,7 @@ and this project adheres to
 * Improved error handling of Cubatic input parameters.
 * PMFTs are now properly normalized such that the pair correlation function tends to unity for an ideal gas.
 * PMFTXYT uses the correct orientations when points and query\_points differ.
+* Fixed Steinhardt for particles without neighbors.
 
 ## v2.2.0 - 2020-02-24
 

--- a/cpp/order/Steinhardt.cc
+++ b/cpp/order/Steinhardt.cc
@@ -135,7 +135,8 @@ void Steinhardt::baseCompute(const freud::locality::NeighborList* nlist,
             {
                 // Cache the index for efficiency.
                 const unsigned int index = m_qlmi.getIndex({static_cast<unsigned int>(i), k});
-                m_qlmi[index] /= total_weight;
+                if (total_weight > 0)
+                    m_qlmi[index] /= total_weight;
                 // Add the norm, which is the (complex) squared magnitude
                 m_qli[i] += norm(m_qlmi[index]);
                 // This array gets populated by computeAve in the averaging case.

--- a/doc/source/reference/credits.rst
+++ b/doc/source/reference/credits.rst
@@ -287,6 +287,10 @@ Mike Henry
 * Fixed syntax in freud-examples notebooks for v2.0.
 * Updated documentation links
 
+Maya Martirossyan
+
+* Fixed Steinhardt for particles without neighbors.
+
 Source code
 -----------
 

--- a/tests/test_order_Steinhardt.py
+++ b/tests/test_order_Steinhardt.py
@@ -309,11 +309,12 @@ class TestSteinhardt(unittest.TestCase):
 
     def test_no_neighbors(self):
         box = freud.box.Box.cube(10)
-        positions = [(0,0,0)]
+        positions = [(0, 0, 0)]
         comp = freud.order.Steinhardt(6)
-        comp.compute((box, positions), neighbors={'r_max':1.25})
-        
+        comp.compute((box, positions), neighbors={'r_max': 1.25})
+
         npt.assert_allclose(comp.particle_order, [0])
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_order_Steinhardt.py
+++ b/tests/test_order_Steinhardt.py
@@ -307,6 +307,13 @@ class TestSteinhardt(unittest.TestCase):
 
         st._repr_png_()
 
+    def test_no_neighbors(self):
+        box = freud.box.Box.cube(10)
+        positions = [(0,0,0)]
+        comp = freud.order.Steinhardt(6)
+        comp.compute((box, positions), neighbors={'r_max':1.25})
+        
+        npt.assert_allclose(comp.particle_order, [0])
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above. -->

## Description
<!-- Describe your changes in detail. -->

Particles with 0 neighbors were have NaN order parameter values because there was a division by 0. This prevents the division by 0.

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- Replace ??? with the issue number that this pull request resolves, if applicable. -->
Resolves: #???

It is useful for cases where particles have no neighbors (ie other particles are further apart than the r_max defined).

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to
     see how your changes affect other areas of the code, etc. -->

There has been a test_no_neighbors function added to the test_order_Steinhardt.py file which initializes a single particle in a box and computes its Steinhardt order parameter, and makes sure that it is 0.

## Screenshots
<!-- (if appropriate) -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds or improves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation improvement (updates to user guides, docstrings, or developer docs)

## Checklist:
<!-- Put an `x` in all the boxes that apply. If you're unsure about any of
     these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/glotzerlab/freud/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] I have updated the documentation (if relevant).
- [x] I have added tests that cover my changes (if relevant).
- [x] All new and existing tests passed.
- [x] I have updated the [credits](https://github.com/glotzerlab/freud/blob/master/doc/source/reference/credits.rst).
- [x] I have updated the [Changelog](https://github.com/glotzerlab/freud/blob/master/ChangeLog.md).
