### PR TITLE
Refactor/util histogram axes

### DIFF
--- a/cpp/density/CorrelationFunction.cc
+++ b/cpp/density/CorrelationFunction.cc
@@ -37,9 +37,8 @@ CorrelationFunction<T>::CorrelationFunction(unsigned int bins, float r_max) : Bo
     m_histogram = util::Histogram<unsigned int>(axes);
     m_local_histograms = util::Histogram<unsigned int>::ThreadLocalHistogram(m_histogram);
 
-    typename util::Axes axes_rdf;
-    axes_rdf.push_back(std::make_shared<util::RegularAxis>(bins, 0, r_max));
-    m_correlation_function = util::Histogram<T>(axes_rdf);
+    axes.push_back(std::make_shared<util::RegularAxis>(bins, 0, r_max));
+    m_correlation_function = util::Histogram<T>(axes);
     m_local_correlation_function = CFThreadHistogram(m_correlation_function);
 }
 

--- a/cpp/density/CorrelationFunction.cc
+++ b/cpp/density/CorrelationFunction.cc
@@ -32,12 +32,12 @@ CorrelationFunction<T>::CorrelationFunction(unsigned int bins, float r_max) : Bo
     // We must construct two separate histograms, one for the counts and one
     // for the actual correlation function. The counts are used to normalize
     // the correlation function.
-    util::Histogram<unsigned int>::Axes axes;
+    util::Axes axes;
     axes.push_back(std::make_shared<util::RegularAxis>(bins, 0, r_max));
     m_histogram = util::Histogram<unsigned int>(axes);
     m_local_histograms = util::Histogram<unsigned int>::ThreadLocalHistogram(m_histogram);
 
-    typename util::Histogram<T>::Axes axes_rdf;
+    typename util::Axes axes_rdf;
     axes_rdf.push_back(std::make_shared<util::RegularAxis>(bins, 0, r_max));
     m_correlation_function = util::Histogram<T>(axes_rdf);
     m_local_correlation_function = CFThreadHistogram(m_correlation_function);

--- a/cpp/density/CorrelationFunction.cc
+++ b/cpp/density/CorrelationFunction.cc
@@ -31,13 +31,11 @@ CorrelationFunction<T>::CorrelationFunction(unsigned int bins, float r_max) : Bo
 
     // We must construct two separate histograms, one for the counts and one
     // for the actual correlation function. The counts are used to normalize
-    // the correlation function.
-    util::Axes axes;
-    axes.push_back(std::make_shared<util::RegularAxis>(bins, 0, r_max));
+    // the correlation function. The histograms can share the same set of axes.
+    const auto axes = util::Axes {std::make_shared<util::RegularAxis>(bins, 0, r_max)};
     m_histogram = util::Histogram<unsigned int>(axes);
     m_local_histograms = util::Histogram<unsigned int>::ThreadLocalHistogram(m_histogram);
 
-    axes.push_back(std::make_shared<util::RegularAxis>(bins, 0, r_max));
     m_correlation_function = util::Histogram<T>(axes);
     m_local_correlation_function = CFThreadHistogram(m_correlation_function);
 }

--- a/cpp/density/RDF.cc
+++ b/cpp/density/RDF.cc
@@ -32,8 +32,7 @@ RDF::RDF(unsigned int bins, float r_max, float r_min, bool normalize)
     }
 
     // Construct the Histogram object that will be used to keep track of counts of bond distances found.
-    BHAxes axes;
-    axes.push_back(std::make_shared<util::RegularAxis>(bins, r_min, r_max));
+    const auto axes = util::Axes {std::make_shared<util::RegularAxis>(bins, r_min, r_max)};
     m_histogram = BondHistogram(axes);
     m_local_histograms = BondHistogram::ThreadLocalHistogram(m_histogram);
 

--- a/cpp/diffraction/StaticStructureFactor.cc
+++ b/cpp/diffraction/StaticStructureFactor.cc
@@ -32,7 +32,7 @@ StaticStructureFactor::StaticStructureFactor(unsigned int bins, float k_max, flo
     }
     // Construct the Histogram object that will be used to track the structure factor
     const auto axes
-        = StructureFactorHistogram::Axes {std::make_shared<util::RegularAxis>(bins, k_min, k_max)};
+        = util::Axes {std::make_shared<util::RegularAxis>(bins, k_min, k_max)};
     m_structure_factor = StructureFactorHistogram(axes);
     m_local_structure_factor = StructureFactorHistogram::ThreadLocalHistogram(m_structure_factor);
 }

--- a/cpp/diffraction/StaticStructureFactor.cc
+++ b/cpp/diffraction/StaticStructureFactor.cc
@@ -31,8 +31,7 @@ StaticStructureFactor::StaticStructureFactor(unsigned int bins, float k_max, flo
         throw std::invalid_argument("StaticStructureFactor requires that k_max must be greater than k_min.");
     }
     // Construct the Histogram object that will be used to track the structure factor
-    const auto axes
-        = util::Axes {std::make_shared<util::RegularAxis>(bins, k_min, k_max)};
+    const auto axes = util::Axes {std::make_shared<util::RegularAxis>(bins, k_min, k_max)};
     m_structure_factor = StructureFactorHistogram(axes);
     m_local_structure_factor = StructureFactorHistogram::ThreadLocalHistogram(m_structure_factor);
 }

--- a/cpp/environment/BondOrder.cc
+++ b/cpp/environment/BondOrder.cc
@@ -56,9 +56,10 @@ BondOrder::BondOrder(unsigned int n_bins_theta, unsigned int n_bins_phi, BondOrd
             m_sa_array(i, j) = sa;
         }
     }
-    BHAxes axes;
-    axes.push_back(std::make_shared<util::RegularAxis>(n_bins_theta, 0, constants::TWO_PI));
-    axes.push_back(std::make_shared<util::RegularAxis>(n_bins_phi, 0, M_PI));
+    const auto axes = util::Axes {
+        std::make_shared<util::RegularAxis>(n_bins_theta, 0, constants::TWO_PI),
+        std::make_shared<util::RegularAxis>(n_bins_phi, 0, M_PI)
+    };
     m_histogram = BondHistogram(axes);
 
     m_local_histograms = BondHistogram::ThreadLocalHistogram(m_histogram);

--- a/cpp/environment/BondOrder.cc
+++ b/cpp/environment/BondOrder.cc
@@ -56,10 +56,8 @@ BondOrder::BondOrder(unsigned int n_bins_theta, unsigned int n_bins_phi, BondOrd
             m_sa_array(i, j) = sa;
         }
     }
-    const auto axes = util::Axes {
-        std::make_shared<util::RegularAxis>(n_bins_theta, 0, constants::TWO_PI),
-        std::make_shared<util::RegularAxis>(n_bins_phi, 0, M_PI)
-    };
+    const auto axes = util::Axes {std::make_shared<util::RegularAxis>(n_bins_theta, 0, constants::TWO_PI),
+                                  std::make_shared<util::RegularAxis>(n_bins_phi, 0, M_PI)};
     m_histogram = BondHistogram(axes);
 
     m_local_histograms = BondHistogram::ThreadLocalHistogram(m_histogram);

--- a/cpp/locality/BondHistogramCompute.h
+++ b/cpp/locality/BondHistogramCompute.h
@@ -122,7 +122,6 @@ protected:
         m_local_histograms; //!< Thread local bin counts for TBB parallelism
 
     using BondHistogram = util::Histogram<unsigned int>;
-    using BHAxes = util::Axes;
 };
 
 }; }; // namespace freud::locality

--- a/cpp/locality/BondHistogramCompute.h
+++ b/cpp/locality/BondHistogramCompute.h
@@ -122,7 +122,7 @@ protected:
         m_local_histograms; //!< Thread local bin counts for TBB parallelism
 
     using BondHistogram = util::Histogram<unsigned int>;
-    using BHAxes = typename BondHistogram::Axes;
+    using BHAxes = typename util::Axes;
 };
 
 }; }; // namespace freud::locality

--- a/cpp/locality/BondHistogramCompute.h
+++ b/cpp/locality/BondHistogramCompute.h
@@ -122,7 +122,7 @@ protected:
         m_local_histograms; //!< Thread local bin counts for TBB parallelism
 
     using BondHistogram = util::Histogram<unsigned int>;
-    using BHAxes = typename util::Axes;
+    using BHAxes = util::Axes;
 };
 
 }; }; // namespace freud::locality

--- a/cpp/order/Cubatic.cc
+++ b/cpp/order/Cubatic.cc
@@ -256,7 +256,7 @@ void Cubatic::compute(quat<float>* orientations, unsigned int num_orientations)
 
     util::forLoopWrapper(0, m_n_replicates, [&](size_t begin, size_t end) {
         // create thread-specific rng
-        auto const thread_start = static_cast<unsigned int>(begin);
+        const auto thread_start = static_cast<unsigned int>(begin);
 
         std::vector<unsigned int> seed_seq(3);
         seed_seq[0] = m_seed;

--- a/cpp/pmft/PMFTR12.cc
+++ b/cpp/pmft/PMFTR12.cc
@@ -32,11 +32,9 @@ PMFTR12::PMFTR12(float r_max, unsigned int n_r, unsigned int n_t1, unsigned int 
     }
 
     // Construct the Histogram object that will be used to keep track of counts of bond distances found.
-    const auto axes = util::Axes {
-        std::make_shared<util::RegularAxis>(n_r, 0, r_max),
-        std::make_shared<util::RegularAxis>(n_t1, 0, constants::TWO_PI),
-        std::make_shared<util::RegularAxis>(n_t2, 0, constants::TWO_PI)
-    };
+    const auto axes = util::Axes {std::make_shared<util::RegularAxis>(n_r, 0, r_max),
+                                  std::make_shared<util::RegularAxis>(n_t1, 0, constants::TWO_PI),
+                                  std::make_shared<util::RegularAxis>(n_t2, 0, constants::TWO_PI)};
     m_histogram = BondHistogram(axes);
     m_local_histograms = BondHistogram::ThreadLocalHistogram(m_histogram);
 

--- a/cpp/pmft/PMFTR12.cc
+++ b/cpp/pmft/PMFTR12.cc
@@ -32,10 +32,11 @@ PMFTR12::PMFTR12(float r_max, unsigned int n_r, unsigned int n_t1, unsigned int 
     }
 
     // Construct the Histogram object that will be used to keep track of counts of bond distances found.
-    BHAxes axes;
-    axes.push_back(std::make_shared<util::RegularAxis>(n_r, 0, r_max));
-    axes.push_back(std::make_shared<util::RegularAxis>(n_t1, 0, constants::TWO_PI));
-    axes.push_back(std::make_shared<util::RegularAxis>(n_t2, 0, constants::TWO_PI));
+    const auto axes = util::Axes {
+        std::make_shared<util::RegularAxis>(n_r, 0, r_max),
+        std::make_shared<util::RegularAxis>(n_t1, 0, constants::TWO_PI),
+        std::make_shared<util::RegularAxis>(n_t2, 0, constants::TWO_PI)
+    };
     m_histogram = BondHistogram(axes);
     m_local_histograms = BondHistogram::ThreadLocalHistogram(m_histogram);
 

--- a/cpp/pmft/PMFTXY.cc
+++ b/cpp/pmft/PMFTXY.cc
@@ -43,9 +43,10 @@ PMFTXY::PMFTXY(float x_max, float y_max, unsigned int n_x, unsigned int n_y) : P
     m_pcf_array.prepare({n_x, n_y});
 
     // Construct the Histogram object that will be used to keep track of counts of bond distances found.
-    BHAxes axes;
-    axes.push_back(std::make_shared<util::RegularAxis>(n_x, -x_max, x_max));
-    axes.push_back(std::make_shared<util::RegularAxis>(n_y, -y_max, y_max));
+    const auto axes = util::Axes {
+        std::make_shared<util::RegularAxis>(n_x, -x_max, x_max),
+        std::make_shared<util::RegularAxis>(n_y, -y_max, y_max)
+    };
     m_histogram = BondHistogram(axes);
     m_local_histograms = BondHistogram::ThreadLocalHistogram(m_histogram);
 }

--- a/cpp/pmft/PMFTXY.cc
+++ b/cpp/pmft/PMFTXY.cc
@@ -43,10 +43,8 @@ PMFTXY::PMFTXY(float x_max, float y_max, unsigned int n_x, unsigned int n_y) : P
     m_pcf_array.prepare({n_x, n_y});
 
     // Construct the Histogram object that will be used to keep track of counts of bond distances found.
-    const auto axes = util::Axes {
-        std::make_shared<util::RegularAxis>(n_x, -x_max, x_max),
-        std::make_shared<util::RegularAxis>(n_y, -y_max, y_max)
-    };
+    const auto axes = util::Axes {std::make_shared<util::RegularAxis>(n_x, -x_max, x_max),
+                                  std::make_shared<util::RegularAxis>(n_y, -y_max, y_max)};
     m_histogram = BondHistogram(axes);
     m_local_histograms = BondHistogram::ThreadLocalHistogram(m_histogram);
 }

--- a/cpp/pmft/PMFTXYT.cc
+++ b/cpp/pmft/PMFTXYT.cc
@@ -49,11 +49,9 @@ PMFTXYT::PMFTXYT(float x_max, float y_max, unsigned int n_x, unsigned int n_y, u
     m_pcf_array.prepare({n_x, n_y, n_t});
 
     // Construct the Histogram object that will be used to keep track of counts of bond distances found.
-    auto const axes = util::Axes {
-        std::make_shared<util::RegularAxis>(n_x, -x_max, x_max),
-        std::make_shared<util::RegularAxis>(n_y, -y_max, y_max),
-        std::make_shared<util::RegularAxis>(n_t, 0, constants::TWO_PI)
-    };
+    auto const axes = util::Axes {std::make_shared<util::RegularAxis>(n_x, -x_max, x_max),
+                                  std::make_shared<util::RegularAxis>(n_y, -y_max, y_max),
+                                  std::make_shared<util::RegularAxis>(n_t, 0, constants::TWO_PI)};
     m_histogram = BondHistogram(axes);
     m_local_histograms = BondHistogram::ThreadLocalHistogram(m_histogram);
 }

--- a/cpp/pmft/PMFTXYT.cc
+++ b/cpp/pmft/PMFTXYT.cc
@@ -49,7 +49,7 @@ PMFTXYT::PMFTXYT(float x_max, float y_max, unsigned int n_x, unsigned int n_y, u
     m_pcf_array.prepare({n_x, n_y, n_t});
 
     // Construct the Histogram object that will be used to keep track of counts of bond distances found.
-    BondHistogram::Axes axes;
+    util::Axes axes;
     axes.push_back(std::make_shared<util::RegularAxis>(n_x, -x_max, x_max));
     axes.push_back(std::make_shared<util::RegularAxis>(n_y, -y_max, y_max));
     axes.push_back(std::make_shared<util::RegularAxis>(n_t, 0, constants::TWO_PI));

--- a/cpp/pmft/PMFTXYT.cc
+++ b/cpp/pmft/PMFTXYT.cc
@@ -49,7 +49,7 @@ PMFTXYT::PMFTXYT(float x_max, float y_max, unsigned int n_x, unsigned int n_y, u
     m_pcf_array.prepare({n_x, n_y, n_t});
 
     // Construct the Histogram object that will be used to keep track of counts of bond distances found.
-    auto const axes = util::Axes {std::make_shared<util::RegularAxis>(n_x, -x_max, x_max),
+    const auto axes = util::Axes {std::make_shared<util::RegularAxis>(n_x, -x_max, x_max),
                                   std::make_shared<util::RegularAxis>(n_y, -y_max, y_max),
                                   std::make_shared<util::RegularAxis>(n_t, 0, constants::TWO_PI)};
     m_histogram = BondHistogram(axes);

--- a/cpp/pmft/PMFTXYT.cc
+++ b/cpp/pmft/PMFTXYT.cc
@@ -49,10 +49,11 @@ PMFTXYT::PMFTXYT(float x_max, float y_max, unsigned int n_x, unsigned int n_y, u
     m_pcf_array.prepare({n_x, n_y, n_t});
 
     // Construct the Histogram object that will be used to keep track of counts of bond distances found.
-    util::Axes axes;
-    axes.push_back(std::make_shared<util::RegularAxis>(n_x, -x_max, x_max));
-    axes.push_back(std::make_shared<util::RegularAxis>(n_y, -y_max, y_max));
-    axes.push_back(std::make_shared<util::RegularAxis>(n_t, 0, constants::TWO_PI));
+    auto const axes = util::Axes {
+        std::make_shared<util::RegularAxis>(n_x, -x_max, x_max),
+        std::make_shared<util::RegularAxis>(n_y, -y_max, y_max),
+        std::make_shared<util::RegularAxis>(n_t, 0, constants::TWO_PI)
+    };
     m_histogram = BondHistogram(axes);
     m_local_histograms = BondHistogram::ThreadLocalHistogram(m_histogram);
 }

--- a/cpp/pmft/PMFTXYZ.cc
+++ b/cpp/pmft/PMFTXYZ.cc
@@ -65,10 +65,11 @@ PMFTXYZ::PMFTXYZ(float x_max, float y_max, float z_max, unsigned int n_x, unsign
 
     // Construct the Histogram object that will be used to keep track of counts
     // of bond distances found.
-    BHAxes axes;
-    axes.push_back(std::make_shared<util::RegularAxis>(n_x, -x_max, x_max));
-    axes.push_back(std::make_shared<util::RegularAxis>(n_y, -y_max, y_max));
-    axes.push_back(std::make_shared<util::RegularAxis>(n_z, -z_max, z_max));
+    const auto axes = util::Axes {
+        std::make_shared<util::RegularAxis>(n_x, -x_max, x_max),
+        std::make_shared<util::RegularAxis>(n_y, -y_max, y_max),
+        std::make_shared<util::RegularAxis>(n_z, -z_max, z_max)
+    };
     m_histogram = BondHistogram(axes);
     m_local_histograms = BondHistogram::ThreadLocalHistogram(m_histogram);
 }

--- a/cpp/pmft/PMFTXYZ.cc
+++ b/cpp/pmft/PMFTXYZ.cc
@@ -65,11 +65,9 @@ PMFTXYZ::PMFTXYZ(float x_max, float y_max, float z_max, unsigned int n_x, unsign
 
     // Construct the Histogram object that will be used to keep track of counts
     // of bond distances found.
-    const auto axes = util::Axes {
-        std::make_shared<util::RegularAxis>(n_x, -x_max, x_max),
-        std::make_shared<util::RegularAxis>(n_y, -y_max, y_max),
-        std::make_shared<util::RegularAxis>(n_z, -z_max, z_max)
-    };
+    const auto axes = util::Axes {std::make_shared<util::RegularAxis>(n_x, -x_max, x_max),
+                                  std::make_shared<util::RegularAxis>(n_y, -y_max, y_max),
+                                  std::make_shared<util::RegularAxis>(n_z, -z_max, z_max)};
     m_histogram = BondHistogram(axes);
     m_local_histograms = BondHistogram::ThreadLocalHistogram(m_histogram);
 }

--- a/cpp/util/Histogram.h
+++ b/cpp/util/Histogram.h
@@ -172,6 +172,8 @@ protected:
     float m_inverse_bin_width; //!< Inverse of bin width
 };
 
+using Axes = std::vector<std::shared_ptr<Axis>>;
+
 //! An n-dimensional histogram class.
 /*! The Histogram is designed to simplify the most common use of histograms in
  * C++ code, which is looping over a series of values and then binning them. To
@@ -273,9 +275,6 @@ public:
         tbb::enumerable_thread_specific<Histogram<T>>
             m_local_histograms; //!< The thread-local copies of m_histogram.
     };
-
-    using Axes = std::vector<std::shared_ptr<Axis>>;
-    using AxisIterator = Axes::const_iterator;
 
     //! Default constructor
     Histogram() = default;


### PR DESCRIPTION
Refactoring and code cleanup in Freud's c++ histogram utility.

## Description
This PR re-namespaces the `util::Histogram<T>::Axes` object in the histogram utility to `util::Axes`, which allows one Axes instance to be used for both histograms in `CorrelationFunction`.

I refactored the `CorrelationFunction` code to account for the namespace change, and also removed the `AxisIterator` object from Histogram.h that was going unused,

## Motivation and Context
Resolves: #826 

## How Has This Been Tested?
~~All but two tests from `test_diffraction_DiffractionPattern` pass, but I think this is because recent tweaks to those tests that incorporate diffraction normalization by N are not included in this branch yet. Would it be appropriate to merge `fix/diffraction-normalization` into this branch to make them pass?~~

~~Not all code has been refactored yet, I am working on this.~~

Existing tests are passing.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds or improves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation improvement (updates to user guides, docstrings, or developer docs)
- [x] Refactoring

## Checklist:
<!-- Put an `x` in all the boxes that apply. If you're unsure about any of
     these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/glotzerlab/freud/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] I have updated the documentation (if relevant).
- [ ] I have added tests that cover my changes (if relevant).
- [x] All new and existing tests passed.
- [x] I have updated the [credits](https://github.com/glotzerlab/freud/blob/master/doc/source/reference/credits.rst).
- [x] I have updated the [Changelog](https://github.com/glotzerlab/freud/blob/master/ChangeLog.md).
