### PR TITLE
Get a newer manylinux2010_x86_64 Docker image with auditwheel 4.0.0.

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -34,11 +34,15 @@ jobs:
           submodules: "recursive"
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v1.11.1
+        uses: pypa/cibuildwheel@v1.12.0
         env:
           # Build for cpython >= 3.6.
           CIBW_PROJECT_REQUIRES_PYTHON: "==${{ matrix.pyver }}.*"
           CIBW_SKIP: pp*
+          
+          # Pin to a manylinux image that contains auditwheel >=4.0.0.
+          # This pinning can be removed once cibuildwheel 2.0.0 is released, since it will use a newer image.
+          CIBW_MANYLINUX_X86_64_IMAGE: "quay.io/pypa/manylinux2010_x86_64:2021-06-07-00faba2"
 
           # Build only on 64-bit architectures.
           CIBW_ARCHS_MACOS: x86_64

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -39,7 +39,7 @@ jobs:
           # Build for cpython >= 3.6.
           CIBW_PROJECT_REQUIRES_PYTHON: "==${{ matrix.pyver }}.*"
           CIBW_SKIP: pp*
-          
+
           # Pin to a manylinux image that contains auditwheel >=4.0.0.
           # This pinning can be removed once cibuildwheel 2.0.0 is released, since it will use a newer image.
           CIBW_MANYLINUX_X86_64_IMAGE: "quay.io/pypa/manylinux2010_x86_64:2021-06-07-00faba2"


### PR DESCRIPTION
## Description
Attempt to fix #803.

Gets a newer manylinux2010_x86_64 Docker image with auditwheel 4.0.0.

See this comment for details: https://github.com/glotzerlab/freud/issues/803#issuecomment-868866647

This patch, if correct, will need to be released as freud version 2.6.2.

## How Has This Been Tested?
A reviewer should verify that the wheels are patched using auditwheel 4.0.0. That should correct the RPATH issues. I'll tag @klarh and @tommy-waltmann for review since you've both expressed interest in this issue.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds or improves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation improvement (updates to user guides, docstrings, or developer docs)

## Checklist:
- [x] I have read the [**CONTRIBUTING**](https://github.com/glotzerlab/freud/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] I have updated the documentation (if relevant).
- [ ] I have added tests that cover my changes (if relevant).
- [ ] All new and existing tests passed.
- [ ] I have updated the [credits](https://github.com/glotzerlab/freud/blob/master/doc/source/reference/credits.rst).
- [ ] I have updated the [Changelog](https://github.com/glotzerlab/freud/blob/master/ChangeLog.md).
