### PR TITLE
Clone submodules for source distributions.

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -70,6 +70,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2.3.4
+        with:
+          submodules: "recursive"
 
       - uses: actions/setup-python@v2.2.2
         name: Install Python


### PR DESCRIPTION
## Description
The source distribution of freud is missing git submodules in `extern/`. These submodules are required to build and we are supposed to ship the contents of `extern/` with the source distribution.

See also: https://github.com/conda-forge/freud-feedstock/pull/40#issuecomment-866436111

## Motivation and Context
Fixes errors seen on https://github.com/conda-forge/freud-feedstock/pull/40.

This will require a new patch release, v2.6.1, or creating and using the tarball from our lab website. If we use the tarball from the lab website we have to remember to manually switch the conda-forge source URL back to PyPI on the next release.

## How Has This Been Tested?
I looked at the logs for the CI, and it appears to be including the `extern/` directory now.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds or improves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation improvement (updates to user guides, docstrings, or developer docs)

## Checklist:
- [x] I have read the [**CONTRIBUTING**](https://github.com/glotzerlab/freud/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] I have updated the documentation (if relevant).
- [x] I have added tests that cover my changes (if relevant).
- [x] All new and existing tests passed.
- [x] I have updated the [credits](https://github.com/glotzerlab/freud/blob/master/doc/source/reference/credits.rst).
- [x] I have updated the [Changelog](https://github.com/glotzerlab/freud/blob/master/ChangeLog.md).
