### PR TITLE
Add Cython pyx, pxd, pxi files to MANIFEST.in

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -9,6 +9,9 @@ and this project adheres to
 ### Added
 * The Box class has a method `contains` to determine particle membership in a box.
 
+### Fixed
+* Source distributions now include Cython source files.
+
 ## v2.3.0 - 2020-08-03
 
 ### Added

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 recursive-include cpp *.cc *.h
 recursive-include extern *
+recursive-include freud *.py *.pyx *.pxd *.pxi
 include LICENSE pyproject.toml


### PR DESCRIPTION
## Description
The release of freud 2.3.0 failed on conda-forge with the PyPI tarball: https://github.com/conda-forge/freud-feedstock/pull/30/

The root cause is that freud's `MANIFEST.in` did not include Cython `*.pyx` and `*.pxd` files in the source distribution, meaning that the source distribution did not detect the Cython modules and could not build. Luckily the tarball hosted at http://glotzerlab.engin.umich.edu/Downloads/freud/ included these files, allowing for a build that is still nearly-canonical (building from the PyPI tarball would have been preferable because the PyPI tarball is smaller and consistent with the released PyPI builds).

## Motivation and Context
Fixes conda-forge builds for the future.

## How Has This Been Tested?
Tested locally by verifying the outputs of `python setup.py sdist`.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds or improves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation improvement (updates to user guides, docstrings, or developer docs)

## Checklist:
<!-- Put an `x` in all the boxes that apply. If you're unsure about any of
     these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/glotzerlab/freud/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] I have updated the documentation (if relevant).
- [ ] I have added tests that cover my changes (if relevant).
- [ ] All new and existing tests passed.
- [ ] I have updated the [credits](https://github.com/glotzerlab/freud/blob/master/doc/source/reference/credits.rst).
- [x] I have updated the [Changelog](https://github.com/glotzerlab/freud/blob/master/ChangeLog.md).
