### PR TITLE
Optimize filter method.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,11 @@ The format is based on
 and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## next
+
+### Changed
+* NeighborList `filter` method has been optimized.
+
 ## v2.4.1 - 2020-11-16
 
 ### Fixed

--- a/cpp/locality/NeighborList.cc
+++ b/cpp/locality/NeighborList.cc
@@ -1,6 +1,8 @@
 // Copyright (c) 2010-2020 The Regents of the University of Michigan
 // This file is from the freud project, released under the BSD 3-Clause License.
 
+#include <algorithm>
+
 #include "NeighborList.h"
 
 namespace freud { namespace locality {
@@ -117,25 +119,38 @@ void NeighborList::updateSegmentCounts() const
 // accept an "end" parameter as well.
 template<typename Iterator> unsigned int NeighborList::filter(Iterator begin)
 {
-    // number of good (unfiltered-out) elements so far
-    unsigned int num_good(0);
     const unsigned int old_size(getNumBonds());
+    const auto end = begin + old_size;
+
+    // new_size is the number of good (unfiltered-out) elements
+    const unsigned int new_size(std::count(begin, end, true));
+
+    // Arrays to hold filtered data - we use new arrays instead of writing over
+    // existing data to avoid requiring a second pass in resize().
+    auto new_neighbors = util::ManagedArray<unsigned int>({new_size, 2});
+    auto new_distances = util::ManagedArray<float>(new_size);
+    auto new_weights = util::ManagedArray<float>(new_size);
 
     auto current_element = begin;
+    auto num_good = 0;
     for (unsigned int i(0); i < old_size; ++i)
     {
         if (*current_element)
         {
-            m_neighbors(num_good, 0) = m_neighbors(i, 0);
-            m_neighbors(num_good, 1) = m_neighbors(i, 1);
-            m_weights[num_good] = m_weights[i];
-            m_distances[num_good] = m_distances[i];
+            new_neighbors(num_good, 0) = m_neighbors(i, 0);
+            new_neighbors(num_good, 1) = m_neighbors(i, 1);
+            new_weights[num_good] = m_weights[i];
+            new_distances[num_good] = m_distances[i];
             ++num_good;
         }
         ++current_element;
     }
-    resize(num_good);
-    return old_size - num_good;
+
+    m_neighbors = new_neighbors;
+    m_distances = new_distances;
+    m_weights = new_weights;
+    m_segments_counts_updated = false;
+    return old_size - new_size;
 }
 
 // Explicit template instantiation required for usage in dynamically linked

--- a/cpp/locality/NeighborList.cc
+++ b/cpp/locality/NeighborList.cc
@@ -132,7 +132,7 @@ template<typename Iterator> unsigned int NeighborList::filter(Iterator begin)
     auto new_weights = util::ManagedArray<float>(new_size);
 
     auto current_element = begin;
-    auto num_good = 0;
+    unsigned int num_good(0);
     for (unsigned int i(0); i < old_size; ++i)
     {
         if (*current_element)

--- a/doc/source/reference/credits.rst
+++ b/doc/source/reference/credits.rst
@@ -113,6 +113,7 @@ Bradley Dice - **Lead developer**
 * Added ``num_query_points`` and ``num_points`` attributes to NeighborList class.
 * Added scikit-build support for Windows.
 * Fixed 2D image calculations.
+* Optimized NeighborList ``filter`` method.
 
 Eric Harper, University of Michigan - **Former lead developer**
 


### PR DESCRIPTION
## Description
I looked at some code in https://github.com/glotzerlab/freud-examples/pull/19/ and noticed that the NeighborList filter method was rather slow. This PR speeds it up by about 2x, by avoiding a second pass through `resize()` which has to allocate and copy all data a second time.

## How Has This Been Tested?
Existing tests pass. Performance for a trajectory of around 500k bonds has roughly doubled.

## Types of changes
- [x] New feature (non-breaking change which adds or improves functionality)

## Checklist:
- [x] I have read the [**CONTRIBUTING**](https://github.com/glotzerlab/freud/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] I have updated the documentation (if relevant).
- [x] I have added tests that cover my changes (if relevant).
- [x] All new and existing tests passed.
- [x] I have updated the [credits](https://github.com/glotzerlab/freud/blob/master/doc/source/reference/credits.rst).
- [x] I have updated the [Changelog](https://github.com/glotzerlab/freud/blob/master/ChangeLog.md).
