### PR TITLE
Use non-broken build of ld_impl_linux-64 for ReadTheDocs.

### DIFF
--- a/doc/readthedocs-env.yml
+++ b/doc/readthedocs-env.yml
@@ -36,7 +36,7 @@ dependencies:
   - jupyter_core=4.6.3=py38h32f6830_1
   - jupyter_sphinx=0.2.4=py38h32f6830_0
   - latexcodec=2.0.0=py_0
-  - ld_impl_linux-64=2.34=h53a641e_0
+  - ld_impl_linux-64=2.34=h53a641e_5
   - libblas=3.8.0=16_openblas
   - libcblas=3.8.0=16_openblas
   - libffi=3.2.1=he1b5a44_1007


### PR DESCRIPTION
## Description
Documentation builds are failing because a conda dependency has been marked as broken. I have updated the package. I will merge this after verifying that it fixes our ReadTheDocs builds.

Broken build: https://readthedocs.org/projects/freud/builds/11261955/
Version list: https://anaconda.org/conda-forge/ld_impl_linux-64/files

Fixed build: https://readthedocs.org/projects/freud/builds/11297394/