### PR TITLE
Remove redundant CI tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,16 +4,6 @@ orbs:
   win: circleci/windows@2.2.0  # Enables Windows executors
 
 references:
-  container_manylinux: &container_manylinux
-    docker:
-      - image: quay.io/pypa/manylinux2010_x86_64
-    working_directory: ~/ci/freud
-
-  container_macos: &container_macos
-    macos:
-      xcode: "12.0.0"
-    working_directory: ~/ci/freud
-
   load_code: &load_code
     checkout
 
@@ -115,15 +105,6 @@ references:
         ${PYTHON} --version
         ${PYTHON} setup.py build_ext --inplace -- -G "Visual Studio 16 2019" -DCOVERAGE=ON
 
-  test: &test
-    run:
-      name: Run unit tests
-      command: |
-        if [ -d "venv" ]; then
-          . venv/bin/activate
-        fi
-        ${PYTHON} -m pytest tests/ -v
-
   test_cov: &test_cov
     run:
       name: Run unit tests with coverage
@@ -181,26 +162,6 @@ references:
       - *get_pre_commit_requirements
       - *pre-test-checks
 
-  build_and_test_linux: &build_and_test_linux
-    working_directory: ~/ci/freud
-    steps:
-      - *load_code
-      - *update_submodules
-      - *get_requirements
-      - *build
-      - *test
-      - *store
-
-  build_and_test_linux_with_cov: &build_and_test_linux_with_cov
-    <<: *build_and_test_linux
-    steps:
-      - *load_code
-      - *update_submodules
-      - *get_requirements
-      - *build
-      - *test_cov
-      - *store
-
   build_and_test_windows: &build_and_test_windows
     executor:
       name: win/default
@@ -231,31 +192,6 @@ jobs:
       PYVER: "3.9"
       PYTHON: "python3.9"
     <<: *load_check_style
-
-  linux-python-39:
-    docker:
-      - image: glotzerlab/ci:2020.10-py39
-    environment:
-      PYVER: "3.9"
-      PYTHON: "python3.9"
-    <<: *build_and_test_linux_with_cov
-
-  linux-python-38:
-    docker:
-      - image: glotzerlab/ci:2020.10-py38
-    environment:
-      PYVER: "3.8"
-      PYTHON: "python3.8"
-    <<: *build_and_test_linux_with_cov
-
-  linux-python-36-oldest:
-    docker:
-      - image: glotzerlab/ci:2020.10-py36
-    environment:
-      PYVER: "3.6"
-      PYTHON: "python3.6"
-      DEPENDENCIES: "OLDEST"
-    <<: *build_and_test_linux
 
   windows-python-310:
     environment:
@@ -296,15 +232,6 @@ workflows:
   test:
     jobs:
       - check-style
-      - linux-python-39
-      - linux-python-38:
-          requires:
-            - check-style
-            - linux-python-39
-      - linux-python-36-oldest:
-          requires:
-            - check-style
-            - linux-python-39
       - windows-python-310
       - windows-python-39:
           requires:

--- a/doc/source/reference/credits.rst
+++ b/doc/source/reference/credits.rst
@@ -326,6 +326,7 @@ Tommy Waltmann
 * Contributed code, design, and testing for ``StaticStructureFactorDirect`` class.
 * Refactor tests for ``StaticStructureFactor`` classes.
 * Improve CMake build system to use more modern style.
+* Remove CI build configurations from CircleCI which were already covered by CIBuildWheel
 
 Maya Martirossyan
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above. -->

## Description
Removing the linux and macos tests from the circleci CI workflow because those environments are already tested via cibuildwheel. This does not remove the windows tests on circleci, since we have not yet ported the windows tests to cibuildwheel.

## Motivation and Context
Resolves: #874 

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds or improves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation improvement (updates to user guides, docstrings, or developer docs)

## Checklist:
<!-- Put an `x` in all the boxes that apply. If you're unsure about any of
     these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/glotzerlab/freud/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] All new and existing tests passed.
- [x] I have updated the [credits](https://github.com/glotzerlab/freud/blob/master/doc/source/reference/credits.rst).
- [ ] I have updated the [Changelog](https://github.com/glotzerlab/freud/blob/master/ChangeLog.md).
