### PR TITLE
Capture "this" by reference in lambda functions.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,11 @@ The format is based on
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## next
+
+### Fixed
+* Updated lambda functions to capture `this` by reference, to ensure compatibility with C++20 and above.
+
 ## v2.6.2 -- 2021-06-26
 
 ### Fixed

--- a/cpp/box/Box.h
+++ b/cpp/box/Box.h
@@ -232,7 +232,7 @@ public:
      */
     void makeAbsolute(const vec3<float>* vecs, unsigned int Nvecs, vec3<float>* out) const
     {
-        util::forLoopWrapper(0, Nvecs, [=](size_t begin, size_t end) {
+        util::forLoopWrapper(0, Nvecs, [&](size_t begin, size_t end) {
             for (size_t i = begin; i < end; ++i)
             {
                 out[i] = makeAbsolute(vecs[i]);
@@ -265,7 +265,7 @@ public:
      */
     void makeFractional(const vec3<float>* vecs, unsigned int Nvecs, vec3<float>* out) const
     {
-        util::forLoopWrapper(0, Nvecs, [=](size_t begin, size_t end) {
+        util::forLoopWrapper(0, Nvecs, [&](size_t begin, size_t end) {
             for (size_t i = begin; i < end; ++i)
             {
                 out[i] = makeFractional(vecs[i]);
@@ -296,7 +296,7 @@ public:
      */
     void getImages(vec3<float>* vecs, unsigned int Nvecs, vec3<int>* res) const
     {
-        util::forLoopWrapper(0, Nvecs, [=](size_t begin, size_t end) {
+        util::forLoopWrapper(0, Nvecs, [&](size_t begin, size_t end) {
             for (size_t i = begin; i < end; ++i)
             {
                 getImage(vecs[i], res[i]);
@@ -339,7 +339,7 @@ public:
      */
     void wrap(const vec3<float>* vecs, unsigned int Nvecs, vec3<float>* out) const
     {
-        util::forLoopWrapper(0, Nvecs, [=](size_t begin, size_t end) {
+        util::forLoopWrapper(0, Nvecs, [&](size_t begin, size_t end) {
             for (size_t i = begin; i < end; ++i)
             {
                 out[i] = wrap(vecs[i]);
@@ -355,7 +355,7 @@ public:
     */
     void unwrap(const vec3<float>* vecs, const vec3<int>* images, unsigned int Nvecs, vec3<float>* out) const
     {
-        util::forLoopWrapper(0, Nvecs, [=](size_t begin, size_t end) {
+        util::forLoopWrapper(0, Nvecs, [&](size_t begin, size_t end) {
             for (size_t i = begin; i < end; ++i)
             {
                 out[i] = vecs[i] + getLatticeVector(0) * float(images[i].x)
@@ -404,7 +404,7 @@ public:
     void center(vec3<float>* vecs, unsigned int Nvecs, const float* masses = nullptr) const
     {
         vec3<float> com(centerOfMass(vecs, Nvecs, masses));
-        util::forLoopWrapper(0, Nvecs, [=](size_t begin, size_t end) {
+        util::forLoopWrapper(0, Nvecs, [&](size_t begin, size_t end) {
             for (size_t i = begin; i < end; ++i)
             {
                 vecs[i] = wrap(vecs[i] - com);

--- a/cpp/density/CorrelationFunction.cc
+++ b/cpp/density/CorrelationFunction.cc
@@ -90,7 +90,7 @@ void CorrelationFunction<T>::accumulate(const freud::locality::NeighborQuery* ne
 {
     accumulateGeneral(
         neighbor_query, query_points, n_query_points, nlist, qargs,
-        [=](const freud::locality::NeighborBond& neighbor_bond) {
+        [&](const freud::locality::NeighborBond& neighbor_bond) {
             size_t value_bin = m_histogram.bin({neighbor_bond.distance});
             m_local_histograms.increment(value_bin);
             m_local_correlation_function.increment(

--- a/cpp/density/LocalDensity.cc
+++ b/cpp/density/LocalDensity.cc
@@ -28,7 +28,7 @@ void LocalDensity::compute(const freud::locality::NeighborQuery* neighbor_query,
     // compute the local density
     freud::locality::loopOverNeighborsIterator(
         neighbor_query, query_points, n_query_points, qargs, nlist,
-        [=](size_t i, const std::shared_ptr<freud::locality::NeighborPerPointIterator>& ppiter) {
+        [&](size_t i, const std::shared_ptr<freud::locality::NeighborPerPointIterator>& ppiter) {
             float num_neighbors = 0;
             for (freud::locality::NeighborBond nb = ppiter->next(); !ppiter->end(); nb = ppiter->next())
             {

--- a/cpp/density/RDF.cc
+++ b/cpp/density/RDF.cc
@@ -84,7 +84,7 @@ void RDF::accumulate(const freud::locality::NeighborQuery* neighbor_query, const
                      freud::locality::QueryArgs qargs)
 {
     accumulateGeneral(neighbor_query, query_points, n_query_points, nlist, qargs,
-                      [=](const freud::locality::NeighborBond& neighbor_bond) {
+                      [&](const freud::locality::NeighborBond& neighbor_bond) {
                           m_local_histograms(neighbor_bond.distance);
                       });
 }

--- a/cpp/environment/AngularSeparation.cc
+++ b/cpp/environment/AngularSeparation.cc
@@ -62,7 +62,7 @@ void AngularSeparationNeighbor::compute(const locality::NeighborQuery* nq, const
     const size_t tot_num_neigh = m_nlist.getNumBonds();
     m_angles.prepare(tot_num_neigh);
 
-    util::forLoopWrapper(0, nq->getNPoints(), [=](size_t begin, size_t end) {
+    util::forLoopWrapper(0, nq->getNPoints(), [&](size_t begin, size_t end) {
         size_t bond(m_nlist.find_first_index(begin));
         for (size_t i = begin; i < end; ++i)
         {
@@ -87,7 +87,7 @@ void AngularSeparationGlobal::compute(const quat<float>* global_orientations, un
 {
     m_angles.prepare({n_points, n_global});
 
-    util::forLoopWrapper(0, n_points, [=](size_t begin, size_t end) {
+    util::forLoopWrapper(0, n_points, [&](size_t begin, size_t end) {
         for (size_t i = begin; i < end; ++i)
         {
             quat<float> q = orientations[i];

--- a/cpp/environment/BondOrder.cc
+++ b/cpp/environment/BondOrder.cc
@@ -85,7 +85,7 @@ void BondOrder::accumulate(const locality::NeighborQuery* neighbor_query, quat<f
                            freud::locality::QueryArgs qargs)
 {
     accumulateGeneral(neighbor_query, query_points, n_query_points, nlist, qargs,
-                      [=](const freud::locality::NeighborBond& neighbor_bond) {
+                      [&](const freud::locality::NeighborBond& neighbor_bond) {
                           const quat<float>& ref_q(orientations[neighbor_bond.point_idx]);
                           vec3<float> v(bondVector(neighbor_bond, neighbor_query, query_points));
                           const quat<float>& q = query_orientations[neighbor_bond.query_point_idx];

--- a/cpp/environment/LocalBondProjection.cc
+++ b/cpp/environment/LocalBondProjection.cc
@@ -62,7 +62,7 @@ void LocalBondProjection::compute(const locality::NeighborQuery* nq, const quat<
     m_local_bond_proj_norm.prepare({tot_num_neigh, n_proj});
 
     // compute the order parameter
-    util::forLoopWrapper(0, n_query_points, [=](size_t begin, size_t end) {
+    util::forLoopWrapper(0, n_query_points, [&](size_t begin, size_t end) {
         size_t bond(m_nlist.find_first_index(begin));
         for (size_t i = begin; i < end; ++i)
         {

--- a/cpp/environment/LocalDescriptors.cc
+++ b/cpp/environment/LocalDescriptors.cc
@@ -32,7 +32,7 @@ void LocalDescriptors::compute(const locality::NeighborQuery* nq, const vec3<flo
     }
     m_sphArray.prepare({m_nlist.getNumBonds(), getSphWidth()});
 
-    util::forLoopWrapper(0, nq->getNPoints(), [=](size_t begin, size_t end) {
+    util::forLoopWrapper(0, nq->getNPoints(), [&](size_t begin, size_t end) {
         fsph::PointSPHEvaluator<float> sph_eval(m_l_max);
 
         for (size_t i = begin; i < end; ++i)

--- a/cpp/locality/NeighborComputeFunctional.h
+++ b/cpp/locality/NeighborComputeFunctional.h
@@ -123,7 +123,7 @@ void loopOverNeighborsIterator(const NeighborQuery* neighbor_query, const vec3<f
     {
         util::forLoopWrapper(
             0, n_query_points,
-            [=](size_t begin, size_t end) {
+            [&](size_t begin, size_t end) {
                 for (size_t i = begin; i != end; ++i)
                 {
                     std::shared_ptr<NeighborListPerPointIterator> niter
@@ -141,7 +141,7 @@ void loopOverNeighborsIterator(const NeighborQuery* neighbor_query, const vec3<f
         // iterate over the query object in parallel
         util::forLoopWrapper(
             0, n_query_points,
-            [=](size_t begin, size_t end) {
+            [&](size_t begin, size_t end) {
                 for (size_t i = begin; i != end; ++i)
                 {
                     std::shared_ptr<NeighborQueryPerPointIterator> it = iter->query(i);
@@ -183,7 +183,7 @@ void loopOverNeighbors(const NeighborQuery* neighbor_query, const vec3<float>* q
     {
         util::forLoopWrapper(
             0, nlist->getNumBonds(),
-            [=](size_t begin, size_t end) {
+            [&](size_t begin, size_t end) {
                 for (size_t bond = begin; bond != end; ++bond)
                 {
                     const NeighborBond nb(nlist->getNeighbors()(bond, 0), nlist->getNeighbors()(bond, 1),

--- a/cpp/locality/Voronoi.cc
+++ b/cpp/locality/Voronoi.cc
@@ -169,7 +169,7 @@ void Voronoi::compute(const freud::locality::NeighborQuery* nq)
     m_neighbor_list->resize(num_bonds);
     m_neighbor_list->setNumBonds(num_bonds, n_points, n_points);
 
-    util::forLoopWrapper(0, num_bonds, [=](size_t begin, size_t end) {
+    util::forLoopWrapper(0, num_bonds, [&](size_t begin, size_t end) {
         for (size_t bond = begin; bond != end; ++bond)
         {
             m_neighbor_list->getNeighbors()(bond, 0) = bonds[bond].query_point_idx;

--- a/cpp/order/HexaticTranslational.cc
+++ b/cpp/order/HexaticTranslational.cc
@@ -21,7 +21,7 @@ void HexaticTranslational<T>::computeGeneral(Func func, const freud::locality::N
 
     freud::locality::loopOverNeighborsIterator(
         points, points->getPoints(), Np, qargs, nlist,
-        [=](size_t i, const std::shared_ptr<freud::locality::NeighborPerPointIterator>& ppiter) {
+        [&](size_t i, const std::shared_ptr<freud::locality::NeighborPerPointIterator>& ppiter) {
             float total_weight(0);
             const vec3<float> ref((*points)[i]);
 

--- a/cpp/order/Nematic.cc
+++ b/cpp/order/Nematic.cc
@@ -52,7 +52,7 @@ void Nematic::compute(quat<float>* orientations, unsigned int n)
     m_nematic_tensor_local.reset();
 
     // calculate per-particle tensor
-    util::forLoopWrapper(0, n, [=](size_t begin, size_t end) {
+    util::forLoopWrapper(0, n, [&](size_t begin, size_t end) {
         for (size_t i = begin; i < end; ++i)
         {
             // get the director of the particle

--- a/cpp/order/RotationalAutocorrelation.cc
+++ b/cpp/order/RotationalAutocorrelation.cc
@@ -77,7 +77,7 @@ void RotationalAutocorrelation::compute(const quat<float>* ref_orientations, con
     }
 
     // Parallel loop is over orientations (technically (ref_or, or) pairs).
-    util::forLoopWrapper(0, N, [=](size_t begin, size_t end) {
+    util::forLoopWrapper(0, N, [&](size_t begin, size_t end) {
         for (size_t i = begin; i < end; ++i)
         {
             // Transform the orientation quaternions into Xi/Zeta coordinates;

--- a/cpp/order/SolidLiquid.cc
+++ b/cpp/order/SolidLiquid.cc
@@ -40,7 +40,7 @@ void SolidLiquid::compute(const freud::locality::NeighborList* nlist,
 
     util::forLoopWrapper(
         0, num_query_points,
-        [=](size_t begin, size_t end) {
+        [&](size_t begin, size_t end) {
             for (unsigned int i = begin; i != end; ++i)
             {
                 unsigned int bond(m_nlist.find_first_index(i));

--- a/cpp/order/Steinhardt.cc
+++ b/cpp/order/Steinhardt.cc
@@ -113,7 +113,7 @@ void Steinhardt::baseCompute(const freud::locality::NeighborList* nlist,
 
     freud::locality::loopOverNeighborsIterator(
         points, points->getPoints(), m_Np, qargs, nlist,
-        [=](size_t i, const std::shared_ptr<freud::locality::NeighborPerPointIterator>& ppiter) {
+        [&](size_t i, const std::shared_ptr<freud::locality::NeighborPerPointIterator>& ppiter) {
             float total_weight(0);
             const vec3<float> ref((*points)[i]);
             // Construct PointSPHEvaluator outside loop since the construction is costly.
@@ -216,7 +216,7 @@ void Steinhardt::computeAve(const freud::locality::NeighborList* nlist,
 
     freud::locality::loopOverNeighborsIterator(
         points, points->getPoints(), m_Np, qargs, nlist,
-        [=](size_t i, const std::shared_ptr<freud::locality::NeighborPerPointIterator>& ppiter) {
+        [&](size_t i, const std::shared_ptr<freud::locality::NeighborPerPointIterator>& ppiter) {
             unsigned int neighborcount(1);
             for (freud::locality::NeighborBond nb = ppiter->next(); !ppiter->end(); nb = ppiter->next())
             {

--- a/cpp/pmft/PMFTR12.cc
+++ b/cpp/pmft/PMFTR12.cc
@@ -82,7 +82,7 @@ void PMFTR12::accumulate(const locality::NeighborQuery* neighbor_query, const fl
 {
     neighbor_query->getBox().enforce2D();
     accumulateGeneral(neighbor_query, query_points, n_query_points, nlist, qargs,
-                      [=](const freud::locality::NeighborBond& neighbor_bond) {
+                      [&](const freud::locality::NeighborBond& neighbor_bond) {
                           vec3<float> delta(bondVector(neighbor_bond, neighbor_query, query_points));
                           // calculate angles
                           float d_theta1 = std::atan2(delta.y, delta.x);

--- a/cpp/pmft/PMFTXY.cc
+++ b/cpp/pmft/PMFTXY.cc
@@ -62,7 +62,7 @@ void PMFTXY::accumulate(const locality::NeighborQuery* neighbor_query, const flo
 {
     neighbor_query->getBox().enforce2D();
     accumulateGeneral(neighbor_query, query_points, n_query_points, nlist, qargs,
-                      [=](const freud::locality::NeighborBond& neighbor_bond) {
+                      [&](const freud::locality::NeighborBond& neighbor_bond) {
                           vec3<float> delta(bondVector(neighbor_bond, neighbor_query, query_points));
 
                           // rotate interparticle vector

--- a/cpp/pmft/PMFTXYT.cc
+++ b/cpp/pmft/PMFTXYT.cc
@@ -70,7 +70,7 @@ void PMFTXYT::accumulate(const locality::NeighborQuery* neighbor_query, const fl
 {
     neighbor_query->getBox().enforce2D();
     accumulateGeneral(neighbor_query, query_points, n_query_points, nlist, qargs,
-                      [=](const freud::locality::NeighborBond& neighbor_bond) {
+                      [&](const freud::locality::NeighborBond& neighbor_bond) {
                           vec3<float> delta(bondVector(neighbor_bond, neighbor_query, query_points));
 
                           // rotate interparticle vector

--- a/cpp/pmft/PMFTXYZ.cc
+++ b/cpp/pmft/PMFTXYZ.cc
@@ -115,7 +115,7 @@ void PMFTXYZ::accumulate(const locality::NeighborQuery* neighbor_query, const qu
     }
     neighbor_query->getBox().enforce3D();
     accumulateGeneral(neighbor_query, query_points, n_query_points, nlist, qargs,
-                      [=](const freud::locality::NeighborBond& neighbor_bond) {
+                      [&](const freud::locality::NeighborBond& neighbor_bond) {
                           // create the reference point quaternion
                           quat<float> query_orientation(query_orientations[neighbor_bond.query_point_idx]);
                           // make sure that the particles are wrapped into the box

--- a/cpp/util/Histogram.h
+++ b/cpp/util/Histogram.h
@@ -258,7 +258,7 @@ public:
         void reduceInto(ManagedArray<T>& result)
         {
             result.reset();
-            util::forLoopWrapper(0, result.size(), [=, &result](size_t begin, size_t end) {
+            util::forLoopWrapper(0, result.size(), [&](size_t begin, size_t end) {
                 for (size_t i = begin; i < end; ++i)
                 {
                     for (auto hist = m_local_histograms.begin(); hist != m_local_histograms.end(); ++hist)
@@ -440,7 +440,7 @@ public:
     void reduceOverThreadsPerBin(ThreadLocalHistogram& local_histograms, const ComputeFunction& cf)
     {
         local_histograms.reduceInto(m_bin_counts);
-        util::forLoopWrapper(0, m_bin_counts.size(), [=](size_t begin, size_t end) {
+        util::forLoopWrapper(0, m_bin_counts.size(), [&](size_t begin, size_t end) {
             for (size_t i = begin; i < end; ++i)
             {
                 cf(i);

--- a/cpp/util/ThreadStorage.h
+++ b/cpp/util/ThreadStorage.h
@@ -102,7 +102,7 @@ public:
         else
         {
             // Reduce over arrays into the result array.
-            util::forLoopWrapper(0, result.size(), [=, &result](size_t begin, size_t end) {
+            util::forLoopWrapper(0, result.size(), [&](size_t begin, size_t end) {
                 for (size_t i = begin; i < end; ++i)
                 {
                     for (auto arr = arrays.begin(); arr != arrays.end(); ++arr)

--- a/doc/source/reference/credits.rst
+++ b/doc/source/reference/credits.rst
@@ -119,6 +119,7 @@ Bradley Dice - **Lead developer**
 * Fixed documented formulas for ``Steinhardt`` class.
 * Fixed incorrect computation of ``Steinhardt`` averaged quantities.
 * Fixed RPATH problems affecting ``libfreud.so`` in Linux wheels.
+* Updated lambda functions to capture ``this`` by reference, to ensure compatibility with C++20 and above.
 
 Eric Harper, University of Michigan - **Former lead developer**
 


### PR DESCRIPTION
## Description
Extends PR #823 with some places that I missed previously.

I fixed lambda captures that were using `[=]` to capture `*this`, when it is better practice to use `[&]` to capture `*this`. The use of `[=]` to capture `*this` is deprecated in C++20. https://en.cppreference.com/w/cpp/language/lambda#Lambda_capture

## Motivation and Context
This PR removes the deprecation warnings that appear when compiling for the C++20 standard.

## How Has This Been Tested?
I built with `set(CMAKE_CXX_STANDARD 20)` in `CMakeLists.txt` with GCC 9.3.0, and this PR fixes the deprecation warnings.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds or improves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation improvement (updates to user guides, docstrings, or developer docs)

## Checklist:
<!-- Put an `x` in all the boxes that apply. If you're unsure about any of
     these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/glotzerlab/freud/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] I have updated the documentation (if relevant).
- [x] I have added tests that cover my changes (if relevant).
- [x] All new and existing tests passed.
- [x] I have updated the [credits](https://github.com/glotzerlab/freud/blob/master/doc/source/reference/credits.rst).
- [x] I have updated the [Changelog](https://github.com/glotzerlab/freud/blob/master/ChangeLog.md).
