### PR TITLE
Add newlines after example blocks to fix Sphinx rendering.

### DIFF
--- a/freud/box.pyx
+++ b/freud/box.pyx
@@ -590,6 +590,7 @@ cdef class Box:
         R"""Return box as dictionary.
 
         Example::
+
             >>> box = freud.box.Box.cube(L=10)
             >>> box.to_dict()
             {'Lx': 10.0, 'Ly': 10.0, 'Lz': 10.0,
@@ -611,6 +612,7 @@ cdef class Box:
         R"""Returns the box matrix (3x3).
 
         Example::
+
             >>> box = freud.box.Box.cube(L=10)
             >>> box.to_matrix()
             array([[10.,  0.,  0.],

--- a/freud/cluster.pyx
+++ b/freud/cluster.pyx
@@ -184,6 +184,7 @@ cdef class ClusterProperties(_Compute):
         :code:`centers` and :code:`gyrations` attributes.
 
         Example::
+
             >>> import freud
             >>> # Compute clusters using box, positions, and nlist data
             >>> box, points = freud.data.make_random_system(10, 100)

--- a/freud/density.pyx
+++ b/freud/density.pyx
@@ -469,6 +469,7 @@ cdef class LocalDensity(_PairCompute):
         R"""Calculates the local density for the specified points.
 
         Example::
+
             >>> import freud
             >>> box, points = freud.data.make_random_system(10, 100, seed=0)
             >>> # Compute Local Density

--- a/freud/environment.pyx
+++ b/freud/environment.pyx
@@ -535,6 +535,7 @@ cdef class EnvironmentCluster(_MatchEnv):
         required neighbor is just outside the cutoff.
 
         Example::
+
             >>> import freud
             >>> # Compute clusters of particles with matching environments
             >>> box, points = freud.data.make_random_system(10, 100, seed=0)

--- a/freud/order.pyx
+++ b/freud/order.pyx
@@ -176,6 +176,7 @@ cdef class Nematic(_Compute):
         R"""Calculates the per-particle and global order parameter.
 
         Example::
+
             >>> orientations = np.array([[1, 0, 0, 0]] * 100)
             >>> director = np.array([1, 1, 0])
             >>> nematic = freud.order.Nematic(director)
@@ -280,6 +281,7 @@ cdef class Hexatic(_PairCompute):
         R"""Calculates the hexatic order parameter.
 
         Example::
+
             >>> box, points = freud.data.make_random_system(
             ...     box_size=10, num_points=100, is2D=True, seed=0)
             >>> # Compute the hexatic (6-fold) order for the 2D system
@@ -561,6 +563,7 @@ cdef class Steinhardt(_PairCompute):
         R"""Compute the order parameter.
 
         Example::
+
             >>> box, points = freud.data.make_random_system(10, 100, seed=0)
             >>> ql = freud.order.Steinhardt(l=6)
             >>> ql.compute((box, points), {'r_max':3})


### PR DESCRIPTION
Minor fix to docstrings. Example blocks were missing a newline before the code started. Can be merged after tests pass.

### Incorrect rendering:

```python
def func():
    """Description.

    Example::
        >>> # code sample missing newline above
    
    """
```
![image](https://user-images.githubusercontent.com/3943761/93421543-3f004380-f877-11ea-9851-da29ec9f5290.png)

### Correct rendering:

```python
def func():
    """Description.

    Example::

        >>> # code sample with newline above
    
    """
```
![image](https://user-images.githubusercontent.com/3943761/93421757-d9f91d80-f877-11ea-8f71-224f895ee89f.png)
