### PR TITLE
Add scipy and rowan to RTD dependencies.

### DIFF
--- a/doc/readthedocs-env.yml
+++ b/doc/readthedocs-env.yml
@@ -11,6 +11,8 @@ dependencies:
   - tbb
   - tbb-devel
   - numpy
+  - rowan
+  - scipy
   - sphinx
   - sphinx_rtd_theme
   - nbsphinx


### PR DESCRIPTION
## Description
Adds scipy and rowan to ReadTheDocs dependencies.

## Motivation and Context
ReadTheDocs builds are failing. The conda environment solver uses Python 3.9 because that's available in conda-forge. We don't currently specify scipy in the RTD environment (this is an oversight), so it tries to install scipy after building freud. This tries to fetch scipy from PyPI, which doesn't have wheels for Python 3.9. This causes a build failure.

Specifying scipy in the conda environment should ensure compatibility and fix the problem.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation improvement (updates to user guides, docstrings, or developer docs)

## Checklist:
- [x] I have read the [**CONTRIBUTING**](https://github.com/glotzerlab/freud/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] I have updated the documentation (if relevant).
- [ ] I have added tests that cover my changes (if relevant).
- [ ] All new and existing tests passed.
- [ ] I have updated the [credits](https://github.com/glotzerlab/freud/blob/master/doc/source/reference/credits.rst).
- [ ] I have updated the [Changelog](https://github.com/glotzerlab/freud/blob/master/ChangeLog.md).
