### PR TITLE
Use clang-format as pre-commit hook.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,5 @@
 ci:
   autoupdate_schedule: quarterly
-  skip: [clang-format]
 
 exclude: (?:^extern/)
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -53,21 +53,14 @@ repos:
     rev: v0.6.13
     hooks:
       - id: cmake-format
+  - repo: https://github.com/pre-commit/mirrors-clang-format
+    rev: 'v13.0.0'
+    hooks:
+      - id: clang-format
 # The following pre-commit hooks should only be run manually because they have
 # dependencies that cannot be pip installed.
   - repo: local
     hooks:
-    - id: clang-format
-      stages: [manual]  # Requires clang-format.
-      name: clang-format
-      entry: clang-format
-      language: system
-      types: [c++]
-      # Unclear if --style=file is necessary, it seems like clang-format uses
-      # .clang-format if found by default, at least for newer versions. We
-      # specify this here just in case.
-      args:
-      - --style=file
     - id: clang-tidy
       stages: [manual]  # Requires clang-tidy.
       name: clang-tidy

--- a/cpp/order/Steinhardt.cc
+++ b/cpp/order/Steinhardt.cc
@@ -324,13 +324,13 @@ void Steinhardt::aggregatewl(util::ManagedArray<float>& target,
                     = reduceWigner3j(&(source_l({i, 0})), l, wigner3j_values);
                 if (m_wl_normalize)
                 {
-                    const float normalization = std::sqrt(normalizationfactor) /
-                        normalization_source[norm_particle_index + l_index];
+                    const float normalization = std::sqrt(normalizationfactor)
+                        / normalization_source[norm_particle_index + l_index];
                     target[target_particle_index + l_index] *= normalization * normalization * normalization;
                 }
             }
         }
-        });
+    });
 }
 
 }; }; // end namespace freud::order

--- a/cpp/order/Steinhardt.h
+++ b/cpp/order/Steinhardt.h
@@ -79,9 +79,10 @@ public:
     /*! Constructor for Steinhardt analysis class.
      *  \param l Spherical harmonic number l. Must be non-negative integers.
      */
-    explicit Steinhardt(const unsigned int l, bool average = false, bool wl = false,
-                        bool weighted = false, bool wl_normalize = false)
-        : Steinhardt(std::vector<unsigned int>{l}, average, wl, weighted, wl_normalize) {}
+    explicit Steinhardt(const unsigned int l, bool average = false, bool wl = false, bool weighted = false,
+                        bool wl_normalize = false)
+        : Steinhardt(std::vector<unsigned int> {l}, average, wl, weighted, wl_normalize)
+    {}
 
     //! Empty destructor
     ~Steinhardt() = default;
@@ -203,11 +204,9 @@ private:
     std::vector<util::ManagedArray<std::complex<float>>> m_qlmi; //!< qlm for each particle i
     std::vector<util::ManagedArray<std::complex<float>>> m_qlm;  //!< Normalized qlm(Ave) for the whole system
     std::vector<util::ThreadStorage<std::complex<float>>>
-        m_qlm_local; //!< Thread-specific m_qlm(Ave) for each l
-    util::ManagedArray<float>
-        m_qli; //!< ql locally invariant order parameter for each particle i
-    util::ManagedArray<float>
-        m_qliAve; //!< Averaged ql with 2nd neighbor shell for each particle i
+        m_qlm_local;                    //!< Thread-specific m_qlm(Ave) for each l
+    util::ManagedArray<float> m_qli;    //!< ql locally invariant order parameter for each particle i
+    util::ManagedArray<float> m_qliAve; //!< Averaged ql with 2nd neighbor shell for each particle i
     std::vector<util::ManagedArray<std::complex<float>>>
         m_qlmiAve; //!< Averaged qlm with 2nd neighbor shell for each particle i
     std::vector<util::ManagedArray<std::complex<float>>>

--- a/cpp/util/ManagedArray.h
+++ b/cpp/util/ManagedArray.h
@@ -201,7 +201,7 @@ public:
         // cppcheck generates a false positive here on old machines (CI),
         // probably due to limited template support on those compilers.
         // cppcheck-suppress returnTempReference
-        return (*this) (buildIndex(indices...));
+        return (*this)(buildIndex(indices...));
     }
 
     //! Constant implementation of variadic indexing function.
@@ -210,7 +210,7 @@ public:
         // cppcheck generates a false positive here on old machines (CI),
         // probably due to limited template support on those compilers.
         // cppcheck-suppress returnTempReference
-        return (*this) (buildIndex(indices...));
+        return (*this)(buildIndex(indices...));
     }
 
     //! Core function for multidimensional indexing.

--- a/doc/source/reference/development/howtoadd.rst
+++ b/doc/source/reference/development/howtoadd.rst
@@ -5,14 +5,10 @@ Contributing to **freud**
 Code Conventions
 ================
 
-Python
-------
+Pre-commit
+----------
 
-Python (and Cython) code in **freud** should follow `PEP 8 <https://www.python.org/dev/peps/pep-0008/>`_.
-
-During continuous integration (CI), all Python and Cython code in **freud** is tested with `flake8 <http://flake8.pycqa.org/>`_ to ensure PEP 8 compliance.
-Additionally, all CMake code is tested using `cmakelang's cmake-format <https://cmake-format.readthedocs.io/en/latest/index.html>`__.
-It is strongly recommended to `set up a pre-commit hook <https://pre-commit.com/>`__ to ensure code is compliant before pushing to the repository:
+It is strongly recommended to `set up a pre-commit hook <https://pre-commit.com/>`__ to ensure code is compliant with all automated linters and style checks before pushing to the repository:
 
 .. code-block:: bash
 
@@ -25,6 +21,13 @@ To manually run `pre-commit <https://pre-commit.com/>`__ for all the files prese
 
     pre-commit run --all-files --show-diff-on-failure
 
+
+Python
+------
+
+Python (and Cython) code in **freud** should follow `PEP 8 <https://www.python.org/dev/peps/pep-0008/>`_.
+
+During continuous integration (CI), all Python and Cython code in **freud** is analyzed using automated linters and formatters including :code:`flake8`, :code:`black`, :code:`isort`, and :code:`pyupgrade`.
 Documentation is written in reStructuredText and generated using `Sphinx <http://www.sphinx-doc.org/en/stable/index.html>`_.
 It should be written according to the `Google Python Style Guide <https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings>`_.
 A few specific notes:
@@ -43,9 +46,13 @@ C++
 
 C++ code should follow the result of running :code:`clang-format` with the style specified in the file :code:`.clang-format`.
 Please refer to the `clang-format documentation <https://clang.llvm.org/docs/ClangFormat.html>`__ for details.
-
+The :code:`clang-format` style will be automatically enforced by pre-commit via CI.
 When in doubt, run :code:`clang-format -style=file FILE_WITH_YOUR_CODE` in the top directory of the **freud** repository.
-If installing :code:`clang-format` is not a viable option, the :code:`check-style` step of continuous integration (CI) contains the information on the correctness of the style.
+
+The :code:`check-style` step of continuous integration (CI) runs :code:`clang-tidy` and :code:`cppcheck`.
+If the :code:`check-style` CI fails, please read the output log for information on what to fix.
+
+Additionally, all CMake code is tested using `cmakelang's cmake-format <https://cmake-format.readthedocs.io/en/latest/index.html>`__.
 
 Doxygen docstrings should be used for classes, functions, etc.
 


### PR DESCRIPTION
## Description
The `clang-format` tool is now available as a pip-installable package, which enables its use in pre-commit hooks that require no additional dependencies. I am opening this PR to test out the new package and CI hook. _edit:_ It works great! 😄

pre-commit hook:
https://github.com/pre-commit/mirrors-clang-format

clang-format wheel:
https://github.com/ssciwr/clang-format-wheel

## Motivation and Context
Improves automation: pre-commit CI will be able to enforce C++ formatting rules automatically.

## How Has This Been Tested?
Testing via CI.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds or improves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation improvement (updates to user guides, docstrings, or developer docs)

## Checklist:
- [x] I have read the [**CONTRIBUTING**](https://github.com/glotzerlab/freud/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] I have updated the documentation (if relevant).
- [ ] I have added tests that cover my changes (if relevant).
- [ ] All new and existing tests passed.
- [ ] I have updated the [credits](https://github.com/glotzerlab/freud/blob/master/doc/source/reference/credits.rst).
- [ ] I have updated the [Changelog](https://github.com/glotzerlab/freud/blob/master/ChangeLog.md).
