### PR TITLE
Set a random seed on all Steinhardt random test systems.

### DIFF
--- a/tests/test_order_Steinhardt.py
+++ b/tests/test_order_Steinhardt.py
@@ -20,7 +20,7 @@ class TestSteinhardt:
         N = 1000
         L = 10
 
-        box, positions = freud.data.make_random_system(L, N)
+        box, positions = freud.data.make_random_system(L, N, seed=0)
 
         comp = freud.order.Steinhardt(6)
         comp.compute((box, positions), neighbors={"r_max": 1.5})
@@ -36,7 +36,7 @@ class TestSteinhardt:
         atol = 1e-4
         L = 8
         N = 100
-        box, points = freud.data.make_random_system(L, N)
+        box, points = freud.data.make_random_system(L, N, seed=0)
 
         num_neighbors = 4
 
@@ -369,7 +369,7 @@ class TestSteinhardt:
         atol = 1e-4
         L = 8
         N = 100
-        box, points = freud.data.make_random_system(L, N)
+        box, points = freud.data.make_random_system(L, N, seed=0)
 
         num_neighbors = 4
 


### PR DESCRIPTION
## Motivation and Context
Tests fail randomly, because of numerical issues in Steinhardt tests. See #851 for details. Resolves #851.

## How Has This Been Tested?
I ran the randomly failing `test_multiple_l` 5000 times after this change. I was able to replicate the problem before, so I think it's fixed now.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds or improves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation improvement (updates to user guides, docstrings, or developer docs)

## Checklist:
- [x] I have read the [**CONTRIBUTING**](https://github.com/glotzerlab/freud/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] I have updated the documentation (if relevant).
- [x] I have added tests that cover my changes (if relevant).
- [x] All new and existing tests passed.
- [ ] I have updated the [credits](https://github.com/glotzerlab/freud/blob/master/doc/source/reference/credits.rst).
- [ ] I have updated the [Changelog](https://github.com/glotzerlab/freud/blob/master/ChangeLog.md).