### PR TITLE
Disable PDF docs due to error.

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,5 +1,4 @@
 version: 2
-formats: all
 conda:
     environment: doc/readthedocs-env.yml
 python:


### PR DESCRIPTION
## Description
The ReadTheDocs build is currently failing when attempting to build PDF docs. I don't think PDF/epub/etc. docs are important so I propose to disable all formats besides the normal website. If other maintainers wish to keep additional documentation formats, I would ask for help with maintaining the other formats.

See failure: https://readthedocs.org/projects/freud/builds/14028885/

Note that the ReadTheDocs PR builds that run as CI checks below do not build additional formats, so this change will only be tested once this PR is merged.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds or improves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation improvement (updates to user guides, docstrings, or developer docs)

## Checklist:
- [x] I have read the [**CONTRIBUTING**](https://github.com/glotzerlab/freud/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] I have updated the documentation (if relevant).
- [x] I have added tests that cover my changes (if relevant).
- [x] All new and existing tests passed.
- [ ] I have updated the [credits](https://github.com/glotzerlab/freud/blob/master/doc/source/reference/credits.rst).
- [ ] I have updated the [Changelog](https://github.com/glotzerlab/freud/blob/master/ChangeLog.md).
