### PR TITLE
Apply flake8 rules to only .py files (remove Cython rules).

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -6,10 +6,9 @@ message = Bump up to version {new_version}.
 
 [flake8]
 max-line-length = 88
-filename = *.py,*.pyx,*.pxi,*.pxd
 exclude = .eggs,*.egg,build,extern,doc/source/gettingstarted/examples
 select = E,F,W
-ignore = E203,E225,E226,E227,E741,E999,W503,W504
+ignore = E203,E741,W503
 per-file-ignores = 
 	freud/__init__.py: F401
 


### PR DESCRIPTION
## Description
Changes in flake8 >= 4.0.0 mean that the tool can no longer be applied to Cython files. Previously, we had a list of flake8 rule exceptions that permitted it to parse Cython files. See #884 for details.

## Motivation and Context
Resolves: #884.

## How Has This Been Tested?
Existing tests are sufficient.

## Types of changes
- [x] New feature (non-breaking change which adds or improves functionality)

## Checklist:
- [x] I have read the [**CONTRIBUTING**](https://github.com/glotzerlab/freud/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] I have updated the documentation (if relevant).
- [x] I have added tests that cover my changes (if relevant).
- [x] All new and existing tests passed.
- [ ] I have updated the [credits](https://github.com/glotzerlab/freud/blob/master/doc/source/reference/credits.rst).
- [ ] I have updated the [Changelog](https://github.com/glotzerlab/freud/blob/master/ChangeLog.md).
