### PR TITLE
Clean up TBB usage / includes / lambda captures in Cubatic and PMFT.

### DIFF
--- a/cpp/order/Cubatic.cc
+++ b/cpp/order/Cubatic.cc
@@ -189,7 +189,7 @@ util::ManagedArray<tensor4> Cubatic::calculatePerParticleTensor(const quat<float
     util::ManagedArray<tensor4> particle_tensor(m_n);
 
     // calculate per-particle tensor
-    util::forLoopWrapper(0, m_n, [=, &particle_tensor](size_t begin, size_t end) {
+    util::forLoopWrapper(0, m_n, [&](size_t begin, size_t end) {
         for (size_t i = begin; i < end; ++i)
         {
             tensor4 l_mbar = tensor4();
@@ -217,7 +217,7 @@ tensor4 Cubatic::calculateGlobalTensor(quat<float>* orientations) const
     // now calculate the global tensor
     float n_inv = float(1.0) / static_cast<float>(m_n);
 
-    util::forLoopWrapper(0, 81, [=, &global_tensor, &n_inv, &particle_tensor](size_t begin, size_t end) {
+    util::forLoopWrapper(0, 81, [&](size_t begin, size_t end) {
         for (size_t i = begin; i < end; i++)
         {
             float tensor_value = 0;
@@ -228,8 +228,8 @@ tensor4 Cubatic::calculateGlobalTensor(quat<float>* orientations) const
             // Note that in the third equation in eq. 27, the prefactor of the
             // sum is 2/N, but the factor of 2 is already accounted for in the
             // calculation of per particle calculation in
-            // calculatePerParticleTensor, so here we just need to apply the
-            // 1/N scaling.
+            // calculatePerParticleTensor, so here we just need to apply the 1/N
+            // scaling.
             global_tensor[i] = tensor_value * n_inv;
         }
     });
@@ -254,44 +254,52 @@ void Cubatic::compute(quat<float>* orientations, unsigned int num_orientations)
     util::ManagedArray<float> p_cubatic_order_parameter(m_n_replicates);
     util::ManagedArray<quat<float>> p_cubatic_orientation(m_n_replicates);
 
-    util::forLoopWrapper(
-        0, m_n_replicates,
-        [=, &p_cubatic_orientation, &p_cubatic_order_parameter, &p_cubatic_tensor](size_t begin, size_t end) {
-            // create thread-specific rng
-            unsigned int thread_start = static_cast<unsigned int>(begin);
+    util::forLoopWrapper(0, m_n_replicates, [&](size_t begin, size_t end) {
+        // create thread-specific rng
+        auto const thread_start = static_cast<unsigned int>(begin);
 
-            std::vector<unsigned int> seed_seq(3);
-            seed_seq[0] = m_seed;
-            seed_seq[1] = thread_start;
-            seed_seq[2] = 0xffaabb;
-            std::seed_seq seed(seed_seq.begin(), seed_seq.end());
-            std::mt19937 rng(seed);
-            std::uniform_real_distribution<float> base_dist(0, 1);
-            auto dist = [&]() { return base_dist(rng); };
+        std::vector<unsigned int> seed_seq(3);
+        seed_seq[0] = m_seed;
+        seed_seq[1] = thread_start;
+        seed_seq[2] = 0xffaabb;
+        std::seed_seq seed(seed_seq.begin(), seed_seq.end());
+        std::mt19937 rng(seed);
+        std::uniform_real_distribution<float> base_dist(0, 1);
+        auto dist = [&]() { return base_dist(rng); };
 
-            for (size_t i = begin; i < end; i++)
+        for (size_t i = begin; i < end; i++)
+        {
+            // need to generate random orientation
+            quat<float> cubatic_orientation = calcRandomQuaternion(dist);
+            quat<float> new_orientation = cubatic_orientation;
+
+            // now calculate the cubatic tensor
+            tensor4 cubatic_tensor = calcCubaticTensor(cubatic_orientation);
+            float cubatic_order_parameter = calcCubaticOrderParameter(cubatic_tensor, global_tensor);
+            float new_order_parameter = cubatic_order_parameter;
+
+            // set initial temperature and count
+            float t_current = m_t_initial;
+            unsigned int loop_count = 0;
+            // simulated annealing loop; loop counter to prevent inf loops
+            while ((t_current > m_t_final) && (loop_count < 10000))
             {
-                // need to generate random orientation
-                quat<float> cubatic_orientation = calcRandomQuaternion(dist);
-                quat<float> new_orientation = cubatic_orientation;
-
+                ++loop_count;
+                new_orientation = calcRandomQuaternion(dist, 0.1) * (cubatic_orientation);
                 // now calculate the cubatic tensor
-                tensor4 cubatic_tensor = calcCubaticTensor(cubatic_orientation);
-                float cubatic_order_parameter = calcCubaticOrderParameter(cubatic_tensor, global_tensor);
-                float new_order_parameter = cubatic_order_parameter;
-
-                // set initial temperature and count
-                float t_current = m_t_initial;
-                unsigned int loop_count = 0;
-                // simulated annealing loop; loop counter to prevent inf loops
-                while ((t_current > m_t_final) && (loop_count < 10000))
+                tensor4 new_cubatic_tensor = calcCubaticTensor(new_orientation);
+                new_order_parameter = calcCubaticOrderParameter(new_cubatic_tensor, global_tensor);
+                if (new_order_parameter > cubatic_order_parameter)
                 {
-                    ++loop_count;
-                    new_orientation = calcRandomQuaternion(dist, 0.1) * (cubatic_orientation);
-                    // now calculate the cubatic tensor
-                    tensor4 new_cubatic_tensor = calcCubaticTensor(new_orientation);
-                    new_order_parameter = calcCubaticOrderParameter(new_cubatic_tensor, global_tensor);
-                    if (new_order_parameter > cubatic_order_parameter)
+                    cubatic_tensor = new_cubatic_tensor;
+                    cubatic_order_parameter = new_order_parameter;
+                    cubatic_orientation = new_orientation;
+                }
+                else
+                {
+                    float boltzmann_factor
+                        = std::exp(-(cubatic_order_parameter - new_order_parameter) / t_current);
+                    if (boltzmann_factor >= dist())
                     {
                         cubatic_tensor = new_cubatic_tensor;
                         cubatic_order_parameter = new_order_parameter;
@@ -299,28 +307,18 @@ void Cubatic::compute(quat<float>* orientations, unsigned int num_orientations)
                     }
                     else
                     {
-                        float boltzmann_factor
-                            = std::exp(-(cubatic_order_parameter - new_order_parameter) / t_current);
-                        if (boltzmann_factor >= dist())
-                        {
-                            cubatic_tensor = new_cubatic_tensor;
-                            cubatic_order_parameter = new_order_parameter;
-                            cubatic_orientation = new_orientation;
-                        }
-                        else
-                        {
-                            continue;
-                        }
+                        continue;
                     }
-                    t_current *= m_scale;
                 }
-                // set values
-                p_cubatic_tensor[i] = cubatic_tensor;
-                p_cubatic_orientation[i].s = cubatic_orientation.s;
-                p_cubatic_orientation[i].v = cubatic_orientation.v;
-                p_cubatic_order_parameter[i] = cubatic_order_parameter;
+                t_current *= m_scale;
             }
-        });
+            // set values
+            p_cubatic_tensor[i] = cubatic_tensor;
+            p_cubatic_orientation[i].s = cubatic_orientation.s;
+            p_cubatic_orientation[i].v = cubatic_orientation.v;
+            p_cubatic_order_parameter[i] = cubatic_order_parameter;
+        }
+    });
 
     // Loop over threads and choose the replicate that found the highest order.
     unsigned int max_idx = 0;
@@ -340,7 +338,7 @@ void Cubatic::compute(quat<float>* orientations, unsigned int num_orientations)
     m_cubatic_order_parameter = p_cubatic_order_parameter[max_idx];
 
     // Now calculate the per-particle order parameters
-    util::forLoopWrapper(0, m_n, [=](size_t begin, size_t end) {
+    util::forLoopWrapper(0, m_n, [&](size_t begin, size_t end) {
         for (size_t i = begin; i < end; i++)
         {
             // The per-particle order parameter is defined as the value of the

--- a/cpp/pmft/PMFT.h
+++ b/cpp/pmft/PMFT.h
@@ -4,8 +4,6 @@
 #ifndef PMFT_H
 #define PMFT_H
 
-#include <tbb/tbb.h>
-
 #include "BondHistogramCompute.h"
 #include "Box.h"
 #include "Histogram.h"


### PR DESCRIPTION
## Description
While working on #820, I noticed some places where we relied on the native TBB APIs instead of our wrapper functions. The wrapper functions are easier to read, so I refactored it to use our wrapper API. Also we had some extra TBB includes that were unnecessary.

I also fixed some lambda captures that were using `[=]` to capture `*this`, when it is better practice to use `[&]` to capture `*this`. The use of `[=]` to capture `*this` is deprecated in C++20. https://en.cppreference.com/w/cpp/language/lambda#Lambda_capture

## Motivation and Context
Cleanup and centralization of TBB logic.

## How Has This Been Tested?
Existing tests should pass.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds or improves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation improvement (updates to user guides, docstrings, or developer docs)

## Checklist:
- [x] I have read the [**CONTRIBUTING**](https://github.com/glotzerlab/freud/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] I have updated the documentation (if relevant).
- [x] I have added tests that cover my changes (if relevant).
- [x] All new and existing tests passed.
- [ ] I have updated the [credits](https://github.com/glotzerlab/freud/blob/master/doc/source/reference/credits.rst).
- [ ] I have updated the [Changelog](https://github.com/glotzerlab/freud/blob/master/ChangeLog.md).
