### PR TITLE
Use np.asarray to convert subclasses. Resolves #766.

### DIFF
--- a/freud/util.pyx
+++ b/freud/util.pyx
@@ -224,6 +224,7 @@ def _convert_array(array, shape=None, dtype=np.float32, requirements=("C", ),
     if array is None:
         return np.empty(shape, dtype=dtype)
 
+    array = np.asarray(array)
     return_arr = np.require(array, dtype=dtype, requirements=requirements)
 
     if not allow_copy and return_arr is not array:

--- a/tests/integration/test_reader_integrations.py
+++ b/tests/integration/test_reader_integrations.py
@@ -7,13 +7,6 @@ import pytest
 
 import freud
 
-try:
-    import MDAnalysis
-
-    MDANALYSIS = True
-except ImportError:
-    MDANALYSIS = False
-
 
 def _relative_path(*path):
     return os.path.join(os.path.dirname(__file__), *path)
@@ -37,13 +30,13 @@ class TestReaderIntegrations:
     @pytest.mark.skipif(
         sys.platform.startswith("win"), reason="Not supported on Windows."
     )
-    @pytest.mark.skipif(not MDANALYSIS, reason="MDAnalysis is not installed.")
     def test_mdanalysis_gsd(self):
+        MDAnalysis = pytest.importorskip("MDAnalysis")
         reader = MDAnalysis.coordinates.GSD.GSDReader(LJ_GSD)
         self.run_analyses(reader)
 
-    @pytest.mark.skipif(not MDANALYSIS, reason="MDAnalysis is not installed.")
     def test_mdanalysis_dcd(self):
+        MDAnalysis = pytest.importorskip("MDAnalysis")
         reader = MDAnalysis.coordinates.DCD.DCDReader(LJ_DCD)
         self.run_analyses(reader)
 

--- a/tests/integration/test_reader_integrations.py
+++ b/tests/integration/test_reader_integrations.py
@@ -58,3 +58,9 @@ class TestReaderIntegrations:
 
         with garnett.read(LJ_DCD) as traj:
             self.run_analyses(traj)
+
+    def test_ovito_gsd(self):
+        import_file = pytest.importorskip("ovito.io").import_file
+        pipeline = import_file(LJ_GSD)
+        traj = [pipeline.compute(i) for i in range(pipeline.source.num_frames)]
+        self.run_analyses(traj)

--- a/tests/test_environment_LocalDescriptors.py
+++ b/tests/test_environment_LocalDescriptors.py
@@ -333,8 +333,7 @@ class TestLocalDescriptors:
     def test_ld(self):
         """Verify the behavior of LocalDescriptors by explicitly calculating
         spherical harmonics manually and verifying them."""
-        special = pytest.importorskip("scipy.special")
-        sph_harm = special.sph_harm
+        sph_harm = pytest.importorskip("scipy.special").sph_harm
 
         atol = 1e-5
         L = 8
@@ -388,8 +387,7 @@ class TestLocalDescriptors:
     def test_query_point_ne_points(self):
         """Verify the behavior of LocalDescriptors by explicitly calculating
         spherical harmonics manually and verifying them."""
-        special = pytest.importorskip("scipy.special")
-        sph_harm = special.sph_harm
+        sph_harm = pytest.importorskip("scipy.special").sph_harm
 
         atol = 1e-5
         L = 8


### PR DESCRIPTION
## Description
Resolves #766. See issue for details. I'm not adding a changelog / credits entry for this because the breaking change in #674 had not yet been released.

## Motivation and Context
Resolves: #766

## How Has This Been Tested?
Tested with local installation of OVITO, and it fixed the problem. I don't know how to write an effective test for this behavior without extensive mocking of `np.ndarray` subclasses.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds or improves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation improvement (updates to user guides, docstrings, or developer docs)

## Checklist:
- [x] I have read the [**CONTRIBUTING**](https://github.com/glotzerlab/freud/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] I have updated the documentation (if relevant).
- [x] I have added tests that cover my changes (if relevant).
- [x] All new and existing tests passed.
- [ ] I have updated the [credits](https://github.com/glotzerlab/freud/blob/master/doc/source/reference/credits.rst).
- [ ] I have updated the [Changelog](https://github.com/glotzerlab/freud/blob/master/ChangeLog.md).
