### PR TITLE
Add Python 3.10 builds.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -227,14 +227,6 @@ jobs:
       PYTHON: "python3.9"
     <<: *load_check_style
 
-  linux-python-310:
-    docker:
-      - image: glotzerlab/ci:2021.11-py310
-    environment:
-      PYVER: "3.10"
-      PYTHON: "python3.10"
-    <<: *build_and_test_linux_with_cov
-
   linux-python-39:
     docker:
       - image: glotzerlab/ci:2020.10-py39
@@ -306,23 +298,19 @@ workflows:
   test:
     jobs:
       - check-style
-      - linux-python-310
-      - linux-python-39:
-          requires:
-            - check-style
-            - linux-python-310
+      - linux-python-39
       - linux-python-38:
           requires:
             - check-style
-            - linux-python-310
+            - linux-python-39
       - linux-python-37:
           requires:
             - check-style
-            - linux-python-310
+            - linux-python-39
       - linux-python-36-oldest:
           requires:
             - check-style
-            - linux-python-310
+            - linux-python-39
       - windows-python-310
       - windows-python-39:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -227,6 +227,14 @@ jobs:
       PYTHON: "python3.9"
     <<: *load_check_style
 
+  linux-python-310:
+    docker:
+      - image: glotzerlab/ci:2021.11-py310
+    environment:
+      PYVER: "3.10"
+      PYTHON: "python3.10"
+    <<: *build_and_test_linux_with_cov
+
   linux-python-39:
     docker:
       - image: glotzerlab/ci:2020.10-py39
@@ -260,6 +268,12 @@ jobs:
       DEPENDENCIES: "OLDEST"
     <<: *build_and_test_linux
 
+  windows-python-310:
+    environment:
+      PYVER: "3.10"
+      <<: *windows_env
+    <<: *build_and_test_windows
+
   windows-python-39:
     environment:
       PYVER: "3.9"
@@ -292,28 +306,36 @@ workflows:
   test:
     jobs:
       - check-style
-      - linux-python-39
+      - linux-python-310
+      - linux-python-39:
+          requires:
+            - check-style
+            - linux-python-310
       - linux-python-38:
           requires:
             - check-style
-            - linux-python-39
+            - linux-python-310
       - linux-python-37:
           requires:
             - check-style
-            - linux-python-39
+            - linux-python-310
       - linux-python-36-oldest:
           requires:
             - check-style
-            - linux-python-39
-      - windows-python-39
+            - linux-python-310
+      - windows-python-310
+      - windows-python-39:
+          requires:
+            - check-style
+            - windows-python-310
       - windows-python-38:
           requires:
             - check-style
-            - windows-python-39
+            - windows-python-310
       - windows-python-37:
           requires:
             - check-style
-            - windows-python-39
+            - windows-python-310
 # Disabled benchmarks on CI - they currently take too much work
 #     - benchmarks:
 #         requires:

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04, macos-10.15] #, windows-2019]
-        pyver: [3.6, 3.7, 3.8, 3.9]
+        pyver: [3.6, 3.7, 3.8, 3.9, 3.10]
 
     steps:
       - uses: actions/checkout@v2.3.5

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04, macos-10.15] #, windows-2019]
-        pyver: [3.6, 3.7, 3.8, 3.9, 3.10]
+        pyver: ["3.6", "3.7", "3.8", "3.9", "3.10"]
 
     steps:
       - uses: actions/checkout@v2.3.5

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -34,7 +34,7 @@ jobs:
           submodules: "recursive"
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.2.2
+        uses: pypa/cibuildwheel@v2.3.0
         env:
           # Build for cpython >= 3.6.
           CIBW_PROJECT_REQUIRES_PYTHON: "==${{ matrix.pyver }}.*"

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -10,7 +10,6 @@ and this project adheres to
 * `freud.diffraction.StaticStructureFactorDirect` class (unstable) can be used to compute the static structure factor S(k) by sampling reciprocal space vectors.
 * Python 3.10 is supported.
 
-
 ### Fixed
 * Added error checking for `r_min`, `r_max` arguments in `freud.density.RDF` and `freud.locality.NeighborList`.
 * Doctests are now run with pytest.

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -8,6 +8,8 @@ and this project adheres to
 
 ### Added
 * `freud.diffraction.StaticStructureFactorDirect` class (unstable) can be used to compute the static structure factor S(k) by sampling reciprocal space vectors.
+* Python 3.10 is supported.
+
 
 ### Fixed
 * Added error checking for `r_min`, `r_max` arguments in `freud.density.RDF` and `freud.locality.NeighborList`.

--- a/requirements/requirements-test.txt
+++ b/requirements/requirements-test.txt
@@ -14,5 +14,5 @@ pytest==6.2.5
 pytest-cov==3.0.0
 rowan==1.3.0.post1
 scikit-build==0.12.0
-scipy==1.7.1
+scipy==1.7.2
 sympy==1.9

--- a/requirements/requirements-test.txt
+++ b/requirements/requirements-test.txt
@@ -14,5 +14,5 @@ pytest==6.2.5
 pytest-cov==3.0.0
 rowan==1.3.0.post1
 scikit-build==0.12.0
-scipy==1.7.2
+scipy==1.7.3
 sympy==1.9

--- a/setup.py
+++ b/setup.py
@@ -67,6 +67,7 @@ setup(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
     ],
     zip_safe=False,
     maintainer="freud Developers",


### PR DESCRIPTION
## Description
Enables cibuildwheel for Python 3.10.

~Currently CI is failing because there aren't wheels available for scipy yet. Building scipy from source fails. This should be re-tried in a few weeks once scipy wheels are available for Python 3.10.~ edit: scipy 1.7.2 is now released, so wheels are available and freud's CI passes.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds or improves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation improvement (updates to user guides, docstrings, or developer docs)

## Checklist:
- [x] I have read the [**CONTRIBUTING**](https://github.com/glotzerlab/freud/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] I have updated the documentation (if relevant).
- [x] I have added tests that cover my changes (if relevant).
- [ ] All new and existing tests passed.
- [ ] I have updated the [credits](https://github.com/glotzerlab/freud/blob/master/doc/source/reference/credits.rst).
- [x] I have updated the [Changelog](https://github.com/glotzerlab/freud/blob/master/ChangeLog.md).
