### PR TITLE
Fix broken CI due to new version of pillow

### DIFF
--- a/.circleci/ci-oldest-reqs.txt
+++ b/.circleci/ci-oldest-reqs.txt
@@ -9,3 +9,4 @@ rowan==1.2.1
 scikit-build==0.10.0
 scipy==1.1.0
 sympy==1.0
+pillow==6.2.0

--- a/.circleci/ci-oldest-reqs.txt
+++ b/.circleci/ci-oldest-reqs.txt
@@ -4,9 +4,9 @@ garnett==0.7.1
 gsd==2.4.2
 matplotlib==3.0.0
 numpy==1.14.0
+pillow==6.2.0
 pytest==6.2.2
 rowan==1.2.1
 scikit-build==0.10.0
 scipy==1.1.0
 sympy==1.0
-pillow==6.2.0

--- a/requirements/requirements-test.txt
+++ b/requirements/requirements-test.txt
@@ -7,6 +7,7 @@ GitPython==3.1.18
 gsd==2.4.2
 matplotlib>=3.0.0
 numpy==1.21.2
+pillow==8.3.1
 pytest==6.2.5
 pytest-cov==2.12.1
 rowan==1.3.0.post1


### PR DESCRIPTION
Newest release of pillow breaks our CI testing. As per discussion with @bdice and @joaander on slack I'm suggesting a quick fix until this issue is resolved in the pillow project.

## Description
The pillow versions have been pinned to 8.3.1 for test requirements and 6.2.0 for circle ci.

## Motivation and Context
Recent release of pillow provides only manylinux2014 wheels which breakes the compatibility of the package. There is an open issue on pillow github, but no resolution as of yet. These changes break our CI testing for freud. Pillow is matplotlib requirement.

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to
     see how your changes affect other areas of the code, etc. -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds or improves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation improvement (updates to user guides, docstrings, or developer docs)

## Checklist:
<!-- Put an `x` in all the boxes that apply. If you're unsure about any of
     these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [**CONTRIBUTING**](https://github.com/glotzerlab/freud/blob/master/CONTRIBUTING.md) document.
- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation (if relevant).
- [ ] I have added tests that cover my changes (if relevant).
- [ ] All new and existing tests passed.
- [ ] I have updated the [credits](https://github.com/glotzerlab/freud/blob/master/doc/source/reference/credits.rst).
- [ ] I have updated the [Changelog](https://github.com/glotzerlab/freud/blob/master/ChangeLog.md).
