### PR TITLE
Replace deprecated scipy.ndimage.fourier namespace with scipy.ndimage.

### DIFF
--- a/freud/diffraction.pyx
+++ b/freud/diffraction.pyx
@@ -709,7 +709,7 @@ cdef class DiffractionPattern(_Compute):
         # Compute FFT and convolve with Gaussian
         cdef double complex[:, :] diffraction_fft
         diffraction_fft = np.fft.fft2(im)
-        diffraction_fft = scipy.ndimage.fourier.fourier_gaussian(
+        diffraction_fft = scipy.ndimage.fourier_gaussian(
             diffraction_fft, peak_width / zoom)
         diffraction_fft = np.fft.fftshift(diffraction_fft)
 


### PR DESCRIPTION
## Description
The scipy package has adjusted its public namespaces to make names more clear in [release 1.8.0](https://github.com/scipy/scipy/releases/tag/v1.8.0). This PR adjusts the one instance I saw in freud's codebase that would raise a `DeprecationWarning` for scipy >= 1.8.0.  I verified that this namespace change is compatible with our minimal requirement of scipy 1.1.0.

## Motivation and Context
See: https://github.com/scipy/scipy/issues/14360

## How Has This Been Tested?
Existing tests are sufficient.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds or improves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation improvement (updates to user guides, docstrings, or developer docs)

## Checklist:
- [x] I have read the [**CONTRIBUTING**](https://github.com/glotzerlab/freud/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] I have updated the documentation (if relevant).
- [ ] I have added tests that cover my changes (if relevant).
- [x] All new and existing tests passed.
- [ ] I have updated the [credits](https://github.com/glotzerlab/freud/blob/master/doc/source/reference/credits.rst).
- [ ] I have updated the [Changelog](https://github.com/glotzerlab/freud/blob/master/ChangeLog.md).
