### PR TITLE
Add bibtex file reference.

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -44,6 +44,9 @@ extensions = [
     'sphinxcontrib.bibtex',
 ]
 
+# For sphinxcontrib.bibtex (as of v2.0).
+bibtex_bibfiles = ["reference/freud.bib"]
+
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
 


### PR DESCRIPTION
## Description
Fix for the docs. `sphinxcontrib-bibtex` requires a new option in v2.0. This can be merged when tests pass.
