### PR TITLE
Expose nlist.num_points and nlist.num_query_points

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ### Added
 * The Box class has a method `contains` to determine particle membership in a box.
+* NeighborList class exposes `num_points` and `num_query_points` attributes.
+
+### Changed
+* NeighborList raises a `ValueError` instead of a `RuntimeError` if provided invalid constructor arguments.
 
 ### Fixed
 * Source distributions now include Cython source files.

--- a/cpp/locality/NeighborList.cc
+++ b/cpp/locality/NeighborList.cc
@@ -34,12 +34,12 @@ NeighborList::NeighborList(unsigned int num_bonds, const unsigned int* query_poi
     {
         index = query_point_index[i];
         if (index < last_index)
-            throw std::runtime_error("NeighborList query_point_index must be sorted.");
+            throw std::invalid_argument("NeighborList query_point_index must be sorted.");
         if (index >= m_num_query_points)
-            throw std::runtime_error(
+            throw std::invalid_argument(
                 "NeighborList query_point_index values must be less than num_query_points.");
         if (point_index[i] >= m_num_points)
-            throw std::runtime_error("NeighborList point_index values must be less than num_points.");
+            throw std::invalid_argument("NeighborList point_index values must be less than num_points.");
         m_neighbors(i, 0) = index;
         m_neighbors(i, 1) = point_index[i];
         m_weights[i] = weights[i];

--- a/doc/source/reference/credits.rst
+++ b/doc/source/reference/credits.rst
@@ -107,6 +107,7 @@ Bradley Dice - **Lead developer**
 * Fixed GaussianDensity normalization in 2D systems.
 * Prevented GaussianDensity from computing 3D systems after it has computed 2D systems.
 * Contributed code, design, and testing for ``DiffractionPattern`` class.
+* Added ``num_query_points`` and ``num_points`` attributes to NeighborList class.
 
 Eric Harper, University of Michigan - **Former lead developer**
 

--- a/freud/locality.pyx
+++ b/freud/locality.pyx
@@ -639,6 +639,23 @@ cdef class NeighborList:
         R"""Returns the number of bonds stored in this object."""
         return self.thisptr.getNumBonds()
 
+    @property
+    def num_query_points(self):
+        """Returns the number of query points.
+
+        All query point indices must be less than this value.
+        """
+
+        return self.thisptr.getNumQueryPoints()
+
+    @property
+    def num_points(self):
+        """Returns the number of points.
+
+        All point indices are less than this value.
+        """
+        return self.thisptr.getNumPoints()
+
     def find_first_index(self, unsigned int i):
         R"""Returns the lowest bond index corresponding to a query particle
         with an index :math:`\geq i`.

--- a/freud/locality.pyx
+++ b/freud/locality.pyx
@@ -643,7 +643,7 @@ cdef class NeighborList:
     def num_query_points(self):
         """Returns the number of query points.
 
-        All query point indices must be less than this value.
+        All query point indices are less than this value.
         """
         return self.thisptr.getNumQueryPoints()
 

--- a/freud/locality.pyx
+++ b/freud/locality.pyx
@@ -641,7 +641,7 @@ cdef class NeighborList:
 
     @property
     def num_query_points(self):
-        """Returns the number of query points.
+        """unsigned int: The number of query points.
 
         All query point indices are less than this value.
         """
@@ -649,7 +649,7 @@ cdef class NeighborList:
 
     @property
     def num_points(self):
-        """Returns the number of points.
+        """unsigned int: The number of points.
 
         All point indices are less than this value.
         """

--- a/freud/locality.pyx
+++ b/freud/locality.pyx
@@ -645,7 +645,6 @@ cdef class NeighborList:
 
         All query point indices must be less than this value.
         """
-
         return self.thisptr.getNumQueryPoints()
 
     @property

--- a/tests/test_locality_NeighborList.py
+++ b/tests/test_locality_NeighborList.py
@@ -151,17 +151,17 @@ class TestNeighborList(unittest.TestCase):
         npt.assert_equal(nlist.segments, nlist2.segments)
 
         # too few reference particles
-        with self.assertRaises(RuntimeError):
+        with self.assertRaises(ValueError):
             freud.locality.NeighborList.from_arrays(
                 3, 4, query_point_indices, point_indices, distances)
 
         # too few target particles
-        with self.assertRaises(RuntimeError):
+        with self.assertRaises(ValueError):
             freud.locality.NeighborList.from_arrays(
                 4, 3, query_point_indices, point_indices, distances)
 
         # query particles not sorted
-        with self.assertRaises(RuntimeError):
+        with self.assertRaises(ValueError):
             freud.locality.NeighborList.from_arrays(
                 4, 4, point_indices, query_point_indices, distances)
 

--- a/tests/test_locality_NeighborList.py
+++ b/tests/test_locality_NeighborList.py
@@ -249,6 +249,23 @@ class TestNeighborList(unittest.TestCase):
 
         self.assertEqual(tuples, sorted_tuples)
 
+    def test_num_points(self):
+        query_point_indices = [0, 0, 1, 2, 3]
+        point_indices = [1, 2, 3, 0, 0]
+        distances = np.ones(len(query_point_indices))
+
+        # test num_query_points and num_points when built from arrays
+        nlist = freud.locality.NeighborList.from_arrays(
+            42, 99, query_point_indices, point_indices, distances)
+        self.assertEqual(nlist.num_query_points, 42)
+        self.assertEqual(nlist.num_points, 99)
+
+        # test num_query_points and num_points when built from a query
+        nlist = self.nq.query(self.nq.points[:-1],
+                              self.query_args).toNeighborList()
+        self.assertEqual(nlist.num_query_points, len(self.nq.points)-1)
+        self.assertEqual(nlist.num_points, len(self.nq.points))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Description
This PR exposes the number of (query) points in a NeighborList object. I think it is just a mild oversight in our API that this wasn't available already, since the state is known by the C++ class and it is exposed to Cython.

I also changed a couple of errors from `std::runtime_error` / `RuntimeError` to `std::invalid_argument` / `ValueError` since that seemed like the more descriptive / appropriate choice for the error and it is in alignment with how we handle invalid constructor arguments in compute classes. This is minorly breaking but I think it's an acceptable change for 2.x releases. I documented the change in the changelog.

## How Has This Been Tested?
Added a test for the new properties, modified tests for errors.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds or improves functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation improvement (updates to user guides, docstrings, or developer docs)

## Checklist:
- [x] I have read the [**CONTRIBUTING**](https://github.com/glotzerlab/freud/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] I have updated the documentation (if relevant).
- [x] I have added tests that cover my changes (if relevant).
- [x] All new and existing tests passed.
- [x] I have updated the [credits](https://github.com/glotzerlab/freud/blob/master/doc/source/reference/credits.rst).
- [x] I have updated the [Changelog](https://github.com/glotzerlab/freud/blob/master/ChangeLog.md).
