### PR TITLE
update cmake to only use TBB target

### DIFF
--- a/.circleci/ci-oldest-reqs.txt
+++ b/.circleci/ci-oldest-reqs.txt
@@ -1,5 +1,5 @@
 ase==3.16.0
-cmake==3.12.4
+cmake==3.12.0
 cython==0.29.14
 dynasor==1.1b0; platform_system != "Windows"
 garnett==0.7.1

--- a/.circleci/ci-oldest-reqs.txt
+++ b/.circleci/ci-oldest-reqs.txt
@@ -1,5 +1,5 @@
 ase==3.16.0
-cmake==3.6.3.post1
+cmake==3.12.4
 cython==0.29.14
 dynasor==1.1b0; platform_system != "Windows"
 garnett==0.7.1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -218,42 +218,6 @@ references:
       - *comparison
       - *store_benchmarks
 
-  build_linux_test_wheels: &build_linux_test_wheels
-    steps:
-      - *load_code
-      - *update_submodules
-      - run:
-          name: Compile Linux wheels
-          command: |
-            bash .circleci/deploy-linux.sh testpypi
-
-  build_linux_wheels: &build_linux_wheels
-    steps:
-      - *load_code
-      - *update_submodules
-      - run:
-          name: Compile Linux wheels
-          command: |
-            bash .circleci/deploy-linux.sh pypi
-
-  build_macos_test_wheels: &build_macos_test_wheels
-    steps:
-      - *load_code
-      - *update_submodules
-      - run:
-          name: Compile Mac wheels
-          command: |
-            bash .circleci/deploy-macos.sh testpypi
-
-  build_macos_wheels: &build_macos_wheels
-    steps:
-      - *load_code
-      - *update_submodules
-      - run:
-          name: Compile Mac wheels
-          command: |
-            bash .circleci/deploy-macos.sh pypi
-
 jobs:
   check-style:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -337,7 +337,7 @@ workflows:
           requires:
             - check-style
             - linux-python-39
-      - linux-python-36-oldest:
+      - linux-python-37-oldest:
           requires:
             - check-style
             - linux-python-39

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -287,12 +287,12 @@ jobs:
       PYTHON: "python3.7"
     <<: *build_and_test_linux_with_cov
 
-  linux-python-37-oldest:
+  linux-python-36-oldest:
     docker:
-      - image: glotzerlab/ci:2021.11-gcc7_py37
+      - image: glotzerlab/ci:2021.11-gcc7_py36
     environment:
-      PYVER: "3.7"
-      PYTHON: "python3.7"
+      PYVER: "3.6"
+      PYTHON: "python3.6"
       DEPENDENCIES: "OLDEST"
     <<: *build_and_test_linux
 
@@ -337,7 +337,7 @@ workflows:
           requires:
             - check-style
             - linux-python-39
-      - linux-python-37-oldest:
+      - linux-python-36-oldest:
           requires:
             - check-style
             - linux-python-39

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -287,12 +287,12 @@ jobs:
       PYTHON: "python3.7"
     <<: *build_and_test_linux_with_cov
 
-  linux-python-36-oldest:
+  linux-python-37-oldest:
     docker:
-      - image: glotzerlab/ci:2020.10-py36
+      - image: glotzerlab/ci:2021.11-gcc7_py37
     environment:
-      PYVER: "3.6"
-      PYTHON: "python3.6"
+      PYVER: "3.7"
+      PYTHON: "python3.7"
       DEPENDENCIES: "OLDEST"
     <<: *build_and_test_linux
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -289,7 +289,7 @@ jobs:
 
   linux-python-36-oldest:
     docker:
-      - image: glotzerlab/ci:2021.11-gcc7_py36
+      - image: glotzerlab/ci:2020.10-py36
     environment:
       PYVER: "3.6"
       PYTHON: "python3.6"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,13 +61,13 @@ add_subdirectory(CMake)
 find_package_config_first(TBB)
 
 # The TBB config doesn't define these variable, which we use later.
-if(NOT DEFINED TBB_INCLUDE_DIR OR NOT DEFINED TBB_LIBRARY)
-  get_target_property(TBB_INCLUDE_DIR TBB::tbb INTERFACE_INCLUDE_DIRECTORIES)
-  get_target_property(TBB_LIBRARY TBB::tbb IMPORTED_LOCATION_RELEASE)
-  set(TBB_USING_CONFIG "TRUE")
-else()
-  set(TBB_USING_CONFIG "FALSE")
-endif()
+#if(NOT DEFINED TBB_INCLUDE_DIR OR NOT DEFINED TBB_LIBRARY)
+#  get_target_property(TBB_INCLUDE_DIR TBB::tbb INTERFACE_INCLUDE_DIRECTORIES)
+#  get_target_property(TBB_LIBRARY TBB::tbb IMPORTED_LOCATION_RELEASE)
+#  set(TBB_USING_CONFIG "TRUE")
+#else()
+#  set(TBB_USING_CONFIG "FALSE")
+#endif()
 
 # Fail fast if users have not cloned submodules.
 if(NOT WIN32)
@@ -103,7 +103,7 @@ include_directories(
 # We treat the extern folder as a SYSTEM library to avoid getting any diagnostic
 # information from it. In particular, this avoids clang-tidy throwing errors due
 # to any issues in external code.
-include_directories(SYSTEM ${TBB_INCLUDE_DIR})
+#include_directories(SYSTEM ${TBB_INCLUDE_DIR})
 
 # Ignore unused variable warning from scikit-build
 set(ignoreMe "${SKBUILD}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 # oldest version of CMake that this build script has been tested with. However,
 # the oldest CMake actively tested against will be determined by the oldest
 # CMake available on PyPI (which is 3.6.3).
-cmake_minimum_required(VERSION 3.3.0)
+cmake_minimum_required(VERSION 3.12.4)
 
 set(DEFAULT_BUILD_TYPE "ReleaseWithDocs")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,7 @@
-# We use the IN_LIST operator, which is first supported in 3.3.0. This is the
-# oldest version of CMake that this build script has been tested with. However,
-# the oldest CMake actively tested against will be determined by the oldest
-# CMake available on PyPI (which is 3.6.3).
-cmake_minimum_required(VERSION 3.12.4)
+# This cmake version is the oldest version that does not error out when trying to
+# link TBB to the object library _cluster. This is also the oldest cmake version
+# we test against in our CI.
+cmake_minimum_required(VERSION 3.12.0)
 
 set(DEFAULT_BUILD_TYPE "ReleaseWithDocs")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,14 +60,11 @@ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 add_subdirectory(CMake)
 find_package_config_first(TBB)
 
-# The TBB config doesn't define these variable, which we use later.
-#if(NOT DEFINED TBB_INCLUDE_DIR OR NOT DEFINED TBB_LIBRARY)
-#  get_target_property(TBB_INCLUDE_DIR TBB::tbb INTERFACE_INCLUDE_DIRECTORIES)
-#  get_target_property(TBB_LIBRARY TBB::tbb IMPORTED_LOCATION_RELEASE)
-#  set(TBB_USING_CONFIG "TRUE")
-#else()
-#  set(TBB_USING_CONFIG "FALSE")
-#endif()
+# The TBB config doesn't define these variable, which we use later. if(NOT
+# DEFINED TBB_INCLUDE_DIR OR NOT DEFINED TBB_LIBRARY)
+# get_target_property(TBB_INCLUDE_DIR TBB::tbb INTERFACE_INCLUDE_DIRECTORIES)
+# get_target_property(TBB_LIBRARY TBB::tbb IMPORTED_LOCATION_RELEASE)
+# set(TBB_USING_CONFIG "TRUE") else() set(TBB_USING_CONFIG "FALSE") endif()
 
 # Fail fast if users have not cloned submodules.
 if(NOT WIN32)
@@ -102,8 +99,7 @@ include_directories(
 
 # We treat the extern folder as a SYSTEM library to avoid getting any diagnostic
 # information from it. In particular, this avoids clang-tidy throwing errors due
-# to any issues in external code.
-#include_directories(SYSTEM ${TBB_INCLUDE_DIR})
+# to any issues in external code. include_directories(SYSTEM ${TBB_INCLUDE_DIR})
 
 # Ignore unused variable warning from scikit-build
 set(ignoreMe "${SKBUILD}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
-# This cmake version is the oldest version that does not error out when trying to
-# link TBB to the object library _cluster. This is also the oldest cmake version
-# we test against in our CI.
+# This cmake version is the oldest version that does not error out when trying
+# to link TBB to the object library _cluster. This is also the oldest cmake
+# version we test against in our CI.
 cmake_minimum_required(VERSION 3.12.0)
 
 set(DEFAULT_BUILD_TYPE "ReleaseWithDocs")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,5 @@
-# This cmake version is the oldest version that does not error out when trying
-# to link TBB to the object library _cluster. This is also the oldest cmake
-# version we test against in our CI.
+# CMake 3.12.0 is the oldest version supported by the way freud links TBB to
+# object libraries like _cluster. This is also the oldest version tested in CI.
 cmake_minimum_required(VERSION 3.12.0)
 
 set(DEFAULT_BUILD_TYPE "ReleaseWithDocs")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,12 +60,6 @@ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 add_subdirectory(CMake)
 find_package_config_first(TBB)
 
-# The TBB config doesn't define these variable, which we use later. if(NOT
-# DEFINED TBB_INCLUDE_DIR OR NOT DEFINED TBB_LIBRARY)
-# get_target_property(TBB_INCLUDE_DIR TBB::tbb INTERFACE_INCLUDE_DIRECTORIES)
-# get_target_property(TBB_LIBRARY TBB::tbb IMPORTED_LOCATION_RELEASE)
-# set(TBB_USING_CONFIG "TRUE") else() set(TBB_USING_CONFIG "FALSE") endif()
-
 # Fail fast if users have not cloned submodules.
 if(NOT WIN32)
   string(ASCII 27 Esc)

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -13,7 +13,7 @@ and this project adheres to
 * Added error checking for `r_min`, `r_max` arguments in `freud.density.RDF` and `freud.locality.NeighborList`.
 * Doctests are now run with pytest.
 * Cleaned up tests for the static structure factor classes.
-* CMake build system only uses references to TBB target
+* CMake build system only uses references to TBB target.
 
 ## v2.7.0 -- 2021-10-01
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -13,6 +13,7 @@ and this project adheres to
 * Added error checking for `r_min`, `r_max` arguments in `freud.density.RDF` and `freud.locality.NeighborList`.
 * Doctests are now run with pytest.
 * Cleaned up tests for the static structure factor classes.
+* CMake build system only uses references to TBB target
 
 ## v2.7.0 -- 2021-10-01
 

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -31,11 +31,11 @@ add_library(
 # The namespaced TBB::tbb currently fails on Windows when discovered via FindTBB
 # rather than the config, and it's unclear why. It seems to be related to issues
 # with the namespacing.
-if(WIN32 AND NOT TBB_USING_CONFIG)
-  target_link_libraries(libfreud PUBLIC ${TBB_LIBRARY})
-else()
-  target_link_libraries(libfreud PUBLIC TBB::tbb)
-endif()
+#if(WIN32 AND NOT TBB_USING_CONFIG)
+#  target_link_libraries(libfreud PUBLIC ${TBB_LIBRARY})
+#else()
+target_link_libraries(libfreud PUBLIC TBB::tbb)
+#endif()
 
 # We treat the extern folder as a SYSTEM library to avoid getting any diagnostic
 # information from it. In particular, this avoids clang-tidy throwing errors due

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -28,12 +28,7 @@ add_library(
   $<TARGET_OBJECTS:_pmft>
   $<TARGET_OBJECTS:_util>)
 
-# The namespaced TBB::tbb currently fails on Windows when discovered via FindTBB
-# rather than the config, and it's unclear why. It seems to be related to issues
-# with the namespacing. if(WIN32 AND NOT TBB_USING_CONFIG)
-# target_link_libraries(libfreud PUBLIC ${TBB_LIBRARY}) else()
 target_link_libraries(libfreud PUBLIC TBB::tbb)
-# endif()
 
 # We treat the extern folder as a SYSTEM library to avoid getting any diagnostic
 # information from it. In particular, this avoids clang-tidy throwing errors due

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -30,12 +30,10 @@ add_library(
 
 # The namespaced TBB::tbb currently fails on Windows when discovered via FindTBB
 # rather than the config, and it's unclear why. It seems to be related to issues
-# with the namespacing.
-#if(WIN32 AND NOT TBB_USING_CONFIG)
-#  target_link_libraries(libfreud PUBLIC ${TBB_LIBRARY})
-#else()
+# with the namespacing. if(WIN32 AND NOT TBB_USING_CONFIG)
+# target_link_libraries(libfreud PUBLIC ${TBB_LIBRARY}) else()
 target_link_libraries(libfreud PUBLIC TBB::tbb)
-#endif()
+# endif()
 
 # We treat the extern folder as a SYSTEM library to avoid getting any diagnostic
 # information from it. In particular, this avoids clang-tidy throwing errors due

--- a/cpp/cluster/CMakeLists.txt
+++ b/cpp/cluster/CMakeLists.txt
@@ -1,6 +1,8 @@
 add_library(_cluster OBJECT Cluster.h Cluster.cc ClusterProperties.h
                             ClusterProperties.cc)
 
+target_link_libraries(_cluster PUBLIC TBB::tbb)
+
 # We treat the extern folder as a SYSTEM library to avoid getting any diagnostic
 # information from it. In particular, this avoids clang-tidy throwing errors due
 # to any issues in external code.

--- a/cpp/density/CMakeLists.txt
+++ b/cpp/density/CMakeLists.txt
@@ -10,3 +10,5 @@ add_library(
   RDF.cc
   SphereVoxelization.h
   SphereVoxelization.cc)
+
+target_link_libraries(_density PUBLIC TBB::tbb)

--- a/cpp/diffraction/CMakeLists.txt
+++ b/cpp/diffraction/CMakeLists.txt
@@ -4,4 +4,6 @@ add_library(
   StaticStructureFactorDebye.cc StaticStructureFactorDirect.h
   StaticStructureFactorDirect.cc)
 
+target_link_libraries(_diffraction PUBLIC TBB::tbb)
+
 target_include_directories(_diffraction PUBLIC ${PROJECT_SOURCE_DIR}/extern/)

--- a/cpp/environment/CMakeLists.txt
+++ b/cpp/environment/CMakeLists.txt
@@ -12,6 +12,8 @@ add_library(
   MatchEnv.cc
   Registration.h)
 
+target_link_libraries(_environment PUBLIC TBB::tbb)
+
 # We treat the extern folder as a SYSTEM library to avoid getting any diagnostic
 # information from it. In particular, this avoids clang-tidy throwing errors due
 # to any issues in external code.

--- a/cpp/locality/CMakeLists.txt
+++ b/cpp/locality/CMakeLists.txt
@@ -34,6 +34,8 @@ add_library(
   ${VOROPP_SOURCE_DIR}/pre_container.cc
   ${VOROPP_SOURCE_DIR}/container_prd.cc)
 
+target_link_libraries(_locality PUBLIC TBB::tbb)
+
 # We treat the extern folder as a SYSTEM library to avoid getting any diagnostic
 # information from it. In particular, this avoids clang-tidy throwing errors due
 # to any issues in external code.

--- a/cpp/order/CMakeLists.txt
+++ b/cpp/order/CMakeLists.txt
@@ -15,6 +15,8 @@ add_library(
   Wigner3j.cc
   Wigner3j.h)
 
+target_link_libraries(_order PUBLIC TBB::tbb)
+
 # We treat the extern folder as a SYSTEM library to avoid getting any diagnostic
 # information from it. In particular, this avoids clang-tidy throwing errors due
 # to any issues in external code.

--- a/cpp/parallel/CMakeLists.txt
+++ b/cpp/parallel/CMakeLists.txt
@@ -1,1 +1,4 @@
 add_library(_parallel OBJECT tbb_config.h tbb_config.cc)
+
+target_link_libraries(_parallel PUBLIC TBB::tbb)
+

--- a/cpp/parallel/CMakeLists.txt
+++ b/cpp/parallel/CMakeLists.txt
@@ -1,4 +1,3 @@
 add_library(_parallel OBJECT tbb_config.h tbb_config.cc)
 
 target_link_libraries(_parallel PUBLIC TBB::tbb)
-

--- a/cpp/pmft/CMakeLists.txt
+++ b/cpp/pmft/CMakeLists.txt
@@ -8,3 +8,5 @@ add_library(
   PMFTXYT.cc
   PMFTXYZ.h
   PMFTXYZ.cc)
+
+target_link_libraries(_pmft PUBLIC TBB::tbb)

--- a/cpp/util/CMakeLists.txt
+++ b/cpp/util/CMakeLists.txt
@@ -1,5 +1,7 @@
 add_library(_util OBJECT diagonalize.h diagonalize.cc)
 
+target_link_libraries(_util PUBLIC TBB::tbb)
+
 # We treat the extern folder as a SYSTEM library to avoid getting any diagnostic
 # information from it. In particular, this avoids clang-tidy throwing errors due
 # to any issues in external code.

--- a/doc/source/gettingstarted/installation.rst
+++ b/doc/source/gettingstarted/installation.rst
@@ -43,7 +43,7 @@ The following are **required** for installing **freud**:
 .. note::
 
     Depending on the generator you are using, you may require a newer version of CMake.
-    In particular, Visual Studio 2019 requires CMake >= 3.14.
+    In particular, Visual Studio 2019 requires CMake >= 3.14.0.
     For more information on specific generators, see the `CMake generator documentation <https://cmake.org/cmake/help/git-stage/manual/cmake-generators.7.html>`__.
 
 The **freud** library uses scikit-build and CMake to handle the build process itself, while the other requirements are required for compiling code in **freud**.

--- a/doc/source/gettingstarted/installation.rst
+++ b/doc/source/gettingstarted/installation.rst
@@ -38,13 +38,13 @@ The following are **required** for installing **freud**:
 - `Intel Threading Building Blocks <https://www.threadingbuildingblocks.org/>`__ (>=2017.03.R2)
 - `Cython <https://cython.org/>`__ (>=0.29.14)
 - `scikit-build <https://scikit-build.readthedocs.io/>`__ (>=0.10.0)
-- `CMake <https://cmake.org/>`__ (>=3.12.4)
+- `CMake <https://cmake.org/>`__ (>=3.12.0)
 
 .. note::
 
     Depending on the generator you are using, you may require a newer version of CMake.
-    In particular, Visual Studio 2019 requires CMake 3.14. For more information on specific
-    generators, see the `CMake generator documentation <https://cmake.org/cmake/help/git-stage/manual/cmake-generators.7.html>`__.
+    In particular, Visual Studio 2019 requires CMake >= 3.14.
+    For more information on specific generators, see the `CMake generator documentation <https://cmake.org/cmake/help/git-stage/manual/cmake-generators.7.html>`__.
 
 The **freud** library uses scikit-build and CMake to handle the build process itself, while the other requirements are required for compiling code in **freud**.
 These requirements can be met by installing the following packages from the `conda-forge channel <https://conda-forge.org/>`__:

--- a/doc/source/gettingstarted/installation.rst
+++ b/doc/source/gettingstarted/installation.rst
@@ -35,7 +35,7 @@ The following are **required** for installing **freud**:
 - A C++14-compliant compiler
 - `Python <https://www.python.org/>`__ (>=3.6)
 - `NumPy <https://www.numpy.org/>`__ (>=1.14)
-- `Intel Threading Building Blocks <https://www.threadingbuildingblocks.org/>`__
+- `Intel Threading Building Blocks <https://www.threadingbuildingblocks.org/>`__ (>=2017.03.R2)
 - `Cython <https://cython.org/>`__ (>=0.29.14)
 - `scikit-build <https://scikit-build.readthedocs.io/>`__ (>=0.10.0)
 - `CMake <https://cmake.org/>`__ (>=3.12.4)

--- a/doc/source/gettingstarted/installation.rst
+++ b/doc/source/gettingstarted/installation.rst
@@ -38,13 +38,13 @@ The following are **required** for installing **freud**:
 - `Intel Threading Building Blocks <https://www.threadingbuildingblocks.org/>`__
 - `Cython <https://cython.org/>`__ (>=0.29.14)
 - `scikit-build <https://scikit-build.readthedocs.io/>`__ (>=0.10.0)
-- `CMake <https://cmake.org/>`__ (>=3.6.3)
+- `CMake <https://cmake.org/>`__ (>=3.12.4)
 
 .. note::
 
     Depending on the generator you are using, you may require a newer version of CMake.
-    In particular, on Windows Visual Studio 2017 requires at least CMake 3.7.1, while Visual Studio 2019 requires CMake 3.14.
-    For more information on specific generators, see the `CMake generator documentation <https://cmake.org/cmake/help/git-stage/manual/cmake-generators.7.html>`__.
+    In particular, Visual Studio 2019 requires CMake 3.14. For more information on specific
+    generators, see the `CMake generator documentation <https://cmake.org/cmake/help/git-stage/manual/cmake-generators.7.html>`__.
 
 The **freud** library uses scikit-build and CMake to handle the build process itself, while the other requirements are required for compiling code in **freud**.
 These requirements can be met by installing the following packages from the `conda-forge channel <https://conda-forge.org/>`__:

--- a/doc/source/reference/credits.rst
+++ b/doc/source/reference/credits.rst
@@ -325,6 +325,7 @@ Tommy Waltmann
 * Contributed code, design, and testing for ``StaticStructureFactorDebye`` class.
 * Contributed code, design, and testing for ``StaticStructureFactorDirect`` class.
 * Refactor tests for ``StaticStructureFactor`` classes.
+* Improve CMake build system to use more modern style.
 
 Maya Martirossyan
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above. -->

## Description
Freud's CMake used the `TBB_INCLUDE_DIR` and `TBB_LIBRARY` variables, instead of just linking to the TBB build target, which caused build issues on #866 . This PR makes changes to fix the build issues on certain systems and use better modern CMake style.

## Motivation and Context
Resolves: #866 

## How Has This Been Tested?
The CI will test the new CMake code on many different systems, and I will verify that the system configuration referenced in #866 builds freud correctly.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds or improves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation improvement (updates to user guides, docstrings, or developer docs)

## Checklist:
<!-- Put an `x` in all the boxes that apply. If you're unsure about any of
     these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [**CONTRIBUTING**](https://github.com/glotzerlab/freud/blob/master/CONTRIBUTING.md) document.
- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation (if relevant).
- [ ] I have added tests that cover my changes (if relevant).
- [ ] All new and existing tests passed.
- [ ] I have updated the [credits](https://github.com/glotzerlab/freud/blob/master/doc/source/reference/credits.rst).
- [ ] I have updated the [Changelog](https://github.com/glotzerlab/freud/blob/master/ChangeLog.md).
