### PR TITLE
Fix examples submodule.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,6 +7,6 @@
 [submodule "extern/voro++"]
 	path = extern/voro++
 	url = https://github.com/chr1shr/voro.git
-[submodule "doc/source/examples"]
+[submodule "doc/source/gettingstarted/examples"]
 	path = doc/source/gettingstarted/examples
 	url = https://github.com/glotzerlab/freud-examples.git


### PR DESCRIPTION
## Description
Re-adds the examples submodule that was accidentally removed in #871. This can be merged immediately after ReadTheDocs builds are verified to be working.

The commit introducing the problem is https://github.com/glotzerlab/freud/pull/871/commits/96f168427ed5a2d5a05a8ad95b04cc643dfad8b4

## Motivation and Context
Fixes examples in documentation.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds or improves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation improvement (updates to user guides, docstrings, or developer docs)