### PR TITLE
Fix Box.contains to run in linear time, O(n_points)

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -11,7 +11,7 @@ and this project adheres to
 
 ### Fixed
 * Updated lambda functions to capture `this` by reference, to ensure compatibility with C++20 and above.
-* `Box.contains` runs in linear time, `O(num_points)`.
+* Fixed ``Box.contains`` to run in linear time, ``O(num_points)``.
 
 ## v2.6.2 -- 2021-06-26
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -11,6 +11,7 @@ and this project adheres to
 
 ### Fixed
 * Updated lambda functions to capture `this` by reference, to ensure compatibility with C++20 and above.
+* `Box.contains` runs in linear time, `O(num_points)`.
 
 ## v2.6.2 -- 2021-06-26
 

--- a/cpp/box/Box.h
+++ b/cpp/box/Box.h
@@ -476,15 +476,12 @@ public:
     void contains(const vec3<float>* points, const unsigned int n_points, bool* contains_mask) const
     {
         util::forLoopWrapper(0, n_points, [&](size_t begin, size_t end) {
-            for (size_t i = begin; i < n_points; ++i)
-            {
-                std::transform(&points[begin], &points[end], &contains_mask[begin],
-                               [this](const vec3<float>& point) -> bool {
-                                   vec3<int> image(0, 0, 0);
-                                   getImage(point, image);
-                                   return image == vec3<int>(0, 0, 0);
-                               });
-            }
+            std::transform(&points[begin], &points[end], &contains_mask[begin],
+                           [this](const vec3<float>& point) -> bool {
+                               vec3<int> image(0, 0, 0);
+                               getImage(point, image);
+                               return image == vec3<int>(0, 0, 0);
+                           });
         });
     }
 

--- a/doc/source/reference/credits.rst
+++ b/doc/source/reference/credits.rst
@@ -121,6 +121,7 @@ Bradley Dice - **Lead developer**
 * Fixed RPATH problems affecting ``libfreud.so`` in Linux wheels.
 * Updated lambda functions to capture ``this`` by reference, to ensure compatibility with C++20 and above.
 * Contributed code, design, documentation, and testing for ``StaticStructureFactorDebye`` class.
+* Fixed ``Box.contains`` to run in linear time, ``O(num_points)``.
 
 Eric Harper, University of Michigan - **Former lead developer**
 

--- a/freud/box.pyx
+++ b/freud/box.pyx
@@ -541,15 +541,18 @@ cdef class Box:
         return np.asarray(distances)
 
     def contains(self, points):
-        r"""Returns boolean array (mask) corresponding to point membership in a box.
+        r"""Compute a boolean array (mask) corresponding to point membership in a box.
 
-        This calculation computes particle membership based on conventions defined by :class:`Box`, ignoring periodicity.
-        This means that in a cubic (3D) box with dimensions ``L``, particles would be considered inside the box if their coordinates are between
-        ``[-L/2, L/2]``.
-        Particles laying at a coordinate such as ``[0, L, 0]`` would be considered outside the box.
-        More information about coordinate conventions can be found `here
-        <https://freud.readthedocs.io/en/latest/gettingstarted/examples/module_intros/box.Box.html?highlight=origin#Using-boxes>`__
-        and `here <https://freud.readthedocs.io/en/latest/gettingstarted/tutorial/periodic.html?highlight=origin#periodic-boundary-conditions>`__.
+        This calculation computes particle membership based on conventions
+        defined by :class:`Box`, ignoring periodicity. This means that in a
+        cubic (3D) box with dimensions ``L``, particles would be considered
+        inside the box if their coordinates are between ``[-L/2, L/2]``.
+        Particles laying at a coordinate such as ``[0, L, 0]`` would be
+        considered outside the box.  More information about coordinate
+        conventions can be found in the documentation on `Using boxes
+        <https://freud.readthedocs.io/en/latest/gettingstarted/examples/module_intros/box.Box.html#Using-boxes>`__
+        and `periodic boundary conditions
+        <https://freud.readthedocs.io/en/latest/gettingstarted/tutorial/periodic.html#periodic-boundary-conditions>`__.
 
         Example::
 
@@ -565,8 +568,8 @@ cdef class Box:
 
         Returns:
             :math:`\left(N, \right)` :class:`numpy.ndarray`:
-                Array of booleans, where `True` corresponds to points within the box,
-                and `False` corresponds to points outside the box.
+                Array of booleans, where ``True`` corresponds to points within
+                the box, and ``False`` corresponds to points outside the box.
         """  # noqa: E501
 
         points = freud.util._convert_array(

--- a/freud/box.pyx
+++ b/freud/box.pyx
@@ -574,14 +574,14 @@ cdef class Box:
 
         cdef:
             const float[:, ::1] l_points = points
-            size_t n_all_points = points.shape[0]
+            size_t n_points = points.shape[0]
 
         contains_mask = freud.util._convert_array(
-            np.ones(n_all_points), dtype=bool)
+            np.ones(n_points), dtype=bool)
         cdef cpp_bool[::1] l_contains_mask = contains_mask
 
         self.thisptr.contains(
-            <vec3[float]*> &l_points[0, 0], n_all_points,
+            <vec3[float]*> &l_points[0, 0], n_points,
             <cpp_bool*> &l_contains_mask[0])
 
         return np.array(l_contains_mask).astype(bool)


### PR DESCRIPTION
## Description
@optimox noticed in #839 that `Box.contains` is slow. This fixes the code so that it does not contain a nested loop that duplicates work.

I also renamed a variable and improved the docs formatting for consistency.

## How Has This Been Tested?
Existing tests pass. See also the Python script in #839 for a demo of the timing.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds or improves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation improvement (updates to user guides, docstrings, or developer docs)

## Checklist:
- [x] I have read the [**CONTRIBUTING**](https://github.com/glotzerlab/freud/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] I have updated the documentation (if relevant).
- [ ] I have added tests that cover my changes (if relevant).
- [x] All new and existing tests passed.
- [x] I have updated the [credits](https://github.com/glotzerlab/freud/blob/master/doc/source/reference/credits.rst).
- [x] I have updated the [Changelog](https://github.com/glotzerlab/freud/blob/master/ChangeLog.md).
