### PR TITLE
Escape dollar sign for ORIGIN in property.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -8,6 +8,7 @@ and this project adheres to
 
 ### Fixed
 * Python 3.8 builds with Windows MSVC were broken due to an unrecognized CMake compiler option.
+* RPATH on Linux is now set correctly to find TBB libraries not on the global search path.
 
 ## v2.4.0 - 2020-11-09
 

--- a/freud/CMakeLists.txt
+++ b/freud/CMakeLists.txt
@@ -86,6 +86,8 @@ foreach(cython_module ${cython_modules_with_cpp} ${cython_modules_without_cpp})
   else()
     set_target_properties(${cython_module} PROPERTIES INSTALL_RPATH "\$ORIGIN")
   endif()
+  set_target_properties(${cython_module} PROPERTIES INSTALL_RPATH_USE_LINK_PATH
+                                                    True)
 endforeach()
 
 # The SolidLiquid class has an instance of cluster::Cluster as a member, so

--- a/freud/CMakeLists.txt
+++ b/freud/CMakeLists.txt
@@ -84,7 +84,7 @@ foreach(cython_module ${cython_modules_with_cpp} ${cython_modules_without_cpp})
     set_target_properties(${cython_module} PROPERTIES INSTALL_RPATH
                                                       "@loader_path")
   else()
-    set_target_properties(${cython_module} PROPERTIES INSTALL_RPATH "$ORIGIN")
+    set_target_properties(${cython_module} PROPERTIES INSTALL_RPATH "\$ORIGIN")
   endif()
 endforeach()
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above. -->

## Description
<!-- Describe your changes in detail. -->

See title.

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- Replace ??? with the issue number that this pull request resolves, if applicable. -->
CMake's handling of $ORIGIN in RPATH setting is fragile. In this case it looks like it does need an escape; I concluded that it wasn't necessary when inspecting executable on our Linux workstations, but that's because it was finding it in the global search paths since we have system installations. This breaks inside conda environments.

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to
     see how your changes affect other areas of the code, etc. -->

Tested on @klywang's computer, will also be tested on RTD as part of this PR.

## Screenshots
<!-- (if appropriate) -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds or improves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation improvement (updates to user guides, docstrings, or developer docs)

## Checklist:
<!-- Put an `x` in all the boxes that apply. If you're unsure about any of
     these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/glotzerlab/freud/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] I have updated the documentation (if relevant).
- [ ] I have added tests that cover my changes (if relevant).
- [ ] All new and existing tests passed.
- [ ] I have updated the [credits](https://github.com/glotzerlab/freud/blob/master/doc/source/reference/credits.rst).
- [x] I have updated the [Changelog](https://github.com/glotzerlab/freud/blob/master/ChangeLog.md).
