### PR TITLE
Fix TBB failures in CI.

### DIFF
--- a/.github/workflows/cibuildwheel-before-build.ps1
+++ b/.github/workflows/cibuildwheel-before-build.ps1
@@ -13,7 +13,7 @@ mv "oneTBB-${TBB_VERSION}" "${PACKAGE_DIR}/tbb"
 cd "${PACKAGE_DIR}/tbb"
 mkdir -p build
 cd build
-cmake ../ -DTBB_TEST=OFF
+cmake ../ -DTBB_TEST=OFF -DTBB_STRICT=OFF
 cmake --build . -j
 cmake -DCOMPONENT=runtime -P cmake_install.cmake
 cmake -DCOMPONENT=devel -P cmake_install.cmake

--- a/.github/workflows/cibuildwheel-before-build.sh
+++ b/.github/workflows/cibuildwheel-before-build.sh
@@ -24,6 +24,6 @@ mv "oneTBB-${TBB_VERSION}" "${PACKAGE_DIR}/tbb"
 cd "${PACKAGE_DIR}/tbb"
 mkdir -p build
 cd build
-cmake ../ -DTBB_TEST=OFF
+cmake ../ -DTBB_TEST=OFF -DTBB_STRICT=OFF
 cmake --build . -j
 cmake --install .


### PR DESCRIPTION
## Description
CI is currently failing while building TBB with error messages like:
```
clang: error: argument unused during compilation: '-MD' [-Werror,-Wunused-command-line-argument]
```

The solution is described here: https://github.com/oneapi-src/oneTBB/issues/272

Setting `-DTBB_STRICT=OFF` will prevent TBB from adding the `-Werror` flag.

@joaander This appears to fix the TBB problems in CI, just wanted to tag you so you know it's solved.

## How Has This Been Tested?
CI should pass.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds or improves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation improvement (updates to user guides, docstrings, or developer docs)

## Checklist:
- [x] I have read the [**CONTRIBUTING**](https://github.com/glotzerlab/freud/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] I have updated the documentation (if relevant).
- [x] I have added tests that cover my changes (if relevant).
- [x] All new and existing tests passed.
- [ ] I have updated the [credits](https://github.com/glotzerlab/freud/blob/master/doc/source/reference/credits.rst).
- [ ] I have updated the [Changelog](https://github.com/glotzerlab/freud/blob/master/ChangeLog.md).
