### PR TITLE
Add support for HOOMD-blue version 3 snapshots in from_system.

### DIFF
--- a/freud/locality.pyx
+++ b/freud/locality.pyx
@@ -313,11 +313,13 @@ cdef class NeighborQuery:
         elif _match_class_path(system, 'MDAnalysis.coordinates.base.Timestep'):
             system = (system.triclinic_dimensions, system.positions)
 
-        # GSD compatibility
-        elif _match_class_path(system, 'gsd.hoomd.Snapshot'):
+        # GSD and HOOMD-blue 3 snapshot compatibility
+        elif _match_class_path(system,
+                               'gsd.hoomd.Snapshot',
+                               'hoomd.snapshot.Snapshot'):
             # Explicitly construct the box to silence warnings from box
-            # constructor because GSD sets Lz=1 rather than 0 for 2D boxes.
-            box = system.configuration.box.copy()
+            # constructor, HOOMD simulations often have Lz=1 for 2D boxes.
+            box = np.array(system.configuration.box)
             if system.configuration.dimensions == 2:
                 box[[2, 4, 5]] = 0
             system = (box, system.particles.position)
@@ -343,7 +345,7 @@ cdef class NeighborQuery:
                 dimensions=2 if system.cell.is2D else 3)
             system = (box, system.particles.positions)
 
-        # HOOMD-blue snapshot compatibility
+        # HOOMD-blue 2 snapshot compatibility
         elif (hasattr(system, 'box') and hasattr(system, 'particles') and
               hasattr(system.particles, 'position')):
             # Explicitly construct the box to silence warnings from box


### PR DESCRIPTION
## Description
Added support for HOOMD v3 snapshots in `NeighborQuery.from_system`.

## How Has This Been Tested?
Tested locally and it works. Note that this won't catch HOOMD v2 snapshots, which have a different class path and also have different attributes. Those are handled by a duck-type later on.

## Types of changes
- [x] New feature (non-breaking change which adds or improves functionality)

## Checklist:
- [x] I have read the [**CONTRIBUTING**](https://github.com/glotzerlab/freud/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] I have updated the documentation (if relevant).
- [ ] I have added tests that cover my changes (if relevant).
- [ ] All new and existing tests passed.
- [ ] I have updated the [credits](https://github.com/glotzerlab/freud/blob/master/doc/source/reference/credits.rst).
- [ ] I have updated the [Changelog](https://github.com/glotzerlab/freud/blob/master/ChangeLog.md).
