### PR TITLE
Changed return value in documentation

### DIFF
--- a/doc/source/reference/credits.rst
+++ b/doc/source/reference/credits.rst
@@ -352,6 +352,10 @@ Emily Siew
 
 * Contributed documentation for ``StaticStructureFactorDebye`` class.
 
+Dylan Marx
+
+* Contributed documentation for ``NeighborQuery`` class.
+
 Source code
 -----------
 

--- a/freud/locality.pyx
+++ b/freud/locality.pyx
@@ -424,7 +424,7 @@ cdef class NeighborQuery:
                 :meth:`matplotlib.axes.Axes.plot`.
 
         Returns:
-            tuple (:class:`matplotlib.axes.Axes`, :class:`matplotlib.collections.PathCollection`): 
+            tuple (:class:`matplotlib.axes.Axes`, :class:`matplotlib.collections.PathCollection`):
                 Axis and point data for the plot.
         """
         import freud.plot

--- a/freud/locality.pyx
+++ b/freud/locality.pyx
@@ -425,7 +425,7 @@ cdef class NeighborQuery:
 
         Returns:
             :class:`matplotlib.axes.Axes`: Axis with the plot.
-            :class:`matplotlib.collections.PathCollection`: Point data for the plot.
+            :class:`matplotlib.collections.PathCollection`: Point data returned for the plot.
         """
         import freud.plot
         return freud.plot.system_plot(

--- a/freud/locality.pyx
+++ b/freud/locality.pyx
@@ -425,7 +425,7 @@ cdef class NeighborQuery:
 
         Returns:
             :class:`matplotlib.axes.Axes`: Axis with the plot.
-            :class:`matplotlib.collections.PathCollection`:
+            :class:`matplotlib.collections.PathCollection`: Point data for the plot.
         """
         import freud.plot
         return freud.plot.system_plot(

--- a/freud/locality.pyx
+++ b/freud/locality.pyx
@@ -424,7 +424,7 @@ cdef class NeighborQuery:
                 :meth:`matplotlib.axes.Axes.plot`.
 
         Returns:
-            :class:`matplotlib.axes.Axes`: Axis with the plot.
+            :class:`PathCollection`: Axis with the plot.
         """
         import freud.plot
         return freud.plot.system_plot(

--- a/freud/locality.pyx
+++ b/freud/locality.pyx
@@ -424,7 +424,8 @@ cdef class NeighborQuery:
                 :meth:`matplotlib.axes.Axes.plot`.
 
         Returns:
-            :class:`PathCollection`: Axis with the plot.
+            :class:`matplotlib.axes.Axes`: Axis with the plot.
+            :class:`matplotlib.collections.PathCollection`:
         """
         import freud.plot
         return freud.plot.system_plot(

--- a/freud/locality.pyx
+++ b/freud/locality.pyx
@@ -424,8 +424,8 @@ cdef class NeighborQuery:
                 :meth:`matplotlib.axes.Axes.plot`.
 
         Returns:
-            :class:`matplotlib.axes.Axes`: Axis with the plot.
-            :class:`matplotlib.collections.PathCollection`: Point data returned for the plot.
+            tuple (:class:`matplotlib.axes.Axes`, :class:`matplotlib.collections.PathCollection`): 
+                Axis and point data for the plot.
         """
         import freud.plot
         return freud.plot.system_plot(


### PR DESCRIPTION
Changed the documentation in locality.pyx to show the true return value of plot in NeighborQuery class. 

## Description
Changed the documentation in locality.pyx to show the true return value of plot in NeighborQuery class. 

## Motivation and Context

Resolves: #763 

## How Has This Been Tested?
Will write tests if needed later. 

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds or improves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation improvement (updates to user guides, docstrings, or developer docs)

## Checklist:
<!-- Put an `x` in all the boxes that apply. If you're unsure about any of
     these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [**CONTRIBUTING**](https://github.com/glotzerlab/freud/blob/master/CONTRIBUTING.md) document.
- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation (if relevant).
- [ ] I have added tests that cover my changes (if relevant).
- [ ] All new and existing tests passed.
- [ ] I have updated the [credits](https://github.com/glotzerlab/freud/blob/master/doc/source/reference/credits.rst).
- [ ] I have updated the [Changelog](https://github.com/glotzerlab/freud/blob/master/ChangeLog.md).
