### PR TITLE
Skip deprecation warning hack on Windows.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,8 +34,8 @@ references:
         # universal wheels instead, so once we upgrade to cmake >=3.14 we
         # won't be dependent on them updating wheels for specific new Python
         # versions.
-        ${PYTHON} -m pip install --user scikit-build==0.10.0
-        ${PYTHON} -m pip install --user -r requirements-testing.txt
+        ${PYTHON} -m pip install --user --progress-bar off scikit-build==0.10.0
+        ${PYTHON} -m pip install --user --progress-bar off -U -r requirements-testing.txt
 
   get_conda_requirements: &get_conda_requirements
     run:
@@ -46,6 +46,7 @@ references:
         conda update -q conda
         conda install python=${PYVER} pip tbb tbb-devel
         conda update --all
+        ${PYTHON} -m pip install --progress-bar off scikit-build==0.10.0
         ${PYTHON} -m pip install --progress-bar off -U -r requirements-testing.txt
         # Install cmake >=3.14 to support Visual Studio 2019 generator
         ${PYTHON} -m pip install --progress-bar off -U cmake~=3.14

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,6 +81,10 @@ references:
         # Max 4 threads to not overtax CI.
         python${PYVER} setup.py build_ext --inplace -- -DCOVERAGE=ON -- -j 4 -v
 
+  windows_env: &windows_env
+    TBB_INCLUDE: "C:\\tools\\miniconda3\\Library\\include"
+    TBB_LINK: "C:\\tools\\miniconda3\\Library\\lib"
+
   build_windows: &build_windows
     run:
       name: Build with MSVC
@@ -140,7 +144,16 @@ references:
       path: benchmarks/reports
       destination: benchmarks-reports
 
+  load_check_style: &load_check_style
+    working_directory: ~/ci/freud
+    steps:
+      - *load_code
+      - *update_submodules
+      - *get_pre_commit_requirements
+      - *pre-test-checks
+
   build_and_test_linux: &build_and_test_linux
+    working_directory: ~/ci/freud
     steps:
       - *load_code
       - *update_submodules
@@ -150,6 +163,7 @@ references:
       - *store
 
   build_and_test_linux_with_cov: &build_and_test_linux_with_cov
+    <<: *build_and_test_linux
     steps:
       - *load_code
       - *update_submodules
@@ -159,6 +173,9 @@ references:
       - *store
 
   build_and_test_windows: &build_and_test_windows
+    executor:
+      name: win/default
+      shell: bash.exe
     steps:
       - *load_code
       - *update_submodules
@@ -166,13 +183,6 @@ references:
       - *build_windows
       - *test_cov
       - *store
-
-  load_check_style: &load_check_style
-    steps:
-      - *load_code
-      - *update_submodules
-      - *get_pre_commit_requirements
-      - *pre-test-checks
 
   build_and_benchmark: &build_and_benchmark
     steps:
@@ -224,7 +234,6 @@ jobs:
   check-style:
     docker:
       - image: glotzerlab/ci:2020.10-clang11_py39
-    working_directory: ~/ci/freud
     environment:
       PYVER: "3.9"
     <<: *load_check_style
@@ -232,7 +241,6 @@ jobs:
   linux-python-39:
     docker:
       - image: glotzerlab/ci:2020.10-py39
-    working_directory: ~/ci/freud
     environment:
       PYVER: "3.9"
     <<: *build_and_test_linux_with_cov
@@ -240,7 +248,6 @@ jobs:
   linux-python-38:
     docker:
       - image: glotzerlab/ci:2020.10-py38
-    working_directory: ~/ci/freud
     environment:
       PYVER: "3.8"
     <<: *build_and_test_linux
@@ -248,7 +255,6 @@ jobs:
   linux-python-37:
     docker:
       - image: glotzerlab/ci:2020.10-py37
-    working_directory: ~/ci/freud
     environment:
       PYVER: "3.7"
     <<: *build_and_test_linux
@@ -256,19 +262,20 @@ jobs:
   linux-python-36:
     docker:
       - image: glotzerlab/ci:2020.10-py36
-    working_directory: ~/ci/freud
     environment:
       PYVER: "3.6"
     <<: *build_and_test_linux
 
-  windows-python-37:
-    executor:
-      name: win/default
-      shell: bash.exe
+  windows-python-38:
     environment:
-      PYVER: "3.7"  # Windows CI image doesn't have aliases for python3.7
-      TBB_INCLUDE: "C:\\tools\\miniconda3\\Library\\include"
-      TBB_LINK: "C:\\tools\\miniconda3\\Library\\lib"
+      PYVER: "3.8"
+      <<: *windows_env
+    <<: *build_and_test_windows
+
+  windows-python-37:
+    environment:
+      PYVER: "3.7"
+      <<: *windows_env
     <<: *build_and_test_windows
 
   test-deploy-pypi-linux:
@@ -319,9 +326,11 @@ workflows:
           requires:
             - check-style
             - linux-python-39
+      - windows-python-38
       - windows-python-37:
           requires:
             - check-style
+            - windows-python-38
 # Disabled benchmarks on CI - they currently take too much work
 #     - benchmarks:
 #         requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,8 +34,8 @@ references:
         # universal wheels instead, so once we upgrade to cmake >=3.14 we
         # won't be dependent on them updating wheels for specific new Python
         # versions.
-        python${PYVER} -m pip install --user scikit-build==0.10.0
-        python${PYVER} -m pip install --user -r requirements-testing.txt
+        ${PYTHON} -m pip install --user scikit-build==0.10.0
+        ${PYTHON} -m pip install --user -r requirements-testing.txt
 
   get_conda_requirements: &get_conda_requirements
     run:
@@ -46,9 +46,9 @@ references:
         conda update -q conda
         conda install python=${PYVER} pip tbb tbb-devel
         conda update --all
-        python${PYVER} -m pip install --progress-bar off -U -r requirements-testing.txt
+        ${PYTHON} -m pip install --progress-bar off -U -r requirements-testing.txt
         # Install cmake >=3.14 to support Visual Studio 2019 generator
-        python${PYVER} -m pip install --progress-bar off -U cmake~=3.14
+        ${PYTHON} -m pip install --progress-bar off -U cmake~=3.14
 
   get_pre_commit_requirements: &get_pre_commit_requirements
     run:
@@ -59,29 +59,30 @@ references:
         # to generate a compile database. For convenience, just use the latest
         # wheels for these; the actual build steps will test against our older
         # supported versions.
-        python${PYVER} -m pip install --user scikit-build cmake
-        python${PYVER} -m pip install --user -r requirements-precommit.txt
+        ${PYTHON} -m pip install --user scikit-build cmake
+        ${PYTHON} -m pip install --user -r requirements-precommit.txt
 
   pre-test-checks: &pre-test-checks
     run:
       name: Run all static checks
       command: |
         # Run the standard pre-commit checks first
-        python${PYVER} -m pre_commit run --all-files --show-diff-on-failure
+        ${PYTHON} -m pre_commit run --all-files --show-diff-on-failure
         # Next, run the C++ pre-commit checks.  We need to generate the
         # compile_commands.json database, which requires building.
-        python${PYVER} setup.py build_ext --inplace -- -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -- -j 4
-        python${PYVER} -m pre_commit run -c .pre-commit-config-cpp.yaml --all-files --show-diff-on-failure
+        ${PYTHON} setup.py build_ext --inplace -- -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -- -j 4
+        ${PYTHON} -m pre_commit run -c .pre-commit-config-cpp.yaml --all-files --show-diff-on-failure
 
   build: &build
     run:
       name: Build
       command: |
-        python${PYVER} --version
+        ${PYTHON} --version
         # Max 4 threads to not overtax CI.
-        python${PYVER} setup.py build_ext --inplace -- -DCOVERAGE=ON -- -j 4 -v
+        ${PYTHON} setup.py build_ext --inplace -- -DCOVERAGE=ON -- -j 4 -v
 
   windows_env: &windows_env
+    PYTHON: "python"
     TBB_INCLUDE: "C:\\tools\\miniconda3\\Library\\include"
     TBB_LINK: "C:\\tools\\miniconda3\\Library\\lib"
 
@@ -89,20 +90,20 @@ references:
     run:
       name: Build with MSVC
       command: |
-        python${PYVER} --version
-        python${PYVER} setup.py build_ext --inplace -- -G "Visual Studio 16 2019" -DCOVERAGE=ON
+        ${PYTHON} --version
+        ${PYTHON} setup.py build_ext --inplace -- -G "Visual Studio 16 2019" -DCOVERAGE=ON
 
   test: &test
     run:
       name: Run unit tests
       command: |
-          python${PYVER} -m unittest discover tests -v
+          ${PYTHON} -m unittest discover tests -v
 
   test_cov: &test_cov
     run:
       name: Run unit tests with coverage
       command: |
-          python${PYVER} -m coverage run -m unittest discover tests -v
+          ${PYTHON} -m coverage run -m unittest discover tests -v
           bash <(curl -s https://codecov.io/bash)
 
   store: &store
@@ -119,7 +120,7 @@ references:
           source $BASH_ENV
           BENCHSCR="benchmarks/benchmarker.py"
           echo "Running benchmark on current HEAD"
-          python${PYVER} "$BENCHSCR" run
+          ${PYTHON} "$BENCHSCR" run
 
   comparison: &comparison
     run:
@@ -132,12 +133,12 @@ references:
           echo 'export BENCHMARK_NPROC=2' >> $BASH_ENV
           source $BASH_ENV
           # Max 4 threads to not overtax CI.
-          python${PYVER} setup.py build_ext --inplace -- -DCOVERAGE=ON -- -j 4
+          ${PYTHON} setup.py build_ext --inplace -- -DCOVERAGE=ON -- -j 4
           git checkout "${CIRCLE_SHA1}" -- benchmarks/
           BENCHSCR="benchmarks/benchmarker.py"
           echo "Running benchmark on origin/master"
-          python${PYVER} "$BENCHSCR" run
-          python${PYVER} "$BENCHSCR" compare origin/master "${CIRCLE_SHA1}"
+          ${PYTHON} "$BENCHSCR" run
+          ${PYTHON} "$BENCHSCR" compare origin/master "${CIRCLE_SHA1}"
 
   store_benchmarks: &store_benchmarks
     store_artifacts:
@@ -236,6 +237,7 @@ jobs:
       - image: glotzerlab/ci:2020.10-clang11_py39
     environment:
       PYVER: "3.9"
+      PYTHON: "python3.9"
     <<: *load_check_style
 
   linux-python-39:
@@ -243,6 +245,7 @@ jobs:
       - image: glotzerlab/ci:2020.10-py39
     environment:
       PYVER: "3.9"
+      PYTHON: "python3.9"
     <<: *build_and_test_linux_with_cov
 
   linux-python-38:
@@ -250,6 +253,7 @@ jobs:
       - image: glotzerlab/ci:2020.10-py38
     environment:
       PYVER: "3.8"
+      PYTHON: "python3.8"
     <<: *build_and_test_linux
 
   linux-python-37:
@@ -257,6 +261,7 @@ jobs:
       - image: glotzerlab/ci:2020.10-py37
     environment:
       PYVER: "3.7"
+      PYTHON: "python3.7"
     <<: *build_and_test_linux
 
   linux-python-36:
@@ -264,7 +269,14 @@ jobs:
       - image: glotzerlab/ci:2020.10-py36
     environment:
       PYVER: "3.6"
+      PYTHON: "python3.6"
     <<: *build_and_test_linux
+
+  windows-python-39:
+    environment:
+      PYVER: "3.9"
+      <<: *windows_env
+    <<: *build_and_test_windows
 
   windows-python-38:
     environment:
@@ -275,6 +287,12 @@ jobs:
   windows-python-37:
     environment:
       PYVER: "3.7"
+      <<: *windows_env
+    <<: *build_and_test_windows
+
+  windows-python-36:
+    environment:
+      PYVER: "3.6"
       <<: *windows_env
     <<: *build_and_test_windows
 
@@ -306,6 +324,7 @@ jobs:
     working_directory: ~/ci/freud
     environment:
       PYVER: "3.8"
+      PYTHON: "python3.8"
     <<: *build_and_benchmark
 
 workflows:
@@ -326,11 +345,19 @@ workflows:
           requires:
             - check-style
             - linux-python-39
-      - windows-python-38
+      - windows-python-39
+      - windows-python-38:
+          requires:
+            - check-style
+            - windows-python-39
       - windows-python-37:
           requires:
             - check-style
-            - windows-python-38
+            - windows-python-39
+      - windows-python-36:
+          requires:
+            - check-style
+            - windows-python-39
 # Disabled benchmarks on CI - they currently take too much work
 #     - benchmarks:
 #         requires:
@@ -345,7 +372,10 @@ workflows:
             - linux-python-38
             - linux-python-37
             - linux-python-36
+            - windows-python-39
+            - windows-python-38
             - windows-python-37
+            - windows-python-36
       - test-deploy-pypi-linux:
           filters:
             branches:
@@ -356,7 +386,10 @@ workflows:
             - linux-python-38
             - linux-python-37
             - linux-python-36
+            - windows-python-39
+            - windows-python-38
             - windows-python-37
+            - windows-python-36
 
   deploy:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,7 +44,7 @@ references:
         conda config --set always_yes yes --set changeps1 no
         conda config --add channels conda-forge
         conda update -q conda
-        conda install python pip tbb tbb-devel
+        conda install python=${PYVER} pip tbb tbb-devel
         conda update --all
         python${PYVER} -m pip install --progress-bar off -U -r requirements-testing.txt
         # Install cmake >=3.14 to support Visual Studio 2019 generator
@@ -266,7 +266,7 @@ jobs:
       name: win/default
       shell: bash.exe
     environment:
-      PYVER: ""  # Windows CI image doesn't have aliases for python3.7
+      PYVER: "3.7"  # Windows CI image doesn't have aliases for python3.7
       TBB_INCLUDE: "C:\\tools\\miniconda3\\Library\\include"
       TBB_LINK: "C:\\tools\\miniconda3\\Library\\lib"
     <<: *build_and_test_windows
@@ -306,18 +306,19 @@ workflows:
   test:
     jobs:
       - check-style
-      - linux-python-39:
-          requires:
-            - check-style
+      - linux-python-39
       - linux-python-38:
           requires:
             - check-style
+            - linux-python-39
       - linux-python-37:
           requires:
             - check-style
+            - linux-python-39
       - linux-python-36:
           requires:
             - check-style
+            - linux-python-39
       - windows-python-37:
           requires:
             - check-style

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,11 @@ The format is based on
 and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## v2.x.x - 20xx-xx-xx
+
+### Fixed
+* Python 3.8 builds with Windows MSVC were broken due to an unrecognized CMake compiler option.
+
 ## v2.4.0 - 2020-11-09
 
 ### Added

--- a/freud/CMakeLists.txt
+++ b/freud/CMakeLists.txt
@@ -26,7 +26,9 @@ include_directories(${NumPy_INCLUDE_DIRS})
 # compatibility with older CMake, I'm using PythonInterp; when we drop support
 # for CMake < 3.12, we should switch to find_package(Python).
 find_package(PythonInterp REQUIRED)
-if(${PYTHON_VERSION_MAJOR} EQUAL 3 AND ${PYTHON_VERSION_MINOR} EQUAL 8)
+if(${PYTHON_VERSION_MAJOR} EQUAL 3
+   AND ${PYTHON_VERSION_MINOR} EQUAL 8
+   AND NOT WIN32)
   add_compile_options("-Wno-deprecated-declarations")
 endif()
 


### PR DESCRIPTION
## Description
There's a specific exclusion for Python 3.8 in our CMake, which adds `-Wno-deprecated-declarations` to the compile options. MSVC doesn't recognize this flag.

## Motivation and Context
Fixes Windows builds for Python 3.8.
This change was needed to build on conda-forge (I added a patch). We didn't catch this locally because we don't test Windows with Python 3.8 (only 3.7).

## How Has This Been Tested?
Tested via conda-forge: https://github.com/conda-forge/freud-feedstock/pull/32

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have read the [**CONTRIBUTING**](https://github.com/glotzerlab/freud/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] I have updated the documentation (if relevant).
- [x] I have added tests that cover my changes (if relevant).
- [x] All new and existing tests passed.
- [x] I have updated the [credits](https://github.com/glotzerlab/freud/blob/master/doc/source/reference/credits.rst).
- [x] I have updated the [Changelog](https://github.com/glotzerlab/freud/blob/master/ChangeLog.md).
