### PR TITLE
Enable scikit-build on Windows

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,7 +101,7 @@ references:
       name: Build with MSVC
       # Load MSVC environment variables before building
       command: |
-        %comspec% /k "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvarsall.bat" x64
+        "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvarsall.bat" x64
         python${PYVER} --version
         python${PYVER} setup.py build_ext --inplace -- -DCOVERAGE=ON
       shell: cmd.exe

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,7 +101,7 @@ references:
       name: Build with MSVC
       # Load MSVC environment variables before building
       command: |
-        "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvarsall.bat" x64
+        C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvarsall.bat x64
         python${PYVER} --version
         python${PYVER} setup.py build_ext --inplace -- -DCOVERAGE=ON
       shell: cmd.exe

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,7 +65,7 @@ references:
         # Invoke-RestMethod -Uri https://curl.haxx.se/ca/cacert.pem -Method Get | Out-File cacert.pem
         python -m pip install --progress-bar off -U -r requirements-testing.txt
         # Update cmake to support Visual Studio 2019 generator
-        python -m pip install -U cmake==3.14.4post1
+        python -m pip install -U scikit-build==0.10.0 cmake==3.14.4post1
 
   get_style_requirements: &get_style_requirements
     run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,13 +59,10 @@ references:
         conda config --set always_yes yes --set changeps1 no
         conda config --add channels conda-forge
         conda update -q conda certifi
-        conda install python pip tbb tbb-devel ninja
-        # Install from PyPI instead of conda-forge for consistency with Linux.
-        # For some reason, the SSL certificates used by pip aren't correct, even with certifi.
-        # Invoke-RestMethod -Uri https://curl.haxx.se/ca/cacert.pem -Method Get | Out-File cacert.pem
-        python -m pip install --progress-bar off -U -r requirements-testing.txt
-        # Update cmake to support Visual Studio 2019 generator
-        python -m pip install -U scikit-build==0.10.0 cmake==3.14.4post1
+        conda install python pip tbb tbb-devel
+        conda install --file requirements-testing.txt
+        # Install cmake 3.14 to support Visual Studio 2019 generator
+        conda install scikit-build=0.10 cmake=3.14
 
   get_style_requirements: &get_style_requirements
     run:
@@ -296,7 +293,6 @@ jobs:
       PYVER: ""  # Windows CI image doesn't have aliases for python3.7
       TBB_INCLUDE: "C:\\tools\\miniconda3\\Library\\include"
       TBB_LINK: "C:\\tools\\miniconda3\\Library\\lib"
-      VCVARSALL: "C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Community\\VC\\Auxiliary\\Build\\vcvarsall.bat"
     <<: *build_and_test_windows
 
   test-deploy-pypi-linux:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -118,6 +118,12 @@ references:
           coverage run -m unittest discover tests -v
           bash <(curl -s https://codecov.io/bash)
 
+  test_windows: &test_windows
+    run:
+      name: Run unit tests
+      command: |
+          python -m unittest discover tests -v
+
   store: &store
     store_artifacts:
       path: test-reports
@@ -183,7 +189,7 @@ references:
       - *update_submodules
       - *get_conda_requirements
       - *build_windows
-      - *test_cov
+      - *test_windows
       - *store
 
   load_check_style: &load_check_style

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,6 +88,13 @@ references:
       command: |
         python${PYVER} -m flake8 --show-source .
 
+  prepare_msvc: &prepare_msvc
+    run:
+      name: Prepare MSVC
+      command: |
+        %comspec% /k "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvarsall.bat" x64
+      shell: cmd.exe
+
   build: &build
     run:
       name: Build
@@ -174,6 +181,7 @@ references:
       - *load_code
       - *update_submodules
       - *get_conda_requirements
+      - *prepare_msvc
       - *build
       - *test_cov
       - *store

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,7 +101,6 @@ references:
       name: Build with MSVC
       # Load MSVC environment variables before building
       command: |
-        "%VCVARSALL%" x64
         python --version
         python setup.py build_ext --inplace -- -DCOVERAGE=ON
       shell: cmd.exe

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,7 +60,7 @@ references:
         conda config --add channels conda-forge
         conda update -q conda certifi
         conda install python pip tbb tbb-devel
-        conda install --file requirements-testing.txt
+        conda install coverage cython garnett GitPython gsd matplotlib-base MDAnalysis numpy rowan scipy sympy
         # Install cmake 3.14 to support Visual Studio 2019 generator
         conda install scikit-build=0.10 cmake=3.14
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,7 +62,7 @@ references:
         conda install python pip tbb tbb-devel ninja
         # Install from PyPI instead of conda-forge for consistency with Linux.
         # For some reason, the SSL certificates used by pip aren't correct, even with certifi.
-        Invoke-RestMethod -Uri https://curl.haxx.se/ca/cacert.pem -Method Get | Out-File cacert.pem
+        # Invoke-RestMethod -Uri https://curl.haxx.se/ca/cacert.pem -Method Get | Out-File cacert.pem
         python -m pip install --cert cacert.pem --progress-bar off -U -r requirements-testing.txt
 
   get_style_requirements: &get_style_requirements

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,7 +101,7 @@ references:
       name: Build with MSVC
       # Load MSVC environment variables before building
       command: |
-        cmd.exe /k ${VCVARSALL} x64
+        cmd.exe /k %VCVARSALL% x64
         python${PYVER} --version
         python${PYVER} setup.py build_ext --inplace -- -DCOVERAGE=ON
       shell: cmd.exe

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,7 +62,7 @@ references:
         conda install python pip tbb tbb-devel ninja
         # Install from PyPI instead of conda-forge for consistency with Linux.
         # For some reason, the SSL certificates used by pip aren't correct, even with certifi.
-        curl -O https://curl.haxx.se/ca/cacert.pem
+        Invoke-RestMethod -Uri https://curl.haxx.se/ca/cacert.pem -Method Get | Out-File cacert.pem
         python -m pip install --cert cacert.pem --progress-bar off -U -r requirements-testing.txt
 
   get_style_requirements: &get_style_requirements

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,13 +88,6 @@ references:
       command: |
         python${PYVER} -m flake8 --show-source .
 
-  prepare_msvc: &prepare_msvc
-    run:
-      name: Prepare MSVC
-      command: |
-        %comspec% /k "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvarsall.bat" x64
-      shell: cmd.exe
-
   build: &build
     run:
       name: Build
@@ -102,6 +95,16 @@ references:
         python${PYVER} --version
         # Max 4 threads to not overtax CI.
         python${PYVER} setup.py build_ext --inplace -- -DCOVERAGE=ON -- -j 4 -v
+
+  build_windows: &build_windows
+    run:
+      name: Build with MSVC
+      # Load MSVC environment variables before building
+      command: |
+        %comspec% /k "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvarsall.bat" x64
+        python${PYVER} --version
+        python${PYVER} setup.py build_ext --inplace -- -DCOVERAGE=ON
+      shell: cmd.exe
 
   test: &test
     run:
@@ -181,8 +184,7 @@ references:
       - *load_code
       - *update_submodules
       - *get_conda_requirements
-      - *prepare_msvc
-      - *build
+      - *build_windows
       - *test_cov
       - *store
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,7 +101,7 @@ references:
       name: Build with MSVC
       # Load MSVC environment variables before building
       command: |
-        "C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Community\\VC\\Auxiliary\\Build\\vcvarsall.bat" x64
+        cmd.exe /k ${VCVARSALL} x64
         python${PYVER} --version
         python${PYVER} setup.py build_ext --inplace -- -DCOVERAGE=ON
       shell: cmd.exe
@@ -291,6 +291,7 @@ jobs:
       PYVER: ""  # Windows CI image doesn't have aliases for python3.7
       TBB_INCLUDE: "C:\\tools\\miniconda3\\Library\\include"
       TBB_LINK: "C:\\tools\\miniconda3\\Library\\lib"
+      VCVARSALL: "C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Community\\VC\\Auxiliary\\Build\\vcvarsall.bat"
     <<: *build_and_test_windows
 
   test-deploy-pypi-linux:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -326,53 +326,53 @@ workflows:
   version: 2
   test:
     jobs:
-      #- check-style
-      #- linux-python-38:
-      #    requires:
-      #      - check-style
-      #- linux-python-37:
-      #    requires:
-      #      - check-style
-      #- linux-python-36:
-      #    requires:
-      #      - check-style
-      - windows-python-37
-      #    requires:
-      #      - check-style
+      - check-style
+      - linux-python-38:
+          requires:
+            - check-style
+      - linux-python-37:
+          requires:
+            - check-style
+      - linux-python-36:
+          requires:
+            - check-style
+      - windows-python-37:
+          requires:
+            - check-style
 # Disabled benchmarks on CI - they currently take too much work
 #     - benchmarks:
 #         requires:
 #           - linux-python-38
-      #- test-deploy-pypi-macos:
-      #    filters:
-      #      branches:
-      #        only: /release\/.*/
-      #    requires:
-      #      - linux-python-38
-      #      - linux-python-37
-      #      - linux-python-36
-      #      - windows-python-37
-      #- test-deploy-pypi-linux:
-      #    filters:
-      #      branches:
-      #        only: /release\/.*/
-      #    requires:
-      #      - linux-python-38
-      #      - linux-python-37
-      #      - linux-python-36
-      #      - windows-python-37
+      - test-deploy-pypi-macos:
+          filters:
+            branches:
+              only: /release\/.*/
+          requires:
+            - linux-python-38
+            - linux-python-37
+            - linux-python-36
+            - windows-python-37
+      - test-deploy-pypi-linux:
+          filters:
+            branches:
+              only: /release\/.*/
+          requires:
+            - linux-python-38
+            - linux-python-37
+            - linux-python-36
+            - windows-python-37
 
-  #deploy:
-  #  jobs:
-  #    - deploy-pypi-macos:
-  #        filters:
-  #            tags:
-  #              only: /^v.*/
-  #            branches:
-  #              ignore: /.*/
-  #    - deploy-pypi-linux:
-  #        filters:
-  #            tags:
-  #              only: /^v.*/
-  #            branches:
-  #              ignore: /.*/
+  deploy:
+    jobs:
+      - deploy-pypi-macos:
+          filters:
+              tags:
+                only: /^v.*/
+              branches:
+                ignore: /.*/
+      - deploy-pypi-linux:
+          filters:
+              tags:
+                only: /^v.*/
+              branches:
+                ignore: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,7 +101,7 @@ references:
       name: Build with MSVC
       # Load MSVC environment variables before building
       command: |
-        C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvarsall.bat x64
+        "C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Community\\VC\\Auxiliary\\Build\\vcvarsall.bat" x64
         python${PYVER} --version
         python${PYVER} setup.py build_ext --inplace -- -DCOVERAGE=ON
       shell: cmd.exe

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,7 +63,9 @@ references:
         # Install from PyPI instead of conda-forge for consistency with Linux.
         # For some reason, the SSL certificates used by pip aren't correct, even with certifi.
         # Invoke-RestMethod -Uri https://curl.haxx.se/ca/cacert.pem -Method Get | Out-File cacert.pem
-        python -m pip install --cert cacert.pem --progress-bar off -U -r requirements-testing.txt
+        python -m pip install --progress-bar off -U -r requirements-testing.txt
+        # Update cmake to support Visual Studio 2019 generator
+        python -m pip install -U cmake==3.14.4post1
 
   get_style_requirements: &get_style_requirements
     run:
@@ -99,10 +101,9 @@ references:
   build_windows: &build_windows
     run:
       name: Build with MSVC
-      # Load MSVC environment variables before building
       command: |
         python --version
-        python setup.py build_ext --inplace -- -DCOVERAGE=ON
+        python setup.py build_ext --inplace -- -G "Visual Studio 16 2019" -DCOVERAGE=ON
 
   test: &test
     run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,6 +101,7 @@ references:
       name: Build with MSVC
       # Load MSVC environment variables before building
       command: |
+        set
         cmd.exe /k "%VCVARSALL%" x64
         python${PYVER} --version
         python${PYVER} setup.py build_ext --inplace -- -DCOVERAGE=ON

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,7 +101,7 @@ references:
       name: Build with MSVC
       # Load MSVC environment variables before building
       command: |
-        cmd.exe /k %VCVARSALL% x64
+        cmd.exe /k "%VCVARSALL%" x64
         python${PYVER} --version
         python${PYVER} setup.py build_ext --inplace -- -DCOVERAGE=ON
       shell: cmd.exe

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -183,9 +183,9 @@ references:
   build_and_test_windows: &build_and_test_windows
     steps:
       - *load_code
+      - *build_windows
       - *update_submodules
       - *get_conda_requirements
-      - *build_windows
       - *test_cov
       - *store
 
@@ -329,53 +329,53 @@ workflows:
   version: 2
   test:
     jobs:
-      - check-style
-      - linux-python-38:
-          requires:
-            - check-style
-      - linux-python-37:
-          requires:
-            - check-style
-      - linux-python-36:
-          requires:
-            - check-style
-      - windows-python-37:
-          requires:
-            - check-style
+      #- check-style
+      #- linux-python-38:
+      #    requires:
+      #      - check-style
+      #- linux-python-37:
+      #    requires:
+      #      - check-style
+      #- linux-python-36:
+      #    requires:
+      #      - check-style
+      - windows-python-37
+      #    requires:
+      #      - check-style
 # Disabled benchmarks on CI - they currently take too much work
 #     - benchmarks:
 #         requires:
 #           - linux-python-38
-      - test-deploy-pypi-macos:
-          filters:
-            branches:
-              only: /release\/.*/
-          requires:
-            - linux-python-38
-            - linux-python-37
-            - linux-python-36
-            - windows-python-37
-      - test-deploy-pypi-linux:
-          filters:
-            branches:
-              only: /release\/.*/
-          requires:
-            - linux-python-38
-            - linux-python-37
-            - linux-python-36
-            - windows-python-37
+      #- test-deploy-pypi-macos:
+      #    filters:
+      #      branches:
+      #        only: /release\/.*/
+      #    requires:
+      #      - linux-python-38
+      #      - linux-python-37
+      #      - linux-python-36
+      #      - windows-python-37
+      #- test-deploy-pypi-linux:
+      #    filters:
+      #      branches:
+      #        only: /release\/.*/
+      #    requires:
+      #      - linux-python-38
+      #      - linux-python-37
+      #      - linux-python-36
+      #      - windows-python-37
 
-  deploy:
-    jobs:
-      - deploy-pypi-macos:
-          filters:
-              tags:
-                only: /^v.*/
-              branches:
-                ignore: /.*/
-      - deploy-pypi-linux:
-          filters:
-              tags:
-                only: /^v.*/
-              branches:
-                ignore: /.*/
+  #deploy:
+  #  jobs:
+  #    - deploy-pypi-macos:
+  #        filters:
+  #            tags:
+  #              only: /^v.*/
+  #            branches:
+  #              ignore: /.*/
+  #    - deploy-pypi-linux:
+  #        filters:
+  #            tags:
+  #              only: /^v.*/
+  #            branches:
+  #              ignore: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,9 +60,12 @@ references:
         conda config --add channels conda-forge
         conda update -q conda certifi
         conda install python pip tbb tbb-devel
-        conda install coverage cython garnett GitPython gsd matplotlib-base MDAnalysis numpy rowan scipy sympy
+        # Install from PyPI instead of conda-forge for consistency with Linux.
+        # For some reason, the SSL certificates used by pip aren't correct, even with certifi.
+        curl -O https://curl.haxx.se/ca/cacert.pem
+        python${PYVER} -m pip install --cert cacert.pem --progress-bar off -U -r requirements-testing.txt
         # Install cmake 3.14 to support Visual Studio 2019 generator
-        conda install scikit-build=0.10 cmake=3.14
+        python${PYVER} -m pip install --cert cacert.pem --progress-bar off -U cmake~=3.14
 
   get_style_requirements: &get_style_requirements
     run:
@@ -99,8 +102,8 @@ references:
     run:
       name: Build with MSVC
       command: |
-        python --version
-        python setup.py build_ext --inplace -- -G "Visual Studio 16 2019" -DCOVERAGE=ON
+        python${PYVER} --version
+        python${PYVER} setup.py build_ext --inplace -- -G "Visual Studio 16 2019" -DCOVERAGE=ON
 
   test: &test
     run:
@@ -115,12 +118,6 @@ references:
           export PATH=~/.local/bin:${PATH}
           coverage run -m unittest discover tests -v
           bash <(curl -s https://codecov.io/bash)
-
-  test_windows: &test_windows
-    run:
-      name: Run unit tests
-      command: |
-          python -m unittest discover tests -v
 
   store: &store
     store_artifacts:
@@ -187,7 +184,7 @@ references:
       - *update_submodules
       - *get_conda_requirements
       - *build_windows
-      - *test_windows
+      - *test_cov
       - *store
 
   load_check_style: &load_check_style
@@ -288,7 +285,7 @@ jobs:
   windows-python-37:
     executor:
       name: win/default
-      shell: powershell.exe
+      shell: bash.exe
     environment:
       PYVER: ""  # Windows CI image doesn't have aliases for python3.7
       TBB_INCLUDE: "C:\\tools\\miniconda3\\Library\\include"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,7 +59,7 @@ references:
         conda config --set always_yes yes --set changeps1 no
         conda config --add channels conda-forge
         conda update -q conda certifi
-        conda install python pip tbb tbb-devel
+        conda install python pip tbb tbb-devel ninja
         # Install from PyPI instead of conda-forge for consistency with Linux.
         # For some reason, the SSL certificates used by pip aren't correct, even with certifi.
         curl -O https://curl.haxx.se/ca/cacert.pem
@@ -182,9 +182,9 @@ references:
   build_and_test_windows: &build_and_test_windows
     steps:
       - *load_code
-      - *build_windows
       - *update_submodules
       - *get_conda_requirements
+      - *build_windows
       - *test_cov
       - *store
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,10 +101,9 @@ references:
       name: Build with MSVC
       # Load MSVC environment variables before building
       command: |
-        set
-        cmd.exe /k "%VCVARSALL%" x64
-        python${PYVER} --version
-        python${PYVER} setup.py build_ext --inplace -- -DCOVERAGE=ON
+        "%VCVARSALL%" x64
+        python --version
+        python setup.py build_ext --inplace -- -DCOVERAGE=ON
       shell: cmd.exe
 
   test: &test
@@ -292,7 +291,7 @@ jobs:
       PYVER: ""  # Windows CI image doesn't have aliases for python3.7
       TBB_INCLUDE: "C:\\tools\\miniconda3\\Library\\include"
       TBB_LINK: "C:\\tools\\miniconda3\\Library\\lib"
-      VCVARSALL: "C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Community\\VC\\Auxiliary\\Build\\vcvarsall.bat"
+      VCVARSALL: "C:/Program Files (x86)/Microsoft Visual Studio/2019/Community/VC/Auxiliary/Build/vcvarsall.bat"
     <<: *build_and_test_windows
 
   test-deploy-pypi-linux:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,7 +63,7 @@ references:
         # Install from PyPI instead of conda-forge for consistency with Linux.
         # For some reason, the SSL certificates used by pip aren't correct, even with certifi.
         curl -O https://curl.haxx.se/ca/cacert.pem
-        python${PYVER} -m pip install --cert cacert.pem --progress-bar off -U -r requirements-testing.txt
+        python -m pip install --cert cacert.pem --progress-bar off -U -r requirements-testing.txt
 
   get_style_requirements: &get_style_requirements
     run:
@@ -103,7 +103,6 @@ references:
       command: |
         python --version
         python setup.py build_ext --inplace -- -DCOVERAGE=ON
-      shell: cmd.exe
 
   test: &test
     run:
@@ -285,12 +284,12 @@ jobs:
   windows-python-37:
     executor:
       name: win/default
-      shell: bash.exe
+      shell: cmd.exe
     environment:
       PYVER: ""  # Windows CI image doesn't have aliases for python3.7
       TBB_INCLUDE: "C:\\tools\\miniconda3\\Library\\include"
       TBB_LINK: "C:\\tools\\miniconda3\\Library\\lib"
-      VCVARSALL: "C:/Program Files (x86)/Microsoft Visual Studio/2019/Community/VC/Auxiliary/Build/vcvarsall.bat"
+      VCVARSALL: "C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Community\\VC\\Auxiliary\\Build\\vcvarsall.bat"
     <<: *build_and_test_windows
 
   test-deploy-pypi-linux:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -290,7 +290,7 @@ jobs:
   windows-python-37:
     executor:
       name: win/default
-      shell: cmd.exe
+      shell: powershell.exe
     environment:
       PYVER: ""  # Windows CI image doesn't have aliases for python3.7
       TBB_INCLUDE: "C:\\tools\\miniconda3\\Library\\include"

--- a/CMake/FindTBB.cmake
+++ b/CMake/FindTBB.cmake
@@ -1,10 +1,27 @@
-find_path(TBB_INCLUDE_DIR tbb/tbb.h)
+find_library(TBB_LIBRARY tbb
+             HINTS ENV TBB_LINK)
 
-find_library(
-    TBB_LIBRARY tbb
-    HINTS ${TBB_INCLUDE_DIR}/../lib )
+get_filename_component(_tbb_lib_dir ${TBB_LIBRARY} DIRECTORY)
 
-add_library(TBB SHARED IMPORTED)
-set_target_properties(TBB PROPERTIES
-	IMPORTED_LOCATION "${TBB_LIBRARY}"
-	INTERFACE_INCLUDE_DIRECTORIES "${TBB_INCLUDE_DIR}")
+find_path(TBB_INCLUDE_DIR tbb/tbb.h
+          HINTS ENV TBB_INC
+          HINTS ${_tbb_lib_dir}/../include)
+
+if(TBB_INCLUDE_DIR AND EXISTS "${TBB_INCLUDE_DIR}/tbb/tbb_stddef.h")
+    file(STRINGS "${TBB_INCLUDE_DIR}/tbb/tbb_stddef.h" TBB_H REGEX "^#define TBB_VERSION_.*$")
+
+    string(REGEX REPLACE ".*#define TBB_VERSION_MAJOR ([0-9]+).*$" "\\1" TBB_VERSION_MAJOR "${TBB_H}")
+    string(REGEX REPLACE "^.*TBB_VERSION_MINOR ([0-9]+).*$" "\\1" TBB_VERSION_MINOR  "${TBB_H}")
+    set(TBB_VERSION_STRING "${TBB_VERSION_MAJOR}.${TBB_VERSION_MINOR}")
+endif()
+
+# handle the QUIETLY and REQUIRED arguments and set TBB_FOUND to TRUE if
+# all listed variables are TRUE
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(TBB
+                                  REQUIRED_VARS TBB_LIBRARY TBB_INCLUDE_DIR
+                                  VERSION_VAR TBB_VERSION_STRING)
+
+if(TBB_FOUND)
+  set(TBB_LIBRARIES ${TBB_LIBRARY})
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,17 @@ foreach (submodule ${submodules})
     endif()
 endforeach(submodule)
 
+# Define preprocessor directives for Windows
+if (WIN32)
+    # Export all symbols (forces creation of .lib file)
+    set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
+    # Use add_compile_definitions when dropping support for CMake < 3.12
+    # Force Windows to define M_PI in <cmath>
+    add_compile_options(/D_USE_MATH_DEFINES)
+    # Prevent Windows from defining min/max as macros
+    add_compile_options(/DNOMINMAX)
+endif()
+
 include_directories(
     ${PROJECT_SOURCE_DIR}/cpp/util
     ${PROJECT_SOURCE_DIR}/cpp/locality

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,7 +43,7 @@ endforeach(submodule)
 
 # Define preprocessor directives for Windows
 if (WIN32)
-    # Export all symbols (forces creation of .lib file)
+    # Export all symbols (forces creation of .def file)
     set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
     # Use add_compile_definitions when dropping support for CMake < 3.12
     # Force Windows to define M_PI in <cmath>

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -21,7 +21,7 @@ add_library(
 
 target_link_libraries(
     libfreud
-    PUBLIC TBB
+    PUBLIC ${TBB_LIBRARY}
     )
 
 target_include_directories(

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -19,6 +19,16 @@ add_library(
     $<TARGET_OBJECTS:_pmft>
     $<TARGET_OBJECTS:_util>)
 
+if(WIN32)
+    target_compile_definitions(
+        libfreud
+        # Export API - required for static data members to have external
+        # linkage with MSVC. This is in addition to
+        # CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS.
+        PRIVATE "LIBFREUD_EXPORTS"
+        )
+endif()
+
 target_link_libraries(
     libfreud
     PUBLIC ${TBB_LIBRARY}

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -1,11 +1,3 @@
-if (WIN32)
-    # Use add_compile_definitions when dropping support for CMake < 3.12
-    # Force Windows to define M_PI in <cmath>
-    add_compile_options(/D_USE_MATH_DEFINES)
-    # Prevent Windows from defining min/max as macros
-    add_compile_options(/DNOMINMAX)
-endif()
-
 add_subdirectory(cluster)
 add_subdirectory(density)
 add_subdirectory(environment)

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -19,7 +19,7 @@ add_library(
     $<TARGET_OBJECTS:_pmft>
     $<TARGET_OBJECTS:_util>)
 
-if(WIN32)
+if (WIN32)
     target_compile_definitions(
         libfreud
         # Export API - required for static data members to have external

--- a/cpp/locality/NeighborComputeFunctional.cc
+++ b/cpp/locality/NeighborComputeFunctional.cc
@@ -38,4 +38,20 @@ NeighborList makeDefaultNlist(const NeighborQuery* nq, const NeighborList* nlist
     return new_nlist;
 }
 
+NeighborBond NeighborListPerPointIterator::next()
+{
+    if (m_current_index == m_nlist->getNumBonds())
+    {
+        m_finished = true;
+        return ITERATOR_TERMINATOR;
+    }
+
+    NeighborBond nb = NeighborBond(
+        m_nlist->getNeighbors()(m_current_index, 0), m_nlist->getNeighbors()(m_current_index, 1),
+        m_nlist->getDistances()[m_current_index], m_nlist->getWeights()[m_current_index]);
+    ++m_current_index;
+    m_returned_point_index = nb.query_point_idx;
+    return nb;
+}
+
 }; }; // end namespace freud::locality

--- a/cpp/locality/NeighborComputeFunctional.h
+++ b/cpp/locality/NeighborComputeFunctional.h
@@ -58,21 +58,7 @@ public:
 
     ~NeighborListPerPointIterator() {}
 
-    virtual NeighborBond next()
-    {
-        if (m_current_index == m_nlist->getNumBonds())
-        {
-            m_finished = true;
-            return ITERATOR_TERMINATOR;
-        }
-
-        NeighborBond nb = NeighborBond(
-            m_nlist->getNeighbors()(m_current_index, 0), m_nlist->getNeighbors()(m_current_index, 1),
-            m_nlist->getDistances()[m_current_index], m_nlist->getWeights()[m_current_index]);
-        ++m_current_index;
-        m_returned_point_index = nb.query_point_idx;
-        return nb;
-    }
+    virtual NeighborBond next();
 
     virtual bool end()
     {

--- a/cpp/locality/NeighborPerPointIterator.cc
+++ b/cpp/locality/NeighborPerPointIterator.cc
@@ -7,11 +7,11 @@ namespace freud { namespace locality {
 
 NeighborPerPointIterator::NeighborPerPointIterator() {}
 
-NeighborPerPointIterator::NeighborPerPointIterator(unsigned int query_point_idx) : m_query_point_idx(query_point_idx)
+NeighborPerPointIterator::NeighborPerPointIterator(unsigned int query_point_idx)
+    : m_query_point_idx(query_point_idx)
 {}
 
 NeighborPerPointIterator::~NeighborPerPointIterator() {}
-
 
 const NeighborBond NeighborPerPointIterator::ITERATOR_TERMINATOR(-1, -1, 0);
 

--- a/cpp/locality/NeighborPerPointIterator.cc
+++ b/cpp/locality/NeighborPerPointIterator.cc
@@ -5,6 +5,14 @@
 
 namespace freud { namespace locality {
 
+NeighborPerPointIterator::NeighborPerPointIterator() {}
+
+NeighborPerPointIterator::NeighborPerPointIterator(unsigned int query_point_idx) : m_query_point_idx(query_point_idx)
+{}
+
+NeighborPerPointIterator::~NeighborPerPointIterator() {}
+
+
 const NeighborBond NeighborPerPointIterator::ITERATOR_TERMINATOR(-1, -1, 0);
 
 }; }; // end namespace freud::locality

--- a/cpp/locality/NeighborPerPointIterator.h
+++ b/cpp/locality/NeighborPerPointIterator.h
@@ -13,7 +13,6 @@
     \brief Defines interface for iterator looping over sets of neighbors.
 */
 
-
 namespace freud { namespace locality {
 
 //! Parent class for all per-point neighbor finding iteration.

--- a/cpp/locality/NeighborPerPointIterator.h
+++ b/cpp/locality/NeighborPerPointIterator.h
@@ -1,11 +1,18 @@
 #ifndef NEIGHBOR_PER_POINT_ITERATOR_H
 #define NEIGHBOR_PER_POINT_ITERATOR_H
 
+#include "NeighborBond.h"
+
+#ifdef LIBFREUD_EXPORTS
+#define DECLSPEC __declspec(dllexport)
+#else
+#define DECLSPEC
+#endif
+
 /*! \file NeighborPerPointIterator.h
     \brief Defines interface for iterator looping over sets of neighbors.
 */
 
-#include "NeighborBond.h"
 
 namespace freud { namespace locality {
 
@@ -33,17 +40,17 @@ namespace freud { namespace locality {
  *  after the last neighbor is found in order to guarantee that the correct set
  *  of neighbors is considered.
  */
-class NeighborPerPointIterator
+class DECLSPEC NeighborPerPointIterator
 {
 public:
     //! Nullary constructor for Cython
-    NeighborPerPointIterator() {}
+    NeighborPerPointIterator();
 
     //! Constructor
-    NeighborPerPointIterator(unsigned int query_point_idx) : m_query_point_idx(query_point_idx) {}
+    NeighborPerPointIterator(unsigned int query_point_idx);
 
     //! Empty Destructor
-    virtual ~NeighborPerPointIterator() {}
+    virtual ~NeighborPerPointIterator();
 
     //! Indicate when done.
     virtual bool end() = 0;

--- a/cpp/locality/NeighborQuery.cc
+++ b/cpp/locality/NeighborQuery.cc
@@ -14,4 +14,196 @@ const float QueryArgs::DEFAULT_R_MIN(0);
 const float QueryArgs::DEFAULT_R_GUESS(-1.0);
 const float QueryArgs::DEFAULT_SCALE(-1.0);
 const bool QueryArgs::DEFAULT_EXCLUDE_II(false);
+
+QueryArgs::QueryArgs() : mode(DEFAULT_MODE),
+    num_neighbors(DEFAULT_NUM_NEIGHBORS), r_max(DEFAULT_R_MAX),
+    r_min(DEFAULT_R_MIN), r_guess(DEFAULT_R_GUESS), scale(DEFAULT_SCALE),
+    exclude_ii(DEFAULT_EXCLUDE_II)
+{}
+
+NeighborQuery::NeighborQuery()
+{}
+
+NeighborQuery::NeighborQuery(const box::Box& box, const vec3<float>* points, unsigned int n_points)
+    : m_box(box), m_points(points), m_n_points(n_points)
+{
+    // Reject systems with 0 particles
+    if (m_n_points == 0)
+    {
+        throw std::invalid_argument("Cannot create a NeighborQuery with 0 particles.");
+    }
+
+    // For 2D systems, check if any z-coordinates are outside some tolerance of z=0
+    if (m_box.is2D())
+    {
+        for (unsigned int i(0); i < n_points; i++)
+        {
+            if (std::abs(m_points[i].z) > 1e-6)
+            {
+                throw std::invalid_argument("A point with z != 0 was provided in a 2D box.");
+            }
+        }
+    }
+}
+
+
+void NeighborQuery::validateQueryArgs(QueryArgs& args) const
+{
+    inferMode(args);
+    // Validate remaining arguments.
+    if (args.mode == QueryArgs::ball)
+    {
+        if (args.r_max == QueryArgs::DEFAULT_R_MAX)
+            throw std::runtime_error(
+                "You must set r_max in the query arguments when performing ball queries.");
+        if (args.num_neighbors != QueryArgs::DEFAULT_NUM_NEIGHBORS)
+            throw std::runtime_error(
+                "You cannot set num_neighbors in the query arguments when performing ball queries.");
+    }
+    else if (args.mode == QueryArgs::nearest)
+    {
+        if (args.num_neighbors == QueryArgs::DEFAULT_NUM_NEIGHBORS)
+            throw std::runtime_error("You must set num_neighbors in the query arguments when performing "
+                                        "number of neighbor queries.");
+        if (args.r_max == QueryArgs::DEFAULT_R_MAX)
+        {
+            args.r_max = std::numeric_limits<float>::infinity();
+        }
+    }
+    else
+    {
+        throw std::runtime_error("Unknown mode");
+    }
+}
+
+void NeighborQuery::inferMode(QueryArgs& args) const
+{
+    // Infer mode if possible.
+    if (args.mode == QueryArgs::none)
+    {
+        if (args.num_neighbors != QueryArgs::DEFAULT_NUM_NEIGHBORS)
+        {
+            args.mode = QueryArgs::nearest;
+        }
+        else if (args.r_max != QueryArgs::DEFAULT_R_MAX)
+        {
+            args.mode = QueryArgs::ball;
+        }
+    }
+}
+
+NeighborQueryPerPointIterator::NeighborQueryPerPointIterator()
+{}
+
+NeighborQueryPerPointIterator::NeighborQueryPerPointIterator(const NeighborQuery* neighbor_query, const vec3<float> query_point,
+                                unsigned int query_point_idx, float r_max, float r_min, bool exclude_ii)
+    : NeighborPerPointIterator(query_point_idx), m_neighbor_query(neighbor_query),
+        m_query_point(query_point), m_finished(false), m_r_max(r_max), m_r_min(r_min),
+        m_exclude_ii(exclude_ii)
+{}
+
+NeighborQueryPerPointIterator::~NeighborQueryPerPointIterator() {}
+
+bool NeighborQueryPerPointIterator::end()
+{
+    return m_finished;
+}
+
+NeighborQueryIterator::NeighborQueryIterator()
+{}
+
+NeighborQueryIterator::NeighborQueryIterator(const NeighborQuery* neighbor_query, const vec3<float>* query_points,
+                    unsigned int num_query_points, QueryArgs qargs)
+    : m_neighbor_query(neighbor_query), m_query_points(query_points),
+        m_num_query_points(num_query_points), m_qargs(qargs), m_finished(false), m_cur_p(0)
+{
+    m_iter = this->query(m_cur_p);
+}
+
+NeighborQueryIterator::~NeighborQueryIterator()
+{}
+
+bool NeighborQueryIterator::end()
+{
+    return m_finished;
+}
+
+std::shared_ptr<NeighborQueryPerPointIterator> NeighborQueryIterator::query(unsigned int i)
+{
+    return m_neighbor_query->querySingle(m_query_points[i], i, m_qargs);
+}
+
+NeighborBond NeighborQueryIterator::next()
+{
+    if (m_finished)
+        return ITERATOR_TERMINATOR;
+    NeighborBond nb;
+    while (true)
+    {
+        while (!m_iter->end())
+        {
+            nb = m_iter->next();
+
+            if (nb != ITERATOR_TERMINATOR)
+            {
+                return nb;
+            }
+        }
+        m_cur_p++;
+        if (m_cur_p >= m_num_query_points)
+            break;
+        m_iter = this->query(m_cur_p);
+    }
+    m_finished = true;
+    return ITERATOR_TERMINATOR;
+}
+
+NeighborList* NeighborQueryIterator::toNeighborList(bool sort_by_distance)
+{
+    typedef tbb::enumerable_thread_specific<std::vector<NeighborBond>> BondVector;
+    BondVector bonds;
+    util::forLoopWrapper(0, m_num_query_points, [&](size_t begin, size_t end) {
+        BondVector::reference local_bonds(bonds.local());
+        NeighborBond nb;
+        for (size_t i = begin; i < end; ++i)
+        {
+            std::shared_ptr<NeighborQueryPerPointIterator> it = this->query(i);
+            while (!it->end())
+            {
+                nb = it->next();
+                // If we're excluding ii bonds, we have to check before adding.
+                if (nb != ITERATOR_TERMINATOR)
+                {
+                    local_bonds.emplace_back(nb.query_point_idx, nb.point_idx, nb.distance);
+                }
+            }
+        }
+    });
+
+    tbb::flattened2d<BondVector> flat_bonds = tbb::flatten2d(bonds);
+    std::vector<NeighborBond> linear_bonds(flat_bonds.begin(), flat_bonds.end());
+    if (sort_by_distance)
+        tbb::parallel_sort(linear_bonds.begin(), linear_bonds.end(), compareNeighborDistance);
+    else
+        tbb::parallel_sort(linear_bonds.begin(), linear_bonds.end(), compareNeighborBond);
+
+    unsigned int num_bonds = linear_bonds.size();
+
+    NeighborList* nl = new NeighborList();
+    nl->setNumBonds(num_bonds, m_num_query_points, m_neighbor_query->getNPoints());
+
+    util::forLoopWrapper(0, num_bonds, [&](size_t begin, size_t end) {
+        for (size_t bond = begin; bond < end; ++bond)
+        {
+            nl->getNeighbors()(bond, 0) = linear_bonds[bond].query_point_idx;
+            nl->getNeighbors()(bond, 1) = linear_bonds[bond].point_idx;
+            nl->getDistances()[bond] = linear_bonds[bond].distance;
+            nl->getWeights()[bond] = float(1.0);
+        }
+    });
+
+    return nl;
+}
+
+
 }; }; // end namespace freud::locality

--- a/cpp/locality/NeighborQuery.cc
+++ b/cpp/locality/NeighborQuery.cc
@@ -15,14 +15,12 @@ const float QueryArgs::DEFAULT_R_GUESS(-1.0);
 const float QueryArgs::DEFAULT_SCALE(-1.0);
 const bool QueryArgs::DEFAULT_EXCLUDE_II(false);
 
-QueryArgs::QueryArgs() : mode(DEFAULT_MODE),
-    num_neighbors(DEFAULT_NUM_NEIGHBORS), r_max(DEFAULT_R_MAX),
-    r_min(DEFAULT_R_MIN), r_guess(DEFAULT_R_GUESS), scale(DEFAULT_SCALE),
-    exclude_ii(DEFAULT_EXCLUDE_II)
+QueryArgs::QueryArgs()
+    : mode(DEFAULT_MODE), num_neighbors(DEFAULT_NUM_NEIGHBORS), r_max(DEFAULT_R_MAX), r_min(DEFAULT_R_MIN),
+      r_guess(DEFAULT_R_GUESS), scale(DEFAULT_SCALE), exclude_ii(DEFAULT_EXCLUDE_II)
 {}
 
-NeighborQuery::NeighborQuery()
-{}
+NeighborQuery::NeighborQuery() {}
 
 NeighborQuery::NeighborQuery(const box::Box& box, const vec3<float>* points, unsigned int n_points)
     : m_box(box), m_points(points), m_n_points(n_points)
@@ -46,7 +44,6 @@ NeighborQuery::NeighborQuery(const box::Box& box, const vec3<float>* points, uns
     }
 }
 
-
 void NeighborQuery::validateQueryArgs(QueryArgs& args) const
 {
     inferMode(args);
@@ -64,7 +61,7 @@ void NeighborQuery::validateQueryArgs(QueryArgs& args) const
     {
         if (args.num_neighbors == QueryArgs::DEFAULT_NUM_NEIGHBORS)
             throw std::runtime_error("You must set num_neighbors in the query arguments when performing "
-                                        "number of neighbor queries.");
+                                     "number of neighbor queries.");
         if (args.r_max == QueryArgs::DEFAULT_R_MAX)
         {
             args.r_max = std::numeric_limits<float>::infinity();
@@ -92,14 +89,14 @@ void NeighborQuery::inferMode(QueryArgs& args) const
     }
 }
 
-NeighborQueryPerPointIterator::NeighborQueryPerPointIterator()
-{}
+NeighborQueryPerPointIterator::NeighborQueryPerPointIterator() {}
 
-NeighborQueryPerPointIterator::NeighborQueryPerPointIterator(const NeighborQuery* neighbor_query, const vec3<float> query_point,
-                                unsigned int query_point_idx, float r_max, float r_min, bool exclude_ii)
-    : NeighborPerPointIterator(query_point_idx), m_neighbor_query(neighbor_query),
-        m_query_point(query_point), m_finished(false), m_r_max(r_max), m_r_min(r_min),
-        m_exclude_ii(exclude_ii)
+NeighborQueryPerPointIterator::NeighborQueryPerPointIterator(const NeighborQuery* neighbor_query,
+                                                             const vec3<float> query_point,
+                                                             unsigned int query_point_idx, float r_max,
+                                                             float r_min, bool exclude_ii)
+    : NeighborPerPointIterator(query_point_idx), m_neighbor_query(neighbor_query), m_query_point(query_point),
+      m_finished(false), m_r_max(r_max), m_r_min(r_min), m_exclude_ii(exclude_ii)
 {}
 
 NeighborQueryPerPointIterator::~NeighborQueryPerPointIterator() {}
@@ -109,19 +106,18 @@ bool NeighborQueryPerPointIterator::end()
     return m_finished;
 }
 
-NeighborQueryIterator::NeighborQueryIterator()
-{}
+NeighborQueryIterator::NeighborQueryIterator() {}
 
-NeighborQueryIterator::NeighborQueryIterator(const NeighborQuery* neighbor_query, const vec3<float>* query_points,
-                    unsigned int num_query_points, QueryArgs qargs)
-    : m_neighbor_query(neighbor_query), m_query_points(query_points),
-        m_num_query_points(num_query_points), m_qargs(qargs), m_finished(false), m_cur_p(0)
+NeighborQueryIterator::NeighborQueryIterator(const NeighborQuery* neighbor_query,
+                                             const vec3<float>* query_points, unsigned int num_query_points,
+                                             QueryArgs qargs)
+    : m_neighbor_query(neighbor_query), m_query_points(query_points), m_num_query_points(num_query_points),
+      m_qargs(qargs), m_finished(false), m_cur_p(0)
 {
     m_iter = this->query(m_cur_p);
 }
 
-NeighborQueryIterator::~NeighborQueryIterator()
-{}
+NeighborQueryIterator::~NeighborQueryIterator() {}
 
 bool NeighborQueryIterator::end()
 {
@@ -204,6 +200,5 @@ NeighborList* NeighborQueryIterator::toNeighborList(bool sort_by_distance)
 
     return nl;
 }
-
 
 }; }; // end namespace freud::locality

--- a/cpp/locality/NeighborQuery.h
+++ b/cpp/locality/NeighborQuery.h
@@ -15,6 +15,12 @@
 #include "NeighborPerPointIterator.h"
 #include "utils.h"
 
+#ifdef LIBFREUD_EXPORTS
+#define DECLSPEC __declspec(dllexport)
+#else
+#define DECLSPEC
+#endif
+
 /*! \file NeighborQuery.h
     \brief Defines the abstract API for collections of points that can be
            queried against for neighbors.
@@ -28,15 +34,12 @@ namespace freud { namespace locality {
  *  specifically, for example, the user can call a generic querying function and
  *  provide an instance of this class to specify the nature of the query.
  */
-struct QueryArgs
+struct DECLSPEC QueryArgs
 {
     //! Default constructor.
-    /*! We set default values for all parameters here.
+    /*! We set default values for all parameters in the implementation.
      */
-    QueryArgs()
-        : mode(DEFAULT_MODE), num_neighbors(DEFAULT_NUM_NEIGHBORS), r_max(DEFAULT_R_MAX),
-          r_min(DEFAULT_R_MIN), r_guess(DEFAULT_R_GUESS), scale(DEFAULT_SCALE), exclude_ii(DEFAULT_EXCLUDE_II)
-    {}
+    QueryArgs();
 
     //! Enumeration for types of queries.
     enum QueryType
@@ -80,30 +83,10 @@ class NeighborQuery
 {
 public:
     //! Nullary constructor for Cython
-    NeighborQuery() {}
+    NeighborQuery();
 
     //! Constructor
-    NeighborQuery(const box::Box& box, const vec3<float>* points, unsigned int n_points)
-        : m_box(box), m_points(points), m_n_points(n_points)
-    {
-        // Reject systems with 0 particles
-        if (m_n_points == 0)
-        {
-            throw std::invalid_argument("Cannot create a NeighborQuery with 0 particles.");
-        }
-
-        // For 2D systems, check if any z-coordinates are outside some tolerance of z=0
-        if (m_box.is2D())
-        {
-            for (unsigned int i(0); i < n_points; i++)
-            {
-                if (std::abs(m_points[i].z) > 1e-6)
-                {
-                    throw std::invalid_argument("A point with z != 0 was provided in a 2D box.");
-                }
-            }
-        }
-    }
+    NeighborQuery(const box::Box& box, const vec3<float>* points, unsigned int n_points);
 
     //! Empty Destructor
     virtual ~NeighborQuery() {}
@@ -183,34 +166,7 @@ protected:
      *  combinations (e.g. just an r_max) without having to specify the mode
      *  explicitly.
      */
-    virtual void validateQueryArgs(QueryArgs& args) const
-    {
-        inferMode(args);
-        // Validate remaining arguments.
-        if (args.mode == QueryArgs::ball)
-        {
-            if (args.r_max == QueryArgs::DEFAULT_R_MAX)
-                throw std::runtime_error(
-                    "You must set r_max in the query arguments when performing ball queries.");
-            if (args.num_neighbors != QueryArgs::DEFAULT_NUM_NEIGHBORS)
-                throw std::runtime_error(
-                    "You cannot set num_neighbors in the query arguments when performing ball queries.");
-        }
-        else if (args.mode == QueryArgs::nearest)
-        {
-            if (args.num_neighbors == QueryArgs::DEFAULT_NUM_NEIGHBORS)
-                throw std::runtime_error("You must set num_neighbors in the query arguments when performing "
-                                         "number of neighbor queries.");
-            if (args.r_max == QueryArgs::DEFAULT_R_MAX)
-            {
-                args.r_max = std::numeric_limits<float>::infinity();
-            }
-        }
-        else
-        {
-            throw std::runtime_error("Unknown mode");
-        }
-    }
+    virtual void validateQueryArgs(QueryArgs& args) const;
 
     //! Try to determine the query mode if one is not specified.
     /*! If no mode is specified and a number of neighbors is specified, the
@@ -218,21 +174,7 @@ protected:
      *  reasonably modify that query). Otherwise, if a max distance is set we
      *  can assume a ball query is desired.
      */
-    virtual void inferMode(QueryArgs& args) const
-    {
-        // Infer mode if possible.
-        if (args.mode == QueryArgs::none)
-        {
-            if (args.num_neighbors != QueryArgs::DEFAULT_NUM_NEIGHBORS)
-            {
-                args.mode = QueryArgs::nearest;
-            }
-            else if (args.r_max != QueryArgs::DEFAULT_R_MAX)
-            {
-                args.mode = QueryArgs::ball;
-            }
-        }
-    }
+    virtual void inferMode(QueryArgs& args) const;
 
     const box::Box m_box;        //!< Simulation box where the particles belong.
     const vec3<float>* m_points; //!< Point coordinates.
@@ -248,28 +190,21 @@ protected:
  *  should indicate that all neighbors have been found, which is by setting the
  *  m_finished flag.
  */
-class NeighborQueryPerPointIterator : public NeighborPerPointIterator
+class DECLSPEC NeighborQueryPerPointIterator : public NeighborPerPointIterator
 {
 public:
     //! Nullary constructor for Cython
-    NeighborQueryPerPointIterator() {}
+    NeighborQueryPerPointIterator();
 
     //! Constructor
     NeighborQueryPerPointIterator(const NeighborQuery* neighbor_query, const vec3<float> query_point,
-                                  unsigned int query_point_idx, float r_max, float r_min, bool exclude_ii)
-        : NeighborPerPointIterator(query_point_idx), m_neighbor_query(neighbor_query),
-          m_query_point(query_point), m_finished(false), m_r_max(r_max), m_r_min(r_min),
-          m_exclude_ii(exclude_ii)
-    {}
+                                  unsigned int query_point_idx, float r_max, float r_min, bool exclude_ii);
 
     //! Empty Destructor
-    virtual ~NeighborQueryPerPointIterator() {}
+    virtual ~NeighborQueryPerPointIterator();
 
     //! Indicate when done.
-    virtual bool end()
-    {
-        return m_finished;
-    }
+    virtual bool end();
 
     //! Get the next element.
     virtual NeighborBond next() = 0;
@@ -297,61 +232,27 @@ protected:
  *  in NeighborQuery subclasses (to return per-point iterators) should be
  *  sufficient for this class to work.
  */
-class NeighborQueryIterator
+class DECLSPEC NeighborQueryIterator
 {
 public:
     //! Nullary constructor for Cython
-    NeighborQueryIterator() {}
+    NeighborQueryIterator();
 
     //! Constructor
     NeighborQueryIterator(const NeighborQuery* neighbor_query, const vec3<float>* query_points,
-                          unsigned int num_query_points, QueryArgs qargs)
-        : m_neighbor_query(neighbor_query), m_query_points(query_points),
-          m_num_query_points(num_query_points), m_qargs(qargs), m_finished(false), m_cur_p(0)
-    {
-        m_iter = this->query(m_cur_p);
-    }
+                          unsigned int num_query_points, QueryArgs qargs);
 
     //! Empty Destructor
-    ~NeighborQueryIterator() {}
+    ~NeighborQueryIterator();
 
     //! Indicate when done.
-    bool end()
-    {
-        return m_finished;
-    }
+    bool end();
 
     //! Get an iterator for a specific query point by index.
-    std::shared_ptr<NeighborQueryPerPointIterator> query(unsigned int i)
-    {
-        return m_neighbor_query->querySingle(m_query_points[i], i, m_qargs);
-    }
+    std::shared_ptr<NeighborQueryPerPointIterator> query(unsigned int i);
 
     //! Get the next element.
-    NeighborBond next()
-    {
-        if (m_finished)
-            return ITERATOR_TERMINATOR;
-        NeighborBond nb;
-        while (true)
-        {
-            while (!m_iter->end())
-            {
-                nb = m_iter->next();
-
-                if (nb != ITERATOR_TERMINATOR)
-                {
-                    return nb;
-                }
-            }
-            m_cur_p++;
-            if (m_cur_p >= m_num_query_points)
-                break;
-            m_iter = this->query(m_cur_p);
-        }
-        m_finished = true;
-        return ITERATOR_TERMINATOR;
-    }
+    NeighborBond next();
 
     //! Generate a NeighborList from query.
     /*! This function exploits parallelism by finding the neighbors for
@@ -366,52 +267,7 @@ public:
      *  the primary use-case is to have this object be managed by instances
      *  of the Cython NeighborList class.
      */
-    NeighborList* toNeighborList(bool sort_by_distance = false)
-    {
-        typedef tbb::enumerable_thread_specific<std::vector<NeighborBond>> BondVector;
-        BondVector bonds;
-        util::forLoopWrapper(0, m_num_query_points, [&](size_t begin, size_t end) {
-            BondVector::reference local_bonds(bonds.local());
-            NeighborBond nb;
-            for (size_t i = begin; i < end; ++i)
-            {
-                std::shared_ptr<NeighborQueryPerPointIterator> it = this->query(i);
-                while (!it->end())
-                {
-                    nb = it->next();
-                    // If we're excluding ii bonds, we have to check before adding.
-                    if (nb != ITERATOR_TERMINATOR)
-                    {
-                        local_bonds.emplace_back(nb.query_point_idx, nb.point_idx, nb.distance);
-                    }
-                }
-            }
-        });
-
-        tbb::flattened2d<BondVector> flat_bonds = tbb::flatten2d(bonds);
-        std::vector<NeighborBond> linear_bonds(flat_bonds.begin(), flat_bonds.end());
-        if (sort_by_distance)
-            tbb::parallel_sort(linear_bonds.begin(), linear_bonds.end(), compareNeighborDistance);
-        else
-            tbb::parallel_sort(linear_bonds.begin(), linear_bonds.end(), compareNeighborBond);
-
-        unsigned int num_bonds = linear_bonds.size();
-
-        NeighborList* nl = new NeighborList();
-        nl->setNumBonds(num_bonds, m_num_query_points, m_neighbor_query->getNPoints());
-
-        util::forLoopWrapper(0, num_bonds, [&](size_t begin, size_t end) {
-            for (size_t bond = begin; bond < end; ++bond)
-            {
-                nl->getNeighbors()(bond, 0) = linear_bonds[bond].query_point_idx;
-                nl->getNeighbors()(bond, 1) = linear_bonds[bond].point_idx;
-                nl->getDistances()[bond] = linear_bonds[bond].distance;
-                nl->getWeights()[bond] = float(1.0);
-            }
-        });
-
-        return nl;
-    }
+    NeighborList* toNeighborList(bool sort_by_distance = false);
 
     static const NeighborBond ITERATOR_TERMINATOR; //!< The object returned when iteration is complete.
 

--- a/freud/CMakeLists.txt
+++ b/freud/CMakeLists.txt
@@ -100,6 +100,9 @@ endforeach(cython_module)
 # Interface is pure Python but relies on the C++ locality classes.
 target_link_libraries(interface libfreud)
 
+# MSD is pure Python but relies on the C++ parallel classes.
+target_link_libraries(msd libfreud)
+
 # The SolidLiquid class has an instance of cluster::Cluster as a member, so
 # including the header requires the Cluster.h header. Would prefer to inherit
 # this information from the _order library, but that's not possible since we're

--- a/freud/CMakeLists.txt
+++ b/freud/CMakeLists.txt
@@ -64,6 +64,10 @@ foreach(cython_module ${cython_modules_with_cpp} ${cython_modules_without_cpp})
         PRIVATE "NPY_NO_DEPRECATED_API=NPY_1_10_API_VERSION"
         # Default voro++ verbosity is high.
         PRIVATE "VOROPP_VERBOSE=1"
+        # Export API - required for static data members to have external
+        # linkage with MSVC. This is in addition to
+        # CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS.
+        PRIVATE "LIBFREUD_EXPORTS"
         )
     if (COVERAGE)
         target_compile_definitions(

--- a/freud/CMakeLists.txt
+++ b/freud/CMakeLists.txt
@@ -64,11 +64,16 @@ foreach(cython_module ${cython_modules_with_cpp} ${cython_modules_without_cpp})
         PRIVATE "NPY_NO_DEPRECATED_API=NPY_1_10_API_VERSION"
         # Default voro++ verbosity is high.
         PRIVATE "VOROPP_VERBOSE=1"
-        # Export API - required for static data members to have external
-        # linkage with MSVC. This is in addition to
-        # CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS.
-        PRIVATE "LIBFREUD_EXPORTS"
         )
+    if (WIN32)
+        target_compile_definitions(
+            ${cython_module}
+            # Export API - required for static data members to have external
+            # linkage with MSVC. This is in addition to
+            # CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS.
+            PRIVATE "LIBFREUD_EXPORTS"
+            )
+    endif()
     if (COVERAGE)
         target_compile_definitions(
             ${cython_module}

--- a/freud/_locality.pxd
+++ b/freud/_locality.pxd
@@ -11,6 +11,11 @@ cimport freud.util
 
 cdef extern from "NeighborBond.h" namespace "freud::locality":
     cdef cppclass NeighborBond:
+        NeighborBond()
+        NeighborBond(unsigned int query_point_idx,
+                     unsigned int point_idx,
+                     float d,
+                     float w)
         unsigned int query_point_idx
         unsigned int point_idx
         float distance
@@ -46,9 +51,6 @@ cdef extern from "NeighborQuery.h" namespace "freud::locality":
         const vec3[float]* getPoints const
         const unsigned int getNPoints const
         const vec3[float] operator[](unsigned int) const
-
-    NeighborBond ITERATOR_TERMINATOR \
-        "freud::locality::NeighborQueryIterator::ITERATOR_TERMINATOR"
 
     cdef cppclass NeighborQueryIterator:
         NeighborQueryIterator()

--- a/freud/locality.pyx
+++ b/freud/locality.pyx
@@ -15,7 +15,6 @@ from freud.util cimport vec3, _Compute
 from cython.operator cimport dereference
 from libcpp.memory cimport shared_ptr
 from libcpp.vector cimport vector
-from freud._locality cimport ITERATOR_TERMINATOR
 
 cimport freud._locality
 cimport freud.box
@@ -183,6 +182,8 @@ cdef class NeighborQueryResult:
 
     def __iter__(self):
         cdef freud._locality.NeighborBond npoint
+        cdef freud._locality.NeighborBond ITERATOR_TERMINATOR
+        ITERATOR_TERMINATOR = freud._locality.NeighborBond(-1, -1, 0.0, 1.0)
 
         cdef const float[:, ::1] l_points = self.points
         cdef shared_ptr[freud._locality.NeighborQueryIterator] iterator = \


### PR DESCRIPTION
## Description
Windows compatibility for scikit-build. Follows up on #668.
- Uses HOOMD's `FindTBB.cmake`.
- Handles MSVC symbol exports. MSVC requires explicit declarations of symbols that need to be exported, with `__declspec(dllexport)`. When we compile `libfreud`, we can tell CMake to automatically export all symbols. This lifts most of the burden for us.
- Fixes some problems where CMake wasn't working as expected. In particular, `target_link_libraries` didn't recognize `TBB` and had to be given `${TBB_LIBRARY}` instead.
- Some symbols, specifically static class members like `NeighborQuery::DEFAULT_NUM_NEIGHBORS` or `NeighborQueryIterator::ITERATOR_TERMINATOR` are not exported by CMake's setting and we must do that manually. The solution I found was to define `__declspec(dllexport)` for all pertinent classes and separate all declarations into `*.h` and implementations into `*.cc`.
- The `msd` module must be linked against `libfreud`, since it uses the `parallel` feature to determine how many threads to use. This seems similar to the configuration for `interface` requiring `locality`. _Update from discussion with @vyasr: All modules need to be linked against libfreud._
- Installs CMake 3.14 on Windows only, since it's the oldest version that supports Visual Studio 2019 (which is installed on this CI image and is used for builds).

## Motivation and Context
Windows builds are useful for integration with OVITO. Also it's our second most popular build after Linux:
![image](https://user-images.githubusercontent.com/3943761/95933667-bfda2e80-0d94-11eb-8c25-f0dffcf8de47.png)
(data collected for freud 2.3.0 only, on Oct. 13, 2020)


## How Has This Been Tested?
Builds eventually passed, after strenuous efforts.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds or improves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation improvement (updates to user guides, docstrings, or developer docs)

## Checklist:
- [x] I have read the [**CONTRIBUTING**](https://github.com/glotzerlab/freud/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] I have updated the documentation (if relevant).
- [x] I have added tests that cover my changes (if relevant).
- [x] All new and existing tests passed.
- [ ] I have updated the [credits](https://github.com/glotzerlab/freud/blob/master/doc/source/reference/credits.rst).
- [ ] I have updated the [Changelog](https://github.com/glotzerlab/freud/blob/master/ChangeLog.md).
