### PR TITLE
Use static casts, compare signed/unsigned like types to reduce warnings.

### DIFF
--- a/cpp/density/GaussianDensity.cc
+++ b/cpp/density/GaussianDensity.cc
@@ -67,9 +67,9 @@ void GaussianDensity::compute(const freud::locality::NeighborQuery* nq, const fl
     const float Lz = m_box.getLz();
     const vec3<bool> periodic = m_box.getPeriodic();
 
-    const float grid_size_x = Lx / m_width.x;
-    const float grid_size_y = Ly / m_width.y;
-    const float grid_size_z = m_box.is2D() ? 0 : Lz / m_width.z;
+    const float grid_size_x = Lx / static_cast<float>(m_width.x);
+    const float grid_size_y = Ly / static_cast<float>(m_width.y);
+    const float grid_size_z = m_box.is2D() ? 0 : Lz / static_cast<float>(m_width.z);
 
     // Find the number of bins within r_max
     const int bin_cut_x = int(m_r_max / grid_size_x);

--- a/cpp/density/SphereVoxelization.cc
+++ b/cpp/density/SphereVoxelization.cc
@@ -66,9 +66,9 @@ void SphereVoxelization::compute(const freud::locality::NeighborQuery* nq)
     const float Lz = m_box.getLz();
     const vec3<bool> periodic = m_box.getPeriodic();
 
-    const float grid_size_x = Lx / m_width.x;
-    const float grid_size_y = Ly / m_width.y;
-    const float grid_size_z = m_box.is2D() ? 0 : Lz / m_width.z;
+    const float grid_size_x = Lx / static_cast<float>(m_width.x);
+    const float grid_size_y = Ly / static_cast<float>(m_width.y);
+    const float grid_size_z = m_box.is2D() ? 0 : Lz / static_cast<float>(m_width.z);
 
     // Find the number of bins within r_max
     const int bin_cut_x = int(m_r_max / grid_size_x);

--- a/cpp/environment/Registration.h
+++ b/cpp/environment/Registration.h
@@ -61,11 +61,7 @@ inline std::vector<vec3<float>> makeVec3Matrix(const matrix& m)
     std::vector<vec3<float>> vecs;
     for (unsigned int i = 0; i < m.rows(); i++)
     {
-        vec3<float> v;
-        v.x = m(i, 0);
-        v.y = m(i, 1);
-        v.z = m(i, 2);
-        vecs.push_back(v);
+        vecs.emplace_back(m(i, 0), m(i, 1), m(i, 2));
     }
     return vecs;
 }

--- a/cpp/locality/NeighborList.cc
+++ b/cpp/locality/NeighborList.cc
@@ -84,17 +84,18 @@ void NeighborList::updateSegmentCounts() const
     {
         m_counts.prepare(m_num_query_points);
         m_segments.prepare(m_num_query_points);
-        int last_index(-1);
+        const unsigned int INDEX_TERMINATOR(0xffffffff);
+        unsigned int last_index(INDEX_TERMINATOR);
         unsigned int counter(0);
         for (unsigned int i = 0; i < getNumBonds(); i++)
         {
-            const int index = m_neighbors(i, 0);
+            const unsigned int index(m_neighbors(i, 0));
             if (index != last_index)
             {
                 m_segments[index] = i;
                 if (index > 0)
                 {
-                    if (last_index >= 0)
+                    if (last_index != INDEX_TERMINATOR)
                     {
                         m_counts[last_index] = counter;
                     }
@@ -104,7 +105,7 @@ void NeighborList::updateSegmentCounts() const
             last_index = index;
             counter++;
         }
-        if (last_index >= 0)
+        if (last_index != INDEX_TERMINATOR)
         {
             m_counts[last_index] = counter;
         }

--- a/cpp/order/HexaticTranslational.cc
+++ b/cpp/order/HexaticTranslational.cc
@@ -54,7 +54,7 @@ void Hexatic::compute(const freud::locality::NeighborList* nlist,
     computeGeneral(
         [this](const vec3<float>& delta) {
             const float theta_ij = std::atan2(delta.y, delta.x);
-            return std::exp(std::complex<float>(0, m_k * theta_ij));
+            return std::exp(std::complex<float>(0, static_cast<float>(m_k) * theta_ij));
         },
         nlist, points, qargs, false);
 }

--- a/cpp/order/RotationalAutocorrelation.cc
+++ b/cpp/order/RotationalAutocorrelation.cc
@@ -43,8 +43,8 @@ inline std::complex<float> RotationalAutocorrelation::hypersphere_harmonic(const
     std::complex<float> sum_tracker(0, 0);
     for (unsigned int k = (m1 + m2 < m_l ? 0 : m1 + m2 - m_l); k <= std::min(m1, m2); k++)
     {
-        float fact_product = static_cast<float>(m_factorials[k]) * m_factorials[m_l + k - m1 - m2]
-            * m_factorials[m1 - k] * m_factorials[m2 - k];
+        float fact_product = static_cast<float>(m_factorials[k]) * static_cast<float>(m_factorials[m_l + k - m1 - m2])
+            * static_cast<float>(m_factorials[m1 - k]) * static_cast<float>(m_factorials[m2 - k]);
         sum_tracker += cpow(xi_conj, k) * cpow(zeta, m2 - k) * cpow(zeta_conj, m1 - k)
             * cpow(-xi, m_l + k - m1 - m2) / fact_product;
     }

--- a/cpp/pmft/PMFT.h
+++ b/cpp/pmft/PMFT.h
@@ -74,7 +74,7 @@ protected:
         float prefactor = inv_num_dens * norm_factor;
 
         m_histogram.reduceOverThreadsPerBin(m_local_histograms, [this, &prefactor, &jf](size_t i) {
-            m_pcf_array[i] = m_histogram[i] * prefactor * jf(i);
+            m_pcf_array[i] = static_cast<float>(m_histogram[i]) * prefactor * jf(i);
         });
     }
 

--- a/cpp/pmft/PMFTXYZ.cc
+++ b/cpp/pmft/PMFTXYZ.cc
@@ -87,7 +87,7 @@ void PMFTXYZ::reduce()
 
     float jacobian_factor = (float) 1.0 / m_jacobian;
     m_histogram.reduceOverThreadsPerBin(m_local_histograms, [this, &prefactor, &jacobian_factor](size_t i) {
-        m_pcf_array[i] = m_histogram[i] * prefactor * jacobian_factor;
+        m_pcf_array[i] = static_cast<float>(m_histogram[i]) * prefactor * jacobian_factor;
     });
 }
 

--- a/cpp/util/Histogram.h
+++ b/cpp/util/Histogram.h
@@ -127,7 +127,7 @@ public:
         {
             // Spacing via multiplication is more numerically stable than
             // adding the bin width repeatedly
-            m_bin_edges[i] = min + i * m_bin_width;
+            m_bin_edges[i] = min + static_cast<float>(i) * m_bin_width;
         }
     }
 


### PR DESCRIPTION
## Description
A handful of minor C++ improvements. I added some `static_cast` calls in places where implicit casts were being performed. Also made some minor changes for implicit casts between signed/unsigned ints.

## Motivation and Context
Makes the codebase more explicit and reduces warnings from linters.

## How Has This Been Tested?
Linters give fewer warnings, existing tests pass.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds or improves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation improvement (updates to user guides, docstrings, or developer docs)

## Checklist:
- [x] I have read the [**CONTRIBUTING**](https://github.com/glotzerlab/freud/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] I have updated the documentation (if relevant).
- [x] I have added tests that cover my changes (if relevant).
- [x] All new and existing tests passed.
- [ ] I have updated the [credits](https://github.com/glotzerlab/freud/blob/master/doc/source/reference/credits.rst).
- [ ] I have updated the [Changelog](https://github.com/glotzerlab/freud/blob/master/ChangeLog.md).
