### PR TITLE
Force --build-type=ReleaseWithDocs to avoid conflicts with UseCython.cmake.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,7 +92,7 @@ references:
       name: Build with MSVC
       command: |
         ${PYTHON} --version
-        ${PYTHON} setup.py build_ext --inplace -- -G "Visual Studio 16 2019" -DCOVERAGE=ON
+        ${PYTHON} setup.py build_ext --inplace -- -G "Visual Studio 16 2019" -DCOVERAGE=ON -- /m
 
   test: &test
     run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,7 +92,7 @@ references:
       name: Build with MSVC
       command: |
         ${PYTHON} --version
-        ${PYTHON} setup.py build_ext --inplace -- -G "Visual Studio 16 2019" -DCOVERAGE=ON -- /m
+        ${PYTHON} setup.py build_ext --inplace -- -G "Visual Studio 16 2019" -DCOVERAGE=ON
 
   test: &test
     run:

--- a/CMake/FindTBB.cmake
+++ b/CMake/FindTBB.cmake
@@ -1,4 +1,5 @@
-find_path(TBB_INCLUDE_DIR tbb/tbb.h HINTS $ENV{TBBROOT}/include)
+find_path(TBB_INCLUDE_DIR tbb/tbb.h HINTS $ENV{TBB_ROOT}/include
+                                          $ENV{TBB_INCLUDE})
 
 # Check OS-specific env variables for libraries.
 if(DEFINED ENV{LD_LIBRARY_PATH})
@@ -12,7 +13,7 @@ else()
 endif()
 
 find_library(TBB_LIBRARY tbb HINTS ${TBB_INCLUDE_DIR}/../lib
-                                   ${LD_LIBRARY_DIR_LIST})
+                                   ${LD_LIBRARY_DIR_LIST} $ENV{TBB_LINK})
 
 if(TBB_INCLUDE_DIR AND EXISTS "${TBB_INCLUDE_DIR}/tbb/tbb_stddef.h")
   file(STRINGS "${TBB_INCLUDE_DIR}/tbb/tbb_stddef.h" TBB_H

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ cmake_minimum_required(VERSION 3.3.0)
 
 project(freud)
 
-set(DEFAULT_BUILD_TYPE "Release")
+set(DEFAULT_BUILD_TYPE "ReleaseWithDocs")
 
 # Set a default build type if none was specified
 if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
@@ -16,8 +16,9 @@ if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
   set(CMAKE_BUILD_TYPE
       "${DEFAULT_BUILD_TYPE}"
       CACHE STRING "Choose the type of build." FORCE)
-  set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug" "Release"
-                                               "MinSizeRel" "RelWithDebInfo")
+  set_property(
+    CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug" "Release" "ReleaseWithDocs"
+                                    "MinSizeRel" "RelWithDebInfo")
 endif()
 
 set(CMAKE_CXX_STANDARD 14)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,9 @@ set(DEFAULT_BUILD_TYPE "ReleaseWithDocs")
 
 # Set a default build type if none was specified
 if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+  set(CMAKE_CONFIGURATION_TYPES
+      "Debug;Release;ReleaseWithDocs;MinSizeRel;RelWithDebInfo"
+      CACHE STRING "List of supported configurations." FORCE)
   message(
     STATUS
       "Setting build type to '${DEFAULT_BUILD_TYPE}' since none was specified.")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,6 @@
 # CMake available on PyPI (which is 3.6.3).
 cmake_minimum_required(VERSION 3.3.0)
 
-
 set(DEFAULT_BUILD_TYPE "ReleaseWithDocs")
 
 # Set a default build type if none was specified
@@ -24,17 +23,24 @@ endif()
 # configuration handled in UseCython.cmake. See this issue for details:
 # https://github.com/scikit-build/scikit-build/issues/518
 set(CMAKE_CONFIGURATION_TYPES
-  "ReleaseWithDocs;Debug;Release;MinSizeRel;RelWithDebInfo"
-  CACHE STRING "List of supported configurations." FORCE)
+    "ReleaseWithDocs;Debug;Release;MinSizeRel;RelWithDebInfo"
+    CACHE STRING "List of supported configurations." FORCE)
 
 # CMake looks for these variables to be defined for the custom configuration.
-set(CMAKE_CXX_FLAGS_RELEASEWITHDOCS ${CMAKE_CXX_FLAGS_RELEASE} CACHE STRING "")
-set(CMAKE_C_FLAGS_RELEASEWITHDOCS ${CMAKE_C_FLAGS_RELEASE} CACHE STRING "")
-set(CMAKE_EXE_LINKER_FLAGS_RELEASEWITHDOCS ${CMAKE_EXE_LINKER_FLAGS_RELEASE} CACHE STRING "")
-set(CMAKE_SHARED_LINKER_FLAGS_RELEASEWITHDOCS ${CMAKE_SHARED_LINKER_FLAGS_RELEASE} CACHE STRING "")
+set(CMAKE_CXX_FLAGS_RELEASEWITHDOCS
+    ${CMAKE_CXX_FLAGS_RELEASE}
+    CACHE STRING "")
+set(CMAKE_C_FLAGS_RELEASEWITHDOCS
+    ${CMAKE_C_FLAGS_RELEASE}
+    CACHE STRING "")
+set(CMAKE_EXE_LINKER_FLAGS_RELEASEWITHDOCS
+    ${CMAKE_EXE_LINKER_FLAGS_RELEASE}
+    CACHE STRING "")
+set(CMAKE_SHARED_LINKER_FLAGS_RELEASEWITHDOCS
+    ${CMAKE_SHARED_LINKER_FLAGS_RELEASE}
+    CACHE STRING "")
 mark_as_advanced(
-  CMAKE_CXX_FLAGS_RELEASEWITHDOCS
-  CMAKE_C_FLAGS_RELEASEWITHDOCS
+  CMAKE_CXX_FLAGS_RELEASEWITHDOCS CMAKE_C_FLAGS_RELEASEWITHDOCS
   CMAKE_EXE_LINKER_FLAGS_RELEASEWITHDOCS
   CMAKE_SHARED_LINKER_FLAGS_RELEASEWITHDOCS)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,9 +13,11 @@ if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
       "Setting build type to '${DEFAULT_BUILD_TYPE}' since none was specified.")
   set(CMAKE_BUILD_TYPE
       "${DEFAULT_BUILD_TYPE}"
-      CACHE STRING "Choose the type of build." FORCE)
+      CACHE STRING
+            "Choose the type of build. The default value is ReleaseWithDocs."
+            FORCE)
   set_property(
-    CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug" "Release" "ReleaseWithDocs"
+    CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "ReleaseWithDocs" "Debug" "Release"
                                     "MinSizeRel" "RelWithDebInfo")
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,15 +4,11 @@
 # CMake available on PyPI (which is 3.6.3).
 cmake_minimum_required(VERSION 3.3.0)
 
-project(freud)
 
 set(DEFAULT_BUILD_TYPE "ReleaseWithDocs")
 
 # Set a default build type if none was specified
 if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
-  set(CMAKE_CONFIGURATION_TYPES
-      "Debug;Release;ReleaseWithDocs;MinSizeRel;RelWithDebInfo"
-      CACHE STRING "List of supported configurations." FORCE)
   message(
     STATUS
       "Setting build type to '${DEFAULT_BUILD_TYPE}' since none was specified.")
@@ -23,6 +19,27 @@ if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
     CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug" "Release" "ReleaseWithDocs"
                                     "MinSizeRel" "RelWithDebInfo")
 endif()
+
+# We define a custom ReleaseWithDocs configuration, to avoid overlap with any
+# configuration handled in UseCython.cmake. See this issue for details:
+# https://github.com/scikit-build/scikit-build/issues/518
+set(CMAKE_CONFIGURATION_TYPES
+  "ReleaseWithDocs;Debug;Release;MinSizeRel;RelWithDebInfo"
+  CACHE STRING "List of supported configurations." FORCE)
+
+# CMake looks for these variables to be defined for the custom configuration.
+set(CMAKE_CXX_FLAGS_RELEASEWITHDOCS ${CMAKE_CXX_FLAGS_RELEASE} CACHE STRING "")
+set(CMAKE_C_FLAGS_RELEASEWITHDOCS ${CMAKE_C_FLAGS_RELEASE} CACHE STRING "")
+set(CMAKE_EXE_LINKER_FLAGS_RELEASEWITHDOCS ${CMAKE_EXE_LINKER_FLAGS_RELEASE} CACHE STRING "")
+set(CMAKE_SHARED_LINKER_FLAGS_RELEASEWITHDOCS ${CMAKE_SHARED_LINKER_FLAGS_RELEASE} CACHE STRING "")
+mark_as_advanced(
+  CMAKE_CXX_FLAGS_RELEASEWITHDOCS
+  CMAKE_C_FLAGS_RELEASEWITHDOCS
+  CMAKE_EXE_LINKER_FLAGS_RELEASEWITHDOCS
+  CMAKE_SHARED_LINKER_FLAGS_RELEASEWITHDOCS)
+
+# We must define the project after adding the custom configuration.
+project(freud)
 
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -8,6 +8,7 @@ and this project adheres to
 
 ### Fixed
 * Python 3.8 builds with Windows MSVC were broken due to an unrecognized CMake compiler option.
+* Fixed broken documentation by overriding scikit-build options.
 
 ## v2.4.0 - 2020-11-09
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -8,6 +8,7 @@ and this project adheres to
 
 ### Fixed
 * Python 3.8 builds with Windows MSVC were broken due to an unrecognized CMake compiler option.
+* RPATH on Linux is now set correctly to find TBB libraries not on the global search path.
 
 ## v2.4.0 - 2020-11-09
 

--- a/doc/source/gettingstarted/installation.rst
+++ b/doc/source/gettingstarted/installation.rst
@@ -89,6 +89,12 @@ The scikit-build tool allows setup.py to accept three different sets of options 
 For example, the command ``python setup.py build_ext --inplace -- -DCOVERAGE=ON -G Ninja -- -j 4`` tell scikit-build to perform an in-place build, it tells CMake to turn on the ``COVERAGE`` option and use Ninja for compilation, and it tells Ninja to compile with 4 parallel threads.
 For more information on these options, see the `scikit-build docs <scikit-build.readthedocs.io/>`__.
 
+.. note::
+
+    The default CMake build configuration for freud is ``ReleaseWithDocs`` (not a standard build configuration like ``Release`` or ``RelWithDebInfo``).
+    On installation, ``setup.py`` assumes ``--build-type=ReleaseWithDocs`` by default if no build type is specified.
+    Using this build configuration is a workaround for `this issue <https://github.com/scikit-build/scikit-build/issues/518>`__ with scikit-build and Cython embedding docstrings.
+
 In addition to standard CMake flags, the following CMake options are available for **freud**:
 
 .. glossary::
@@ -115,11 +121,11 @@ The **freud** CMake configuration also respects the following environment variab
 
 .. note::
 
-    **freud** makes use of git submodules. If you ever wish to manually update these, you can execute:
+    **freud** makes use of git submodules. To manually update git submodules, execute:
 
     .. code-block:: bash
 
-        git submodule update --init
+        git submodule update --init --recursive
 
 Unit Tests
 ==========

--- a/freud/CMakeLists.txt
+++ b/freud/CMakeLists.txt
@@ -86,6 +86,8 @@ foreach(cython_module ${cython_modules_with_cpp} ${cython_modules_without_cpp})
   else()
     set_target_properties(${cython_module} PROPERTIES INSTALL_RPATH "\$ORIGIN")
   endif()
+  set_target_properties(${cython_module} PROPERTIES INSTALL_RPATH_USE_LINK_PATH
+                                                    True)
 endforeach()
 
 # The SolidLiquid class has an instance of cluster::Cluster as a member, so

--- a/freud/CMakeLists.txt
+++ b/freud/CMakeLists.txt
@@ -84,7 +84,7 @@ foreach(cython_module ${cython_modules_with_cpp} ${cython_modules_without_cpp})
     set_target_properties(${cython_module} PROPERTIES INSTALL_RPATH
                                                       "@loader_path")
   else()
-    set_target_properties(${cython_module} PROPERTIES INSTALL_RPATH "$ORIGIN")
+    set_target_properties(${cython_module} PROPERTIES INSTALL_RPATH "\$ORIGIN")
   endif()
 endforeach()
 

--- a/setup.py
+++ b/setup.py
@@ -29,13 +29,15 @@ def setup(*args, **kwargs):
         if arg == '--':
             # Insert at the end of the options that go to scikit-build
             break
-        elif arg.startswith('--build-type') and arg != BUILD_TYPE:
-            raise RuntimeError(f'Specifying --build-type is not allowed. '
-                               f'freud requires {BUILD_TYPE}')
+        elif arg.startswith('--build-type'):
+            # Don't override user-specified build type
+            index = False
+            break
     else:
         # Insert at the end of the provided arguments
         index = len(sys.argv)
-    sys.argv.insert(index, BUILD_TYPE)
+    if index:
+        sys.argv.insert(index, BUILD_TYPE)
     skbuild_setup(*args, **kwargs)
 
 

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
+import sys
 import os
-from skbuild import setup
+from skbuild import setup as skbuild_setup
 
 version = '2.4.0'
 
@@ -12,6 +13,31 @@ try:
         readme = f.read()
 except ImportError:
     readme = desc
+
+
+def setup(*args, **kwargs):
+    """This wrapper exists to force the option --build-type=ReleaseWithDocs.
+
+    Neither Release nor RelWithDebInfo will work, due to hard-coded options in
+    scikit-build's UseCython.cmake that disable docstrings. The choice of
+    ReleaseWithDocs is arbitrary, as a string that won't overlap with any build
+    type handled in UseCython.cmake. See this issue for details:
+    https://github.com/scikit-build/scikit-build/issues/518
+    """
+    BUILD_TYPE = '--build-type=ReleaseWithDocs'
+    for index, arg in enumerate(sys.argv):
+        if arg == '--':
+            # Insert at the end of the options that go to scikit-build
+            break
+        elif arg.startswith('--build-type') and arg != BUILD_TYPE:
+            raise RuntimeError(f'Specifying --build-type is not allowed. '
+                               f'freud requires {BUILD_TYPE}')
+    else:
+        # Insert at the end of the provided arguments
+        index = len(sys.argv)
+    sys.argv.insert(index, BUILD_TYPE)
+    skbuild_setup(*args, **kwargs)
+
 
 setup(
     name='freud-analysis',


### PR DESCRIPTION
## Description
The flags Cython relies on for documentation were changed with the merge of #668 when scikit-build was introduced. This means that the 2.4.0 release does not have functioning documentation. I opened an issue https://github.com/scikit-build/scikit-build/issues/518 to detail what is going wrong. In this PR, I introduce a workaround that forces `--build-type=ReleaseWithDocs`, an arbitrary build type that is not detected by scikit-build's `UseCython.cmake` configuration.

## Motivation and Context
Fixes broken documentation. This will be released as freud 2.4.1.

## How Has This Been Tested?
Works locally for me. I will verify the output of ReadTheDocs. I would like other developers to try it as well.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!-- Put an `x` in all the boxes that apply. If you're unsure about any of
     these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/glotzerlab/freud/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] I have updated the documentation (if relevant).
- [x] I have added tests that cover my changes (if relevant).
- [x] All new and existing tests passed.
- [x] I have updated the [credits](https://github.com/glotzerlab/freud/blob/master/doc/source/reference/credits.rst).
- [x] I have updated the [Changelog](https://github.com/glotzerlab/freud/blob/master/ChangeLog.md).
