### PR TITLE
Force fractional offset to zero for 2D image calculations.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -10,6 +10,7 @@ and this project adheres to
 * Python 3.8 builds with Windows MSVC were broken due to an unrecognized CMake compiler option.
 * Fixed broken documentation by overriding scikit-build options.
 * RPATH on Linux is now set correctly to find TBB libraries not on the global search path.
+* 2D box image calculations now return zero for the image z value.
 
 ## v2.4.0 - 2020-11-09
 
@@ -32,7 +33,6 @@ and this project adheres to
 * Hexatic order parameter (unweighted) normalizes by number of neighbors instead of the symmetry order k.
 * Particles with an i-j normal vector of [0, 0, 0] are excluded from 2D Voronoi NeighborList computations for numerical stability reasons.
 * Memory leak in `makeDefaultNlist` function where a NeighborList was being allocated and not freed.
-* Forced fractional offset ot zero for 2D image calculations.
 
 ## v2.3.0 - 2020-08-03
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -30,6 +30,7 @@ and this project adheres to
 * Hexatic order parameter (unweighted) normalizes by number of neighbors instead of the symmetry order k.
 * Particles with an i-j normal vector of [0, 0, 0] are excluded from 2D Voronoi NeighborList computations for numerical stability reasons.
 * Memory leak in `makeDefaultNlist` function where a NeighborList was being allocated and not freed.
+* Forced fractional offset ot zero for 2D image calculations.
 
 ## v2.3.0 - 2020-08-03
 

--- a/cpp/box/Box.h
+++ b/cpp/box/Box.h
@@ -280,6 +280,10 @@ public:
     inline void getImage(const vec3<float>& v, vec3<int>& image) const
     {
         vec3<float> f = makeFractional(v) - vec3<float>(0.5, 0.5, 0.5);
+        if (m_2d)
+        {
+            f.z = float(0.0);
+        }
         image.x = (int) ((f.x >= float(0.0)) ? f.x + float(0.5) : f.x - float(0.5));
         image.y = (int) ((f.y >= float(0.0)) ? f.y + float(0.5) : f.y - float(0.5));
         image.z = (int) ((f.z >= float(0.0)) ? f.z + float(0.5) : f.z - float(0.5));

--- a/doc/source/reference/credits.rst
+++ b/doc/source/reference/credits.rst
@@ -112,6 +112,7 @@ Bradley Dice - **Lead developer**
 * Fixed ``Hexatic`` order parameter (unweighted) to normalize by number of neighbors instead of the symmetry order k.
 * Added ``num_query_points`` and ``num_points`` attributes to NeighborList class.
 * Added scikit-build support for Windows.
+* Fixed 2D image calculations. 
 
 Eric Harper, University of Michigan - **Former lead developer**
 
@@ -270,6 +271,7 @@ Kelly Wang
 * Enabled NeighborList indexing.
 * Added methods ``compute_distances`` and ``compute_all_distances`` to Box.
 * Added method ``crop`` to Box.
+* Added 2D Box tests for ``get_image`` and ``contains``.
 
 Yezhi Jin
 

--- a/doc/source/reference/credits.rst
+++ b/doc/source/reference/credits.rst
@@ -112,7 +112,7 @@ Bradley Dice - **Lead developer**
 * Fixed ``Hexatic`` order parameter (unweighted) to normalize by number of neighbors instead of the symmetry order k.
 * Added ``num_query_points`` and ``num_points`` attributes to NeighborList class.
 * Added scikit-build support for Windows.
-* Fixed 2D image calculations. 
+* Fixed 2D image calculations.
 
 Eric Harper, University of Michigan - **Former lead developer**
 

--- a/tests/test_box_Box.py
+++ b/tests/test_box_Box.py
@@ -510,12 +510,14 @@ class TestBox(unittest.TestCase):
                             [[1., 0., 1.], [np.sqrt(2), 1., 0.]], rtol=1e-6)
 
     def test_contains_2d(self):
-        box = freud.box.Box(2, 3, 0, 1, 0.1, 0)
+        box = freud.box.Box(2, 3, 0, 1, 0, 0)
         points = np.random.uniform(-0.5, 0.5, size=(100, 3)).astype(np.float32)
         points[:50] = np.random.uniform(
             0.50001, 0.6, size=(50, 3)).astype(np.float32)
         points[:50] *= (-1)**np.random.randint(0, 2, size=(50, 3))
         points = points @ box.to_matrix().T
+        # Force z=0
+        points[:, 2] = 0
 
         in_box_mask = np.ones(points.shape[0]).astype(bool)
         in_box_mask[:50] = False

--- a/tests/test_box_Box.py
+++ b/tests/test_box_Box.py
@@ -160,7 +160,7 @@ class TestBox(unittest.TestCase):
         npt.assert_allclose(
             box.unwrap(points, imgs), [[20, 1, 2], [21, 1, 2]], rtol=1e-6)
 
-    def test_images(self):
+    def test_images_3d(self):
         box = freud.box.Box(2, 2, 2, 0, 0, 0)
         points = np.array([[50, 40, 30],
                            [-10, 0, 0]])
@@ -171,6 +171,19 @@ class TestBox(unittest.TestCase):
         images = box.get_images(points)
         npt.assert_equal(images,
                          np.array([[25, 20, 15],
+                                   [-5, 0, 0]]))
+
+    def test_images_2d(self):
+        box = freud.box.Box(2, 2, 0, 0, 0, 0)
+        points = np.array([[50, 40, 0],
+                           [-10, 0, 0]])
+        images = np.array([box.get_images(vec) for vec in points])
+        npt.assert_equal(images,
+                         np.array([[25, 20, 0],
+                                   [-5, 0, 0]]))
+        images = box.get_images(points)
+        npt.assert_equal(images,
+                         np.array([[25, 20, 0],
                                    [-5, 0, 0]]))
 
     def test_center_of_mass(self):
@@ -496,7 +509,19 @@ class TestBox(unittest.TestCase):
         npt.assert_allclose(distances,
                             [[1., 0., 1.], [np.sqrt(2), 1., 0.]], rtol=1e-6)
 
-    def test_contains(self):
+    def test_contains_2d(self):
+        box = freud.box.Box(2, 3, 0, 1, 0.1, 0)
+        points = np.random.uniform(-0.5, 0.5, size=(100, 3)).astype(np.float32)
+        points[:50] = np.random.uniform(
+            0.50001, 0.6, size=(50, 3)).astype(np.float32)
+        points[:50] *= (-1)**np.random.randint(0, 2, size=(50, 3))
+        points = points @ box.to_matrix().T
+
+        in_box_mask = np.ones(points.shape[0]).astype(bool)
+        in_box_mask[:50] = False
+        npt.assert_array_equal(in_box_mask, box.contains(points))
+
+    def test_contains_3d(self):
         box = freud.box.Box(2, 3, 4, 1, 0.1, 0.3)
         points = np.random.uniform(-0.5, 0.5, size=(100, 3)).astype(np.float32)
         points[:50] = np.random.uniform(


### PR DESCRIPTION
## Description
Resolves issue #696 with images in 2D boxes by correcting the fractional offset used during the calculation.

@klywang I went ahead with this so that it doesn't delay #694 when we're ready to release v2.4.1. Would you be willing to add tests that catch the problem, update the changelog, etc.?

## Motivation and Context
Resolves: #696

## How Has This Been Tested?
(needs tests)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have read the [**CONTRIBUTING**](https://github.com/glotzerlab/freud/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] I have updated the documentation (if relevant).
- [x] I have added tests that cover my changes (if relevant).
- [x] All new and existing tests passed.
- [x] I have updated the [credits](https://github.com/glotzerlab/freud/blob/master/doc/source/reference/credits.rst).
- [x] I have updated the [Changelog](https://github.com/glotzerlab/freud/blob/master/ChangeLog.md).
