### PR TITLE
Fix box docs

### DIFF
--- a/doc/source/topics/optimizing.rst
+++ b/doc/source/topics/optimizing.rst
@@ -65,4 +65,4 @@ Minor speedups may also be gained from passing properly structured data to **fre
 The package was originally designed for analyzing particle simulation trajectories, which are typically stored in single-precision binary formats.
 As a result, the **freud** library also operates in single precision and therefore converts all inputs to single-precision.
 However, NumPy will typically work in double precision by default, so depending on how data is streamed to **freud**, the package may be performing numerous data copies in order to ensure that all its data is in single-precision.
-To avoid this problem, make sure to specify the appropriate data types (`numpy.float32 <https://docs.scipy.org/doc/numpy/user/basics.types.html>`_) when constructing your NumPy arrays.
+To avoid this problem, make sure to specify the appropriate data types (:attr:`numpy.float32`) when constructing your NumPy arrays.

--- a/freud/box.pyx
+++ b/freud/box.pyx
@@ -1,7 +1,7 @@
 # Copyright (c) 2010-2020 The Regents of the University of Michigan
 # This file is from the freud project, released under the BSD 3-Clause License.
 
-R"""
+r"""
 The :class:`~.Box` class defines the geometry of a simulation box. The class
 natively supports periodicity by providing the fundamental features for
 wrapping vectors outside the box back into it.
@@ -28,7 +28,7 @@ logger = logging.getLogger(__name__)
 np.import_array()
 
 cdef class Box:
-    R"""The freud Box class for simulation boxes.
+    r"""The freud Box class for simulation boxes.
 
     This class defines an arbitrary triclinic geometry within which all points are confined.
     By convention, the freud Box is centered at the origin (``[0, 0, 0]``),
@@ -78,7 +78,7 @@ cdef class Box:
 
     @property
     def L(self):
-        R""":math:`\left(3, \right)` :class:`numpy.ndarray`: Get or set the
+        r""":math:`\left(3, \right)` :class:`numpy.ndarray`: Get or set the
         box lengths along x, y, and z."""
         cdef vec3[float] result = self.thisptr.getL()
         return np.asarray([result.x, result.y, result.z])
@@ -170,7 +170,7 @@ cdef class Box:
 
     @property
     def L_inv(self):
-        R""":math:`\left(3, \right)` :class:`numpy.ndarray`: The inverse box
+        r""":math:`\left(3, \right)` :class:`numpy.ndarray`: The inverse box
         lengths."""
         cdef vec3[float] result = self.thisptr.getLinv()
         return np.asarray([result.x, result.y, result.z])
@@ -181,7 +181,7 @@ cdef class Box:
         return self.thisptr.getVolume()
 
     def make_absolute(self, fractional_coordinates, out=None):
-        R"""Convert fractional coordinates into absolute coordinates.
+        r"""Convert fractional coordinates into absolute coordinates.
 
         Args:
             fractional_coordinates (:math:`\left(3, \right)` or :math:`\left(N, 3\right)` :class:`numpy.ndarray`):
@@ -215,7 +215,7 @@ cdef class Box:
         return np.squeeze(out) if flatten else out
 
     def make_fractional(self, absolute_coordinates, out=None):
-        R"""Convert absolute coordinates into fractional coordinates.
+        r"""Convert absolute coordinates into fractional coordinates.
 
         Args:
             absolute_coordinates (:math:`\left(3, \right)` or :math:`\left(N, 3\right)` :class:`numpy.ndarray`):
@@ -248,7 +248,7 @@ cdef class Box:
         return np.squeeze(out) if flatten else out
 
     def get_images(self, vecs):
-        R"""Returns the images corresponding to unwrapped vectors.
+        r"""Returns the images corresponding to unwrapped vectors.
 
         Args:
             vecs (:math:`\left(3, \right)` or :math:`\left(N, 3\right)` :class:`numpy.ndarray`):
@@ -273,7 +273,7 @@ cdef class Box:
         return np.squeeze(images) if flatten else images
 
     def get_box_vector(self, i):
-        R"""Get the box vector with index :math:`i`.
+        r"""Get the box vector with index :math:`i`.
 
         Args:
             i (unsigned int):
@@ -305,7 +305,7 @@ cdef class Box:
         return self.get_box_vector(2)
 
     def wrap(self, vecs, out=None):
-        R"""Wrap an array of vectors into the box, using periodic boundaries.
+        r"""Wrap an array of vectors into the box, using periodic boundaries.
 
         .. note:: Since the origin of the box is in the center, wrapping is
                   equivalent to applying the minimum image convention to the
@@ -341,7 +341,7 @@ cdef class Box:
         return np.squeeze(out) if flatten else out
 
     def unwrap(self, vecs, imgs, out=None):
-        R"""Unwrap an array of vectors inside the box back into real space,
+        r"""Unwrap an array of vectors inside the box back into real space,
         using an array of image indices that determine how many times to unwrap
         in each dimension.
 
@@ -385,7 +385,7 @@ cdef class Box:
         return np.squeeze(out) if flatten else out
 
     def center_of_mass(self, vecs, masses=None):
-        R"""Compute center of mass of an array of vectors, using periodic boundaries.
+        r"""Compute center of mass of an array of vectors, using periodic boundaries.
 
         This calculation accounts for periodic images. `This Wikipedia page
         <https://en.wikipedia.org/wiki/Center_of_mass#Systems_with_periodic_boundary_conditions>`_
@@ -428,7 +428,7 @@ cdef class Box:
         return np.asarray([result.x, result.y, result.z])
 
     def center(self, vecs, masses=None):
-        R"""Subtract center of mass from an array of vectors, using periodic boundaries.
+        r"""Subtract center of mass from an array of vectors, using periodic boundaries.
 
         This calculation accounts for periodic images. `This Wikipedia page
         <https://en.wikipedia.org/wiki/Center_of_mass#Systems_with_periodic_boundary_conditions>`_
@@ -469,7 +469,7 @@ cdef class Box:
         return vecs
 
     def compute_distances(self, query_points, points):
-        R"""Calculate distances between two sets of points, using periodic boundaries.
+        r"""Calculate distances between two sets of points, using periodic boundaries.
 
         Distances are calculated row-wise, i.e. ``distances[i]`` is the
         distance from ``query_points[i]`` to ``points[i]``.
@@ -505,7 +505,7 @@ cdef class Box:
         return np.asarray(distances)
 
     def compute_all_distances(self, query_points, points):
-        R"""Calculate distances between all pairs of query points and points, using periodic boundaries.
+        r"""Calculate distances between all pairs of query points and points, using periodic boundaries.
 
         Distances are calculated pairwise, i.e. ``distances[i, j]`` is the
         distance from ``query_points[i]`` to ``points[j]``.
@@ -541,7 +541,7 @@ cdef class Box:
         return np.asarray(distances)
 
     def contains(self, points):
-        R"""Returns boolean array (mask) corresponding to point membership in a box.
+        r"""Returns boolean array (mask) corresponding to point membership in a box.
 
         This calculation computes particle membership based on conventions defined by :class:`Box`, ignoring periodicity.
         This means that in a cubic (3D) box with dimensions ``L``, particles would be considered inside the box if their coordinates are between
@@ -588,7 +588,7 @@ cdef class Box:
 
     @property
     def periodic(self):
-        R""":math:`\left(3, \right)` :class:`numpy.ndarray`: Get or set the
+        r""":math:`\left(3, \right)` :class:`numpy.ndarray`: Get or set the
         periodicity of the box in each dimension."""
         periodic = self.thisptr.getPeriodic()
         return np.asarray([periodic.x, periodic.y, periodic.z])
@@ -630,7 +630,7 @@ cdef class Box:
         self.thisptr.setPeriodicZ(periodic)
 
     def to_dict(self):
-        R"""Return box as dictionary.
+        r"""Return box as dictionary.
 
         Example::
 
@@ -652,7 +652,7 @@ cdef class Box:
             'dimensions': self.dimensions}
 
     def to_matrix(self):
-        R"""Returns the box matrix (3x3).
+        r"""Returns the box matrix (3x3).
 
         Example::
 
@@ -688,7 +688,7 @@ cdef class Box:
         return self.to_dict() == other.to_dict()
 
     def __richcmp__(self, other, int op):
-        R"""Implement all comparisons for Cython extension classes"""
+        r"""Implement all comparisons for Cython extension classes"""
         if op == Py_EQ:
             return self._eq(other)
         if op == Py_NE:
@@ -740,7 +740,7 @@ cdef class Box:
 
     @classmethod
     def from_box(cls, box, dimensions=None):
-        R"""Initialize a Box instance from a box-like object.
+        r"""Initialize a Box instance from a box-like object.
 
         Args:
             box:
@@ -831,7 +831,7 @@ cdef class Box:
 
     @classmethod
     def from_matrix(cls, box_matrix, dimensions=None):
-        R"""Initialize a Box instance from a box matrix.
+        r"""Initialize a Box instance from a box matrix.
 
         For more information and the source for this code,
         see: https://hoomd-blue.readthedocs.io/en/stable/box.html
@@ -870,7 +870,7 @@ cdef class Box:
 
     @classmethod
     def cube(cls, L=None):
-        R"""Construct a cubic box with equal lengths.
+        r"""Construct a cubic box with equal lengths.
 
         Args:
             L (float): The edge length
@@ -887,7 +887,7 @@ cdef class Box:
 
     @classmethod
     def square(cls, L=None):
-        R"""Construct a 2-dimensional (square) box with equal lengths.
+        r"""Construct a 2-dimensional (square) box with equal lengths.
 
         Args:
             L (float): The edge length

--- a/freud/box.pyx
+++ b/freud/box.pyx
@@ -34,7 +34,7 @@ cdef class Box:
     By convention, the freud Box is centered at the origin (``[0, 0, 0]``),
     with the extent in each dimension described by the half-open interval ``[-L/2, L/2)``.
     For more information, see the `documentation
-    <https://freud.readthedocs.io/en/stable/gettingstarted/tutorial/periodic.html>`_
+    <https://freud.readthedocs.io/en/stable/gettingstarted/tutorial/periodic.html>`__
     on boxes and periodic boundary conditions.
 
     Also available as ``freud.Box``.
@@ -188,9 +188,9 @@ cdef class Box:
                 Fractional coordinate vector(s), between 0 and 1 within
                 parallelepipedal box.
             out (:math:`\left(3, \right)` or :math:`\left(N, 3\right)` :class:`numpy.ndarray` or :code:`None`):
-                The array in which to place the absolute coordinates. It must be
-                of dtype `np.float32`. If ``None``, this function will return a
-                newly allocated array (Default value = None).
+                The array in which to place the absolute coordinates. It must
+                be of dtype :attr:`numpy.float32`. If ``None``, this function
+                will return a newly allocated array (Default value = None).
 
         Returns:
             :math:`\left(3, \right)` or :math:`\left(N, 3\right)` :class:`numpy.ndarray`:
@@ -221,9 +221,9 @@ cdef class Box:
             absolute_coordinates (:math:`\left(3, \right)` or :math:`\left(N, 3\right)` :class:`numpy.ndarray`):
                 Absolute coordinate vector(s).
             out (:math:`\left(3, \right)` or :math:`\left(N, 3\right)` :class:`numpy.ndarray` or :code:`None`):
-                The array in which to place the fractional positions. It must be
-                of dtype `np.float32`. If ``None``, this function will return a
-                newly allocated array (Default value = None).
+                The array in which to place the fractional positions. It must
+                be of dtype :attr:`numpy.float32`. If ``None``, this function
+                will return a newly allocated array (Default value = None).
 
         Returns:
             :math:`\left(3, \right)` or :math:`\left(N, 3\right)` :class:`numpy.ndarray`:
@@ -316,7 +316,7 @@ cdef class Box:
                 Unwrapped vector(s).
             out (:math:`\left(3, \right)` or :math:`\left(N, 3\right)` :class:`numpy.ndarray` or :code:`None`):
                 The array in which to place the wrapped vectors. It must be of
-                dtype `np.float32`. If ``None``, this function will
+                dtype :attr:`numpy.float32`. If ``None``, this function will
                 return a newly allocated array (Default value = None).
 
         Returns:
@@ -351,9 +351,9 @@ cdef class Box:
             imgs (:math:`\left(3, \right)` or :math:`\left(N, 3\right)` :class:`numpy.ndarray`):
                 Image indices for vector(s).
             out (:math:`\left(3, \right)` or :math:`\left(N, 3\right)` :class:`numpy.ndarray` or :code:`None`):
-                The array in which to place the unwrapped vectors. It must be of
-                dtype `np.float32`. If ``None``, this function will
-                return a newly allocated array (Default value = None).
+                The array in which to place the unwrapped vectors. It must be
+                of dtype :attr:`numpy.float32`. If ``None``, this function
+                will return a newly allocated array (Default value = None).
 
         Returns:
             :math:`\left(3, \right)` or :math:`\left(N, 3\right)` :class:`numpy.ndarray`:
@@ -388,7 +388,7 @@ cdef class Box:
         r"""Compute center of mass of an array of vectors, using periodic boundaries.
 
         This calculation accounts for periodic images. `This Wikipedia page
-        <https://en.wikipedia.org/wiki/Center_of_mass#Systems_with_periodic_boundary_conditions>`_
+        <https://en.wikipedia.org/wiki/Center_of_mass#Systems_with_periodic_boundary_conditions>`__
         describes the mathematics of this method.
 
         Example::
@@ -431,7 +431,7 @@ cdef class Box:
         r"""Subtract center of mass from an array of vectors, using periodic boundaries.
 
         This calculation accounts for periodic images. `This Wikipedia page
-        <https://en.wikipedia.org/wiki/Center_of_mass#Systems_with_periodic_boundary_conditions>`_
+        <https://en.wikipedia.org/wiki/Center_of_mass#Systems_with_periodic_boundary_conditions>`__
         describes the mathematics of this method.
 
         Example::

--- a/freud/box.pyx
+++ b/freud/box.pyx
@@ -78,7 +78,7 @@ cdef class Box:
 
     @property
     def L(self):
-        """:math:`\\left(3, \\right)` :class:`numpy.ndarray`: Get or set the
+        R""":math:`\left(3, \right)` :class:`numpy.ndarray`: Get or set the
         box lengths along x, y, and z."""
         cdef vec3[float] result = self.thisptr.getL()
         return np.asarray([result.x, result.y, result.z])
@@ -170,7 +170,7 @@ cdef class Box:
 
     @property
     def L_inv(self):
-        """:math:`\\left(3, \\right)` :class:`numpy.ndarray`: The inverse box
+        R""":math:`\left(3, \right)` :class:`numpy.ndarray`: The inverse box
         lengths."""
         cdef vec3[float] result = self.thisptr.getLinv()
         return np.asarray([result.x, result.y, result.z])
@@ -294,14 +294,14 @@ cdef class Box:
 
     @property
     def v2(self):
-        """:math:`(3, )` :class:`np.ndarray`: The second box vector
-        :math:`(xy*L_y, L_y, 0)`."""
+        r""":math:`(3, )` :class:`np.ndarray`: The second box vector
+        :math:`(xy \times L_y, L_y, 0)`."""
         return self.get_box_vector(1)
 
     @property
     def v3(self):
-        """:math:`(3, )` :class:`np.ndarray`: The third box vector
-        :math:`(xz*L_z, yz*L_z, L_z)`."""
+        r""":math:`(3, )` :class:`np.ndarray`: The third box vector
+        :math:`(xz \times L_z, yz \times L_z, L_z)`."""
         return self.get_box_vector(2)
 
     def wrap(self, vecs, out=None):
@@ -405,12 +405,12 @@ cdef class Box:
         Args:
             vecs (:math:`\left(N, 3\right)` :class:`numpy.ndarray`):
                 Vectors used to find center of mass.
-            masses (:math:`\left(N, 3\right)` :class:`numpy.ndarray`):
+            masses (:math:`\left(N,\right)` :class:`numpy.ndarray`):
                 Masses corresponding to each vector, defaulting to 1 if not
                 provided or :code:`None` (Default value = :code:`None`).
 
         Returns:
-            :math:`\left(3\right)` :class:`numpy.ndarray`:
+            :math:`\left(3, \right)` :class:`numpy.ndarray`:
                 Center of mass.
         """  # noqa: E501
         vecs = freud.util._convert_array(vecs, shape=(None, 3))
@@ -588,7 +588,7 @@ cdef class Box:
 
     @property
     def periodic(self):
-        """:math:`\\left(3, \\right)` :class:`numpy.ndarray`: Get or set the
+        R""":math:`\left(3, \right)` :class:`numpy.ndarray`: Get or set the
         periodicity of the box in each dimension."""
         periodic = self.thisptr.getPeriodic()
         return np.asarray([periodic.x, periodic.y, periodic.z])
@@ -841,6 +841,9 @@ cdef class Box:
                 A 3x3 matrix or list of lists
             dimensions (int):
                 Number of dimensions (Default value = :code:`None`)
+
+        Returns:
+            :class:`freud.box.Box`: The resulting box object.
         """
         box_matrix = np.asarray(box_matrix, dtype=np.float32)
         v0 = box_matrix[:, 0]
@@ -871,6 +874,9 @@ cdef class Box:
 
         Args:
             L (float): The edge length
+
+        Returns:
+            :class:`freud.box.Box`: The resulting box object.
         """
         # classmethods compiled with cython don't appear to support
         # named access to positional arguments, so we keep this to
@@ -885,6 +891,9 @@ cdef class Box:
 
         Args:
             L (float): The edge length
+
+        Returns:
+            :class:`freud.box.Box`: The resulting box object.
         """
         # classmethods compiled with cython don't appear to support
         # named access to positional arguments, so we keep this to

--- a/freud/cluster.pyx
+++ b/freud/cluster.pyx
@@ -1,7 +1,7 @@
 # Copyright (c) 2010-2020 The Regents of the University of Michigan
 # This file is from the freud project, released under the BSD 3-Clause License.
 
-R"""
+r"""
 The :class:`freud.cluster` module aids in finding and computing the properties
 of clusters of points in a system.
 """
@@ -62,7 +62,7 @@ cdef class Cluster(_PairCompute):
         del self.thisptr
 
     def compute(self, system, keys=None, neighbors=None):
-        R"""Compute the clusters for the given set of points.
+        r"""Compute the clusters for the given set of points.
 
         Args:
             system:
@@ -152,7 +152,7 @@ cdef class Cluster(_PairCompute):
 
 
 cdef class ClusterProperties(_Compute):
-    R"""Routines for computing properties of point clusters.
+    r"""Routines for computing properties of point clusters.
 
     Given a set of points and cluster ids (from :class:`~.Cluster` or another
     source), this class determines the following properties for each cluster:
@@ -179,7 +179,7 @@ cdef class ClusterProperties(_Compute):
         del self.thisptr
 
     def compute(self, system, cluster_idx):
-        R"""Compute properties of the point clusters.
+        r"""Compute properties of the point clusters.
         Loops over all points in the given array and determines the center of
         mass of the cluster as well as the gyration tensor. After calling
         this method, these properties can be accessed with the

--- a/freud/data.py
+++ b/freud/data.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2010-2020 The Regents of the University of Michigan
 # This file is from the freud project, released under the BSD 3-Clause License.
 
-R"""
+r"""
 The :class:`freud.data` module provides certain sample data sets and utility
 functions that are useful for testing and examples.
 

--- a/freud/density.pyx
+++ b/freud/density.pyx
@@ -1,7 +1,7 @@
 # Copyright (c) 2010-2020 The Regents of the University of Michigan
 # This file is from the freud project, released under the BSD 3-Clause License.
 
-R"""
+r"""
 The :class:`freud.density` module contains various classes relating to the
 density of the system. These functions allow evaluation of particle
 distributions with respect to other particles.
@@ -34,7 +34,7 @@ np.import_array()
 ctypedef unsigned int uint
 
 cdef class CorrelationFunction(_SpatialHistogram1D):
-    R"""Computes the complex pairwise correlation function.
+    r"""Computes the complex pairwise correlation function.
 
     The correlation function is given by
     :math:`C(r) = \left\langle s^*_1(0) \cdot s_2(r) \right\rangle` between
@@ -75,7 +75,7 @@ cdef class CorrelationFunction(_SpatialHistogram1D):
 
     def compute(self, system, values, query_points=None,
                 query_values=None, neighbors=None, reset=True):
-        R"""Calculates the correlation function and adds to the current
+        r"""Calculates the correlation function and adds to the current
         histogram.
 
         Args:
@@ -184,7 +184,7 @@ cdef class CorrelationFunction(_SpatialHistogram1D):
 
 
 cdef class GaussianDensity(_Compute):
-    R"""Computes the density of a system on a grid.
+    r"""Computes the density of a system on a grid.
 
     Replaces particle positions with a Gaussian blur and calculates the
     contribution from each to the proscribed grid based upon the distance of
@@ -239,7 +239,7 @@ cdef class GaussianDensity(_Compute):
         return freud.box.BoxFromCPP(self.thisptr.getBox())
 
     def compute(self, system, values=None):
-        R"""Calculates the Gaussian blur for the specified points.
+        r"""Calculates the Gaussian blur for the specified points.
 
         Args:
             system:
@@ -325,7 +325,7 @@ cdef class GaussianDensity(_Compute):
 
 
 cdef class SphereVoxelization(_Compute):
-    R"""Computes a grid of voxels occupied by spheres.
+    r"""Computes a grid of voxels occupied by spheres.
 
     This class constructs a grid of voxels. From a given set of points and a
     desired radius, a set of spheres are created. The voxels are assigned a
@@ -368,7 +368,7 @@ cdef class SphereVoxelization(_Compute):
         return freud.box.BoxFromCPP(self.thisptr.getBox())
 
     def compute(self, system):
-        R"""Calculates the voxelization of spheres about the specified points.
+        r"""Calculates the voxelization of spheres about the specified points.
 
         Args:
             system:
@@ -434,7 +434,7 @@ cdef class SphereVoxelization(_Compute):
 
 
 cdef class LocalDensity(_PairCompute):
-    R"""Computes the local density around a particle.
+    r"""Computes the local density around a particle.
 
     The density of the local environment is computed and averaged for a given
     set of query points in a sea of data points. Providing the same points
@@ -490,7 +490,7 @@ cdef class LocalDensity(_PairCompute):
         return freud.box.BoxFromCPP(self.thisptr.getBox())
 
     def compute(self, system, query_points=None, neighbors=None):
-        R"""Calculates the local density for the specified points.
+        r"""Calculates the local density for the specified points.
 
         Example::
 
@@ -563,7 +563,7 @@ cdef class LocalDensity(_PairCompute):
 
 
 cdef class RDF(_SpatialHistogram1D):
-    R"""Computes the RDF :math:`g \left( r \right)` for supplied data.
+    r"""Computes the RDF :math:`g \left( r \right)` for supplied data.
 
     Note that the RDF is defined strictly according to the pair correlation
     function, i.e.
@@ -626,7 +626,7 @@ cdef class RDF(_SpatialHistogram1D):
 
     def compute(self, system, query_points=None, neighbors=None,
                 reset=True):
-        R"""Calculates the RDF and adds to the current RDF histogram.
+        r"""Calculates the RDF and adds to the current RDF histogram.
 
         Args:
             system:

--- a/freud/diffraction.pyx
+++ b/freud/diffraction.pyx
@@ -1,7 +1,7 @@
 # Copyright (c) 2010-2020 The Regents of the University of Michigan
 # This file is from the freud project, released under the BSD 3-Clause License.
 
-R"""
+r"""
 The :class:`freud.diffraction` module provides functions for computing the
 diffraction pattern of particles in systems with long range order.
 
@@ -30,7 +30,7 @@ logger = logging.getLogger(__name__)
 
 
 cdef class DiffractionPattern(_Compute):
-    R"""Computes a 2D diffraction pattern.
+    r"""Computes a 2D diffraction pattern.
 
     The diffraction image represents the scattering of incident radiation,
     and is useful for identifying translational and/or rotational symmetry
@@ -199,7 +199,7 @@ cdef class DiffractionPattern(_Compute):
         return img
 
     def compute(self, system, view_orientation=None, zoom=4, peak_width=1, reset=True):
-        R"""Computes diffraction pattern.
+        r"""Computes diffraction pattern.
 
         Args:
             system:

--- a/freud/environment.pyx
+++ b/freud/environment.pyx
@@ -1,7 +1,7 @@
 # Copyright (c) 2010-2020 The Regents of the University of Michigan
 # This file is from the freud project, released under the BSD 3-Clause License.
 
-R"""
+r"""
 The :class:`freud.environment` module contains functions which characterize the
 local environments of particles in the system. These methods use the positions
 and orientations of particles in the local neighborhood of a given particle to
@@ -32,7 +32,7 @@ np.import_array()
 
 
 cdef class BondOrder(_SpatialHistogram):
-    R"""Compute the bond orientational order diagram for the system of
+    r"""Compute the bond orientational order diagram for the system of
     particles.
 
     The bond orientational order diagram (BOOD) is a way of studying the
@@ -134,7 +134,7 @@ cdef class BondOrder(_SpatialHistogram):
 
     def compute(self, system, orientations=None, query_points=None,
                 query_orientations=None, neighbors=None, reset=True):
-        R"""Calculates the correlation function and adds to the current
+        r"""Calculates the correlation function and adds to the current
         histogram.
 
         Args:
@@ -226,7 +226,7 @@ cdef class BondOrder(_SpatialHistogram):
 
 
 cdef class LocalDescriptors(_PairCompute):
-    R"""Compute a set of descriptors (a numerical "fingerprint") of a particle's
+    r"""Compute a set of descriptors (a numerical "fingerprint") of a particle's
     local environment.
 
     The resulting spherical harmonic array will be a complex-valued
@@ -276,7 +276,7 @@ cdef class LocalDescriptors(_PairCompute):
 
     def compute(self, system, query_points=None, orientations=None,
                 neighbors=None, max_num_neighbors=0):
-        R"""Calculates the local descriptors of bonds from a set of source
+        r"""Calculates the local descriptors of bonds from a set of source
         points to a set of destination points.
 
         Args:
@@ -389,7 +389,7 @@ cdef class LocalDescriptors(_PairCompute):
 
 
 def _minimize_RMSD(box, ref_points, points, registration=False):
-    R"""Get the somewhat-optimal RMSD between the set of vectors ref_points
+    r"""Get the somewhat-optimal RMSD between the set of vectors ref_points
     and the set of vectors points.
 
     Args:
@@ -435,7 +435,7 @@ def _minimize_RMSD(box, ref_points, points, registration=False):
 
 
 def _is_similar_motif(box, ref_points, points, threshold, registration=False):
-    R"""Test if the motif provided by ref_points is similar to the motif
+    r"""Test if the motif provided by ref_points is similar to the motif
     provided by points.
 
     Args:
@@ -487,7 +487,7 @@ def _is_similar_motif(box, ref_points, points, threshold, registration=False):
 
 
 cdef class _MatchEnv(_PairCompute):
-    R"""Parent for environment matching methods. """
+    r"""Parent for environment matching methods. """
     cdef freud._environment.MatchEnv * matchptr
 
     def __cinit__(self, *args, **kwargs):
@@ -508,7 +508,7 @@ cdef class _MatchEnv(_PairCompute):
 
 
 cdef class EnvironmentCluster(_MatchEnv):
-    R"""Clusters particles according to whether their local environments match
+    r"""Clusters particles according to whether their local environments match
     or not, according to various shape matching metrics.
     """
 
@@ -527,7 +527,7 @@ cdef class EnvironmentCluster(_MatchEnv):
     def compute(self, system, threshold, neighbors=None,
                 env_neighbors=None, registration=False,
                 global_search=False):
-        R"""Determine clusters of particles with matching environments.
+        r"""Determine clusters of particles with matching environments.
 
         In general, it is recommended to specify a number of neighbors rather
         than just a distance cutoff as part of your neighbor querying when
@@ -656,7 +656,7 @@ cdef class EnvironmentCluster(_MatchEnv):
 
 
 cdef class EnvironmentMotifMatch(_MatchEnv):
-    R"""Find matches between local arrangements of a set of points and a provided motif.
+    r"""Find matches between local arrangements of a set of points and a provided motif.
 
     In general, it is recommended to specify a number of neighbors rather than
     just a distance cutoff as part of your neighbor querying when performing
@@ -678,7 +678,7 @@ cdef class EnvironmentMotifMatch(_MatchEnv):
 
     def compute(self, system, motif, threshold, neighbors=None,
                 registration=False):
-        R"""Determine clusters of particles that match the motif provided by
+        r"""Determine clusters of particles that match the motif provided by
         motif.
 
         Args:
@@ -734,7 +734,7 @@ cdef class EnvironmentMotifMatch(_MatchEnv):
 
 
 cdef class _EnvironmentRMSDMinimizer(_MatchEnv):
-    R"""Find linear transformations that map the environments of points onto a
+    r"""Find linear transformations that map the environments of points onto a
     motif.
 
     In general, it is recommended to specify a number of neighbors rather than
@@ -758,7 +758,7 @@ cdef class _EnvironmentRMSDMinimizer(_MatchEnv):
 
     def compute(self, system, motif, neighbors=None,
                 registration=False):
-        R"""Rotate (if registration=True) and permute the environments of all
+        r"""Rotate (if registration=True) and permute the environments of all
         particles to minimize their RMSD with respect to the motif provided by
         motif.
 
@@ -816,7 +816,7 @@ cdef class _EnvironmentRMSDMinimizer(_MatchEnv):
 
 
 cdef class AngularSeparationNeighbor(_PairCompute):
-    R"""Calculates the minimum angles of separation between orientations and
+    r"""Calculates the minimum angles of separation between orientations and
     query orientations."""
     cdef freud._environment.AngularSeparationNeighbor * thisptr
 
@@ -833,7 +833,7 @@ cdef class AngularSeparationNeighbor(_PairCompute):
                 query_orientations=None,
                 equiv_orientations=np.array([[1, 0, 0, 0]]),
                 neighbors=None):
-        R"""Calculates the minimum angles of separation between :code:`orientations`
+        r"""Calculates the minimum angles of separation between :code:`orientations`
         and :code:`query_orientations`, checking for underlying symmetry as encoded
         in :code:`equiv_orientations`. The result is stored in the :code:`neighbor_angles`
         class attribute.
@@ -928,7 +928,7 @@ cdef class AngularSeparationNeighbor(_PairCompute):
 
 
 cdef class AngularSeparationGlobal(_Compute):
-    R"""Calculates the minimum angles of separation between orientations and
+    r"""Calculates the minimum angles of separation between orientations and
     global orientations."""
     cdef freud._environment.AngularSeparationGlobal * thisptr
 
@@ -943,7 +943,7 @@ cdef class AngularSeparationGlobal(_Compute):
 
     def compute(self, global_orientations, orientations,
                 equiv_orientations=np.array([[1, 0, 0, 0]])):
-        R"""Calculates the minimum angles of separation between
+        r"""Calculates the minimum angles of separation between
         :code:`global_orientations` and :code:`orientations`, checking for
         underlying symmetry as encoded in :code:`equiv_orientations`. The
         result is stored in the :code:`global_angles` class attribute.
@@ -1001,7 +1001,7 @@ cdef class AngularSeparationGlobal(_Compute):
 
 
 cdef class LocalBondProjection(_PairCompute):
-    R"""Calculates the maximal projection of nearest neighbor bonds for each
+    r"""Calculates the maximal projection of nearest neighbor bonds for each
     particle onto some set of reference vectors, defined in the particles'
     local reference frame.
     """
@@ -1019,7 +1019,7 @@ cdef class LocalBondProjection(_PairCompute):
     def compute(self, system, orientations, proj_vecs,
                 query_points=None, equiv_orientations=np.array([[1, 0, 0, 0]]),
                 neighbors=None):
-        R"""Calculates the maximal projections of nearest neighbor bonds
+        r"""Calculates the maximal projections of nearest neighbor bonds
         (between :code:`points` and :code:`query_points`) onto the set of
         reference vectors :code:`proj_vecs`, defined in the local reference
         frames of the :code:`points` as defined by the orientations

--- a/freud/interface.pyx
+++ b/freud/interface.pyx
@@ -1,7 +1,7 @@
 # Copyright (c) 2010-2020 The Regents of the University of Michigan
 # This file is from the freud project, released under the BSD 3-Clause License.
 
-R"""
+r"""
 The :class:`freud.interface` module contains functions to measure the interface
 between sets of points.
 """
@@ -22,7 +22,7 @@ cimport freud.locality
 np.import_array()
 
 cdef class Interface(_PairCompute):
-    R"""Measures the interface between two sets of points."""
+    r"""Measures the interface between two sets of points."""
     cdef const unsigned int[::1] _point_ids
     cdef const unsigned int[::1] _query_point_ids
 
@@ -31,7 +31,7 @@ cdef class Interface(_PairCompute):
         self._query_point_ids = np.empty(0, dtype=np.uint32)
 
     def compute(self, system, query_points, neighbors=None):
-        R"""Compute the particles at the interface between two sets of points.
+        r"""Compute the particles at the interface between two sets of points.
 
         Args:
             system:

--- a/freud/locality.pyx
+++ b/freud/locality.pyx
@@ -1,7 +1,7 @@
 # Copyright (c) 2010-2020 The Regents of the University of Michigan
 # This file is from the freud project, released under the BSD 3-Clause License.
 
-R"""
+r"""
 The :mod:`freud.locality` module contains data structures to efficiently
 locate points based on their proximity to other points.
 """
@@ -28,7 +28,7 @@ from freud.util cimport _Compute, vec3
 np.import_array()
 
 cdef class _QueryArgs:
-    R"""Container for query arguments.
+    r"""Container for query arguments.
 
     This class is use internally throughout freud to provide a nice interface
     between keyword- or dict-style query arguments and the C++ QueryArgs
@@ -166,7 +166,7 @@ cdef class _QueryArgs:
 
 
 cdef class NeighborQueryResult:
-    R"""Class encapsulating the output of queries of NeighborQuery objects.
+    r"""Class encapsulating the output of queries of NeighborQuery objects.
 
     .. warning::
 
@@ -231,7 +231,7 @@ cdef class NeighborQueryResult:
 
 
 cdef class NeighborQuery:
-    R"""Class representing a set of points along with the ability to query for
+    r"""Class representing a set of points along with the ability to query for
     neighbors of these points.
 
     .. warning::
@@ -267,7 +267,7 @@ cdef class NeighborQuery:
 
     @classmethod
     def from_system(cls, system, dimensions=None):
-        R"""Create a :class:`~.NeighborQuery` from any system-like object.
+        r"""Create a :class:`~.NeighborQuery` from any system-like object.
 
         The standard concept of a system in **freud** is any object that
         provides a way to access a box-like object (anything that can be
@@ -382,7 +382,7 @@ cdef class NeighborQuery:
         return np.asarray(self.points)
 
     def query(self, query_points, query_args):
-        R"""Query for nearest neighbors of the provided point.
+        r"""Query for nearest neighbors of the provided point.
 
         Args:
             query_points ((:math:`N`, 3) :class:`numpy.ndarray`):
@@ -403,7 +403,7 @@ cdef class NeighborQuery:
         return NeighborQueryResult.init(self, query_points, args)
 
     cdef freud._locality.NeighborQuery * get_ptr(self):
-        R"""Returns a pointer to the raw C++ object we are wrapping."""
+        r"""Returns a pointer to the raw C++ object we are wrapping."""
         return self.nqptr
 
     def plot(self, ax=None, title=None, *args, **kwargs):
@@ -432,7 +432,7 @@ cdef class NeighborQuery:
 
 
 cdef class NeighborList:
-    R"""Class representing bonds between two sets of points.
+    r"""Class representing bonds between two sets of points.
 
     Compute classes contain a set of bonds between two sets of position
     arrays ("query points" and "points") and hold a list of index pairs
@@ -477,7 +477,7 @@ cdef class NeighborList:
     @classmethod
     def from_arrays(cls, num_query_points, num_points, query_point_indices,
                     point_indices, distances, weights=None):
-        R"""Create a NeighborList from a set of bond information arrays.
+        r"""Create a NeighborList from a set of bond information arrays.
 
         Example::
 
@@ -560,15 +560,15 @@ cdef class NeighborList:
             del self.thisptr
 
     cdef freud._locality.NeighborList * get_ptr(self):
-        R"""Returns a pointer to the raw C++ object we are wrapping."""
+        r"""Returns a pointer to the raw C++ object we are wrapping."""
         return self.thisptr
 
     cdef void copy_c(self, NeighborList other):
-        R"""Copies the contents of other into this object."""
+        r"""Copies the contents of other into this object."""
         self.thisptr.copy(dereference(other.thisptr))
 
     def copy(self, other=None):
-        R"""Create a copy. If other is given, copy its contents into this
+        r"""Create a copy. If other is given, copy its contents into this
         object. Otherwise, return a copy of this object.
 
         Args:
@@ -586,7 +586,7 @@ cdef class NeighborList:
             return new_copy
 
     def __getitem__(self, key):
-        R"""Access the bond array by index or slice."""
+        r"""Access the bond array by index or slice."""
         return freud.util.make_managed_numpy_array(
             &self.thisptr.getNeighbors(),
             freud.util.arr_type_t.UNSIGNED_INT)[key]
@@ -640,7 +640,7 @@ cdef class NeighborList:
             freud.util.arr_type_t.UNSIGNED_INT)
 
     def __len__(self):
-        R"""Returns the number of bonds stored in this object."""
+        r"""Returns the number of bonds stored in this object."""
         return self.thisptr.getNumBonds()
 
     @property
@@ -660,7 +660,7 @@ cdef class NeighborList:
         return self.thisptr.getNumPoints()
 
     def find_first_index(self, unsigned int i):
-        R"""Returns the lowest bond index corresponding to a query particle
+        r"""Returns the lowest bond index corresponding to a query particle
         with an index :math:`\geq i`.
 
         Args:
@@ -669,7 +669,7 @@ cdef class NeighborList:
         return self.thisptr.find_first_index(i)
 
     def filter(self, filt):
-        R"""Removes bonds that satisfy a boolean criterion.
+        r"""Removes bonds that satisfy a boolean criterion.
 
         Args:
             filt (:class:`np.ndarray`):
@@ -690,7 +690,7 @@ cdef class NeighborList:
         return self
 
     def filter_r(self, float r_max, float r_min=0):
-        R"""Removes bonds that are outside of a given radius range.
+        r"""Removes bonds that are outside of a given radius range.
 
         Args:
             r_max (float):
@@ -723,7 +723,7 @@ cdef NeighborList _nlist_from_cnlist(freud._locality.NeighborList *c_nlist):
 
 
 def _make_default_nq(neighbor_query):
-    R"""Helper function to return a NeighborQuery object.
+    r"""Helper function to return a NeighborQuery object.
 
     Currently the resolution for NeighborQuery objects is such that if Python
     users pass in a NumPy array of points and a box, we always make a
@@ -757,7 +757,7 @@ def _make_default_nq(neighbor_query):
 
 
 def _make_default_nlist(system, neighbors, query_points=None):
-    R"""Helper function to return a neighbor list object if is given, or to
+    r"""Helper function to return a neighbor list object if is given, or to
     construct one using AABBQuery if it is not.
 
     Args:
@@ -793,7 +793,7 @@ def _make_default_nlist(system, neighbors, query_points=None):
 
 
 cdef class _RawPoints(NeighborQuery):
-    R"""Class containing :class:`~.box.Box` and points with no spatial data
+    r"""Class containing :class:`~.box.Box` and points with no spatial data
     structures for accelerating neighbor queries."""
 
     def __cinit__(self, box, points):
@@ -815,7 +815,7 @@ cdef class _RawPoints(NeighborQuery):
 
 
 cdef class AABBQuery(NeighborQuery):
-    R"""Use an Axis-Aligned Bounding Box (AABB) tree :cite:`howard2016` to
+    r"""Use an Axis-Aligned Bounding Box (AABB) tree :cite:`howard2016` to
     find neighbors.
 
     Also available as ``freud.AABBQuery``.
@@ -847,7 +847,7 @@ cdef class AABBQuery(NeighborQuery):
 
 
 cdef class LinkCell(NeighborQuery):
-    R"""Supports efficiently finding all points in a set within a certain
+    r"""Supports efficiently finding all points in a set within a certain
     distance from a given point.
 
     Also available as ``freud.LinkCell``.
@@ -884,7 +884,7 @@ cdef class LinkCell(NeighborQuery):
 
 
 cdef class _PairCompute(_Compute):
-    R"""Parent class for all compute classes in freud that depend on finding
+    r"""Parent class for all compute classes in freud that depend on finding
     nearest neighbors.
 
     The purpose of this class is to consolidate some of the logic for parsing
@@ -964,7 +964,7 @@ cdef class _PairCompute(_Compute):
 
 
 cdef class _SpatialHistogram(_PairCompute):
-    R"""Parent class for all compute classes in freud that perform a spatial
+    r"""Parent class for all compute classes in freud that perform a spatial
     binning of particle bonds by distance.
     """
 
@@ -1025,7 +1025,7 @@ cdef class _SpatialHistogram(_PairCompute):
 
 
 cdef class _SpatialHistogram1D(_SpatialHistogram):
-    R"""Subclasses _SpatialHistogram to provide a simplified API for
+    r"""Subclasses _SpatialHistogram to provide a simplified API for
     properties of 1-dimensional histograms.
     """
 
@@ -1068,7 +1068,7 @@ cdef class _SpatialHistogram1D(_SpatialHistogram):
 
 
 cdef class PeriodicBuffer(_Compute):
-    R"""Replicate periodic images of points inside a box."""
+    r"""Replicate periodic images of points inside a box."""
 
     def __cinit__(self):
         self.thisptr = new freud._locality.PeriodicBuffer()
@@ -1080,7 +1080,7 @@ cdef class PeriodicBuffer(_Compute):
         del self.thisptr
 
     def compute(self, system, buffer, cbool images=False):
-        R"""Compute the periodic buffer.
+        r"""Compute the periodic buffer.
 
         Args:
             system:
@@ -1137,7 +1137,7 @@ cdef class PeriodicBuffer(_Compute):
 
 
 cdef class Voronoi(_Compute):
-    R"""Computes Voronoi diagrams using voro++.
+    r"""Computes Voronoi diagrams using voro++.
 
     Voronoi diagrams (`Wikipedia
     <https://en.wikipedia.org/wiki/Voronoi_diagram>`_) are composed of convex
@@ -1159,7 +1159,7 @@ cdef class Voronoi(_Compute):
         del self.thisptr
 
     def compute(self, system):
-        R"""Compute Voronoi diagram.
+        r"""Compute Voronoi diagram.
 
         Args:
             system:
@@ -1204,7 +1204,7 @@ cdef class Voronoi(_Compute):
 
     @_Compute._computed_property
     def nlist(self):
-        R"""Returns the computed :class:`~.locality.NeighborList`.
+        r"""Returns the computed :class:`~.locality.NeighborList`.
 
         The :class:`~.locality.NeighborList` computed by this class is
         weighted. In 2D systems, the bond weight is the length of the ridge

--- a/freud/msd.pyx
+++ b/freud/msd.pyx
@@ -1,7 +1,7 @@
 # Copyright (c) 2010-2020 The Regents of the University of Michigan
 # This file is from the freud project, released under the BSD 3-Clause License.
 
-R"""
+r"""
 The :class:`freud.msd` module provides functions for computing the
 mean-squared-displacement (MSD) of particles in periodic systems.
 """
@@ -52,7 +52,7 @@ except ImportError:
 
 
 def _autocorrelation(x):
-    R"""Compute the autocorrelation of a sequence"""
+    r"""Compute the autocorrelation of a sequence"""
     N = x.shape[0]
     F = fft(x, n=2*N, axis=0)
     PSD = F * F.conjugate()
@@ -63,7 +63,7 @@ def _autocorrelation(x):
 
 
 cdef class MSD(_Compute):
-    R"""Compute the mean squared displacement.
+    r"""Compute the mean squared displacement.
 
     The mean squared displacement (MSD) measures how much particles move over
     time. The MSD plays an important role in characterizing Brownian motion,

--- a/freud/order.pyx
+++ b/freud/order.pyx
@@ -1,7 +1,7 @@
 # Copyright (c) 2010-2020 The Regents of the University of Michigan
 # This file is from the freud project, released under the BSD 3-Clause License.
 
-R"""
+r"""
 The :class:`freud.order` module contains functions which compute order
 parameters for the whole system or individual particles. Order parameters take
 bond order data and interpret it in some way to quantify the degree of order in
@@ -38,7 +38,7 @@ logger = logging.getLogger(__name__)
 np.import_array()
 
 cdef class Cubatic(_Compute):
-    R"""Compute the cubatic order parameter :cite:`Haji_Akbari_2015` for a system of
+    r"""Compute the cubatic order parameter :cite:`Haji_Akbari_2015` for a system of
     particles using simulated annealing instead of Newton-Raphson root finding.
 
     Args:
@@ -68,7 +68,7 @@ cdef class Cubatic(_Compute):
         del self.thisptr
 
     def compute(self, orientations):
-        R"""Calculates the per-particle and global order parameter.
+        r"""Calculates the per-particle and global order parameter.
 
         Args:
             orientations ((:math:`N_{particles}`, 4) :class:`numpy.ndarray`):
@@ -158,7 +158,7 @@ cdef class Cubatic(_Compute):
 
 
 cdef class Nematic(_Compute):
-    R"""Compute the nematic order parameter for a system of particles.
+    r"""Compute the nematic order parameter for a system of particles.
 
     Args:
         u (:math:`\left(3 \right)` :class:`numpy.ndarray`):
@@ -179,7 +179,7 @@ cdef class Nematic(_Compute):
         del self.thisptr
 
     def compute(self, orientations):
-        R"""Calculates the per-particle and global order parameter.
+        r"""Calculates the per-particle and global order parameter.
 
         Example::
 
@@ -245,7 +245,7 @@ cdef class Nematic(_Compute):
 
 
 cdef class Hexatic(_PairCompute):
-    R"""Calculates the :math:`k`-atic order parameter for 2D systems.
+    r"""Calculates the :math:`k`-atic order parameter for 2D systems.
 
     The :math:`k`-atic order parameter (called the hexatic order parameter for
     :math:`k = 6`) is analogous to Steinhardt order parameters, and is used to
@@ -303,7 +303,7 @@ cdef class Hexatic(_PairCompute):
         del self.thisptr
 
     def compute(self, system, neighbors=None):
-        R"""Calculates the hexatic order parameter.
+        r"""Calculates the hexatic order parameter.
 
         Example::
 
@@ -400,7 +400,7 @@ cdef class Hexatic(_PairCompute):
 
 
 cdef class Translational(_PairCompute):
-    R"""Compute the translational order parameter for each particle.
+    r"""Compute the translational order parameter for each particle.
 
     The translational order parameter is used to measure order in the bonds
     of 2D systems. The translational order parameter for a particle :math:`i`
@@ -436,7 +436,7 @@ cdef class Translational(_PairCompute):
         del self.thisptr
 
     def compute(self, system, neighbors=None):
-        R"""Calculates the local descriptors.
+        r"""Calculates the local descriptors.
 
         Args:
             system:
@@ -488,7 +488,7 @@ cdef class Translational(_PairCompute):
 
 
 cdef class Steinhardt(_PairCompute):
-    R"""Compute one or more of the rotationally invariant Steinhardt order
+    r"""Compute one or more of the rotationally invariant Steinhardt order
     parameter :math:`q_l` or :math:`w_l` for a set of points
     :cite:`Steinhardt:1983aa`.
 
@@ -694,7 +694,7 @@ cdef class Steinhardt(_PairCompute):
         return qlm_list if len(qlm_list) > 1 else qlm_list[0]
 
     def compute(self, system, neighbors=None):
-        R"""Compute the order parameter.
+        r"""Compute the order parameter.
 
         Example::
 
@@ -787,7 +787,7 @@ cdef class Steinhardt(_PairCompute):
 
 
 cdef class SolidLiquid(_PairCompute):
-    R"""Identifies solid-like clusters using dot products of :math:`q_{lm}`.
+    r"""Identifies solid-like clusters using dot products of :math:`q_{lm}`.
 
     The solid-liquid order parameter :cite:`Wolde:1995aa,Filion_2010` uses a
     Steinhardt-like approach to identify solid-like particles. First, a bond
@@ -834,7 +834,7 @@ cdef class SolidLiquid(_PairCompute):
         del self.thisptr
 
     def compute(self, system, neighbors=None):
-        R"""Compute the order parameter.
+        r"""Compute the order parameter.
 
         Args:
             system:

--- a/freud/parallel.pyx
+++ b/freud/parallel.pyx
@@ -1,7 +1,7 @@
 # Copyright (c) 2010-2020 The Regents of the University of Michigan
 # This file is from the freud project, released under the BSD 3-Clause License.
 
-R"""
+r"""
 The :class:`freud.parallel` module controls the parallelization behavior of
 freud, determining how many threads the TBB-enabled parts of freud will use.
 freud uses all available threads for parallelization unless directed otherwise.
@@ -13,7 +13,7 @@ _num_threads = 0
 
 
 def get_num_threads():
-    R"""Get the number of threads for parallel computation.
+    r"""Get the number of threads for parallel computation.
 
     Returns:
         (int): Number of threads.
@@ -23,7 +23,7 @@ def get_num_threads():
 
 
 def set_num_threads(nthreads=None):
-    R"""Set the number of threads for parallel computation.
+    r"""Set the number of threads for parallel computation.
 
     Args:
         nthreads (int, optional):
@@ -41,7 +41,7 @@ def set_num_threads(nthreads=None):
 
 
 class NumThreads:
-    R"""Context manager for managing the number of threads to use.
+    r"""Context manager for managing the number of threads to use.
 
     Args:
         N (int, optional): Number of threads to use in this context. If

--- a/freud/pmft.pyx
+++ b/freud/pmft.pyx
@@ -1,7 +1,7 @@
 # Copyright (c) 2010-2020 The Regents of the University of Michigan
 # This file is from the freud project, released under the BSD 3-Clause License.
 
-R"""
+r"""
 The :class:`freud.pmft` module allows for the calculation of the Potential of
 Mean Force and Torque (PMFT) :cite:`vanAnders:2014aa,van_Anders_2013` in a
 number of different coordinate systems. The shape of the arrays computed by
@@ -93,7 +93,7 @@ def _gen_angle_array(orientations, shape):
 
 
 cdef class _PMFT(_SpatialHistogram):
-    R"""Compute the PMFT :cite:`vanAnders:2014aa,van_Anders_2013` for a
+    r"""Compute the PMFT :cite:`vanAnders:2014aa,van_Anders_2013` for a
     given set of points.
 
     This class provides an abstract interface for computing the PMFT.
@@ -125,7 +125,7 @@ cdef class _PMFT(_SpatialHistogram):
 
 
 cdef class PMFTR12(_PMFT):
-    R"""Computes the PMFT :cite:`vanAnders:2014aa,van_Anders_2013` in a 2D
+    r"""Computes the PMFT :cite:`vanAnders:2014aa,van_Anders_2013` in a 2D
     system described by :math:`r`, :math:`\theta_1`, :math:`\theta_2`.
 
     .. note::
@@ -159,7 +159,7 @@ cdef class PMFTR12(_PMFT):
 
     def compute(self, system, orientations, query_points=None,
                 query_orientations=None, neighbors=None, reset=True):
-        R"""Calculates the PMFT.
+        r"""Calculates the PMFT.
 
         Args:
             system:
@@ -232,7 +232,7 @@ cdef class PMFTR12(_PMFT):
 
 
 cdef class PMFTXYT(_PMFT):
-    R"""Computes the PMFT :cite:`vanAnders:2014aa,van_Anders_2013` for
+    r"""Computes the PMFT :cite:`vanAnders:2014aa,van_Anders_2013` for
     systems described by coordinates :math:`x`, :math:`y`, :math:`\theta`.
 
     .. note::
@@ -268,7 +268,7 @@ cdef class PMFTXYT(_PMFT):
 
     def compute(self, system, orientations, query_points=None,
                 query_orientations=None, neighbors=None, reset=True):
-        R"""Calculates the PMFT.
+        r"""Calculates the PMFT.
 
         Args:
             system:
@@ -343,7 +343,7 @@ cdef class PMFTXYT(_PMFT):
 
 
 cdef class PMFTXY(_PMFT):
-    R"""Computes the PMFT :cite:`vanAnders:2014aa,van_Anders_2013` in
+    r"""Computes the PMFT :cite:`vanAnders:2014aa,van_Anders_2013` in
     coordinates :math:`x`, :math:`y`.
 
     There are 3 degrees of translational and rotational freedom in 2
@@ -383,7 +383,7 @@ cdef class PMFTXY(_PMFT):
 
     def compute(self, system, query_orientations, query_points=None,
                 neighbors=None, reset=True):
-        R"""Calculates the PMFT.
+        r"""Calculates the PMFT.
 
         .. note::
             The orientations of the system points are irrelevant for this
@@ -480,7 +480,7 @@ cdef class PMFTXY(_PMFT):
 
 
 cdef class PMFTXYZ(_PMFT):
-    R"""Computes the PMFT :cite:`vanAnders:2014aa,van_Anders_2013` in
+    r"""Computes the PMFT :cite:`vanAnders:2014aa,van_Anders_2013` in
     coordinates :math:`x`, :math:`y`, :math:`z`.
 
     There are 6 degrees of translational and rotational freedom in 3
@@ -529,7 +529,7 @@ cdef class PMFTXYZ(_PMFT):
 
     def compute(self, system, query_orientations, query_points=None,
                 equiv_orientations=None, neighbors=None, reset=True):
-        R"""Calculates the PMFT.
+        r"""Calculates the PMFT.
 
         .. note::
             The orientations of the system points are irrelevant for this

--- a/freud/util.pyx
+++ b/freud/util.pyx
@@ -210,7 +210,7 @@ def _convert_array(array, shape=None, dtype=np.float32, requirements=("C", ),
             (Default value = :code:`None`).
         dtype: :code:`dtype` to convert the array to if :code:`array.dtype`
             is different. If :code:`None`, :code:`dtype` will not be changed
-            (Default value = :class:`numpy.float32`).
+            (Default value = :attr:`numpy.float32`).
         requirements (Sequence[str]): A sequence of string flags to be passed to
             :func:`numpy.require`.
         allow_copy (bool): If :code:`False` and the input array does not already

--- a/freud/util.pyx
+++ b/freud/util.pyx
@@ -124,7 +124,7 @@ cdef class _ManagedArrayContainer:
 
 
 cdef class _Compute(object):
-    R"""Parent class for all compute classes in freud.
+    r"""Parent class for all compute classes in freud.
 
     The primary purpose of this class is to prevent access of uncomputed
     values. This is accomplished by maintaining a boolean flag to track whether
@@ -174,7 +174,7 @@ cdef class _Compute(object):
 
     @staticmethod
     def _computed_property(prop):
-        R"""Decorator that makes a class method to be a property with limited access.
+        r"""Decorator that makes a class method to be a property with limited access.
 
         Args:
             prop (callable): The property function.


### PR DESCRIPTION
## Description
@ramanishsingh caught an error in the box class documentation: masses are an array of shape `(N,)`, not `(N, 3)`.

I also added return types to a few methods that were missing them.

This PR also fixes a minor nitpick that has always confused me. Raw strings can be written with `R"` or `r"`, but I am used to seeing the lowercase form everywhere except in freud. For clarity (and to use the more common format), I flipped them to use the lowercase form.

## Motivation and Context
Fixes docs. No changelog line needed.

## How Has This Been Tested?
ReadTheDocs should render correctly.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds or improves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation improvement (updates to user guides, docstrings, or developer docs)

## Checklist:
- [x] I have read the [**CONTRIBUTING**](https://github.com/glotzerlab/freud/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] I have updated the documentation (if relevant).
- [x] I have added tests that cover my changes (if relevant).
- [x] All new and existing tests passed.
- [ ] I have updated the [credits](https://github.com/glotzerlab/freud/blob/master/doc/source/reference/credits.rst).
- [ ] I have updated the [Changelog](https://github.com/glotzerlab/freud/blob/master/ChangeLog.md).
