### PR TITLE
Update Black

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,7 +39,7 @@ repos:
     hooks:
       - id: isort
   - repo: https://github.com/psf/black
-    rev: '21.12b0'
+    rev: '22.3.0'
     hooks:
       - id: black
   - repo: https://github.com/PyCQA/flake8

--- a/tests/test_density_LocalDensity.py
+++ b/tests/test_density_LocalDensity.py
@@ -82,7 +82,7 @@ class TestLocalDensity:
         diameter = 1
         r_max = 2
 
-        v_around = 4 / 3 * (r_max ** 3) * np.pi
+        v_around = 4 / 3 * (r_max**3) * np.pi
 
         ld = freud.density.LocalDensity(r_max, diameter)
         ld.compute((box, points), query_points)

--- a/tests/test_density_RDF.py
+++ b/tests/test_density_RDF.py
@@ -109,7 +109,7 @@ class TestRDF:
             bin_boundaries = np.array(
                 [r_min + dr * i for i in range(bins + 1) if r_min + dr * i <= r_max]
             )
-            bin_volumes = 4 / 3 * np.pi * np.diff(bin_boundaries ** 3)
+            bin_volumes = 4 / 3 * np.pi * np.diff(bin_boundaries**3)
             avg_counts = rdf.rdf * ndens * bin_volumes
             npt.assert_allclose(rdf.n_r, np.cumsum(avg_counts), rtol=tolerance)
 

--- a/tests/test_environment_LocalDescriptors.py
+++ b/tests/test_environment_LocalDescriptors.py
@@ -29,7 +29,7 @@ def get_ql(p, descriptors, nlist, weighted=False):
     ql = np.zeros((qbar_lm.shape[0], descriptors.l_max + 1))
     for i in range(ql.shape[0]):
         for l in range(ql.shape[1]):
-            for k in range(l ** 2, (l + 1) ** 2):
+            for k in range(l**2, (l + 1) ** 2):
                 ql[i, l] += np.absolute(qbar_lm[i, k]) ** 2
             ql[i, l] = np.sqrt(4 * np.pi / (2 * l + 1) * ql[i, l])
 
@@ -37,7 +37,7 @@ def get_ql(p, descriptors, nlist, weighted=False):
 
 
 def lm_index(l, m):
-    return l ** 2 + (m if m >= 0 else l - m)
+    return l**2 + (m if m >= 0 else l - m)
 
 
 @lru_cache(maxsize=None)
@@ -129,7 +129,7 @@ class TestLocalDescriptors:
 
         box, positions = freud.data.make_random_system(L, N)
         orientations = np.random.uniform(-1, 1, size=(N, 4)).astype(np.float32)
-        orientations /= np.sqrt(np.sum(orientations ** 2, axis=-1))[:, np.newaxis]
+        orientations /= np.sqrt(np.sum(orientations**2, axis=-1))[:, np.newaxis]
 
         comp = freud.environment.LocalDescriptors(l_max, True, mode="particle_local")
 

--- a/tests/test_locality_NeighborQuery.py
+++ b/tests/test_locality_NeighborQuery.py
@@ -387,9 +387,9 @@ class NeighborQueryTest:
             all_vectors = box.wrap(all_vectors.reshape((-1, 3))).reshape(
                 all_vectors.shape
             )
-            all_rsqs = np.sum(all_vectors ** 2, axis=-1)
+            all_rsqs = np.sum(all_vectors**2, axis=-1)
             (exhaustive_i, exhaustive_j) = np.where(
-                np.logical_and(all_rsqs < r_max ** 2, all_rsqs > 0)
+                np.logical_and(all_rsqs < r_max**2, all_rsqs > 0)
             )
 
             exhaustive_ijs = set(zip(exhaustive_i, exhaustive_j))
@@ -430,9 +430,9 @@ class NeighborQueryTest:
             all_vectors = box.wrap(all_vectors.reshape((-1, 3))).reshape(
                 all_vectors.shape
             )
-            all_rsqs = np.sum(all_vectors ** 2, axis=-1)
+            all_rsqs = np.sum(all_vectors**2, axis=-1)
             (exhaustive_i, exhaustive_j) = np.where(
-                np.logical_and(all_rsqs < r_max ** 2, all_rsqs > 0)
+                np.logical_and(all_rsqs < r_max**2, all_rsqs > 0)
             )
 
             exhaustive_ijs = set(zip(exhaustive_i, exhaustive_j))

--- a/tests/test_pmft.py
+++ b/tests/test_pmft.py
@@ -25,7 +25,7 @@ def build_radii(bin_centers):
         sl = tuple(
             slice(None, None, None) if i == j else None for j in range(len(bin_centers))
         )
-        radii += (centers ** 2)[sl]
+        radii += (centers**2)[sl]
     return np.sqrt(radii)
 
 
@@ -161,7 +161,7 @@ class PMFTTestBase:
 
         def get_pmft_bydist(r_max, nbins):
             """Get a PMFT with a specified radial cutoff."""
-            limit = np.sqrt(r_max ** 2 / self.ndim)
+            limit = np.sqrt(r_max**2 / self.ndim)
             return self.pmft_cls(*(limit,) * len(self.limits), bins=nbins)
 
         L = 10
@@ -325,7 +325,7 @@ class TestPMFTXYT(PMFT2DTestBase):
         orientations = np.array([0] * len(points))
         query_orientations = np.array([0] * len(query_points))
 
-        r_max = np.sqrt(x_max ** 2 + y_max ** 2)
+        r_max = np.sqrt(x_max**2 + y_max**2)
         test_set = util.make_raw_query_nlist_test_set(
             box, points, query_points, "ball", r_max, 0, False
         )
@@ -435,7 +435,7 @@ class TestPMFTXY(PMFT2DTestBase):
 
         query_orientations = np.array([0] * len(query_points))
 
-        r_max = np.sqrt(x_max ** 2 + y_max ** 2)
+        r_max = np.sqrt(x_max**2 + y_max**2)
         test_set = util.make_raw_query_nlist_test_set(
             box, points, query_points, "ball", r_max, 0, False
         )


### PR DESCRIPTION
## Description
This PR bumps the version of black we use in our pre-commit CI checks.

The newer version of black appears to enforce one new syntax change, being that the `**` syntax for exponentials no longer has spaces between the base and the power it's being taken to.

## Motivation and Context
Black 22.1.0 cannot import a module from the click package, causing our `pre-commit` CI to fail. A full description and solution to the issue with black is located at https://github.com/psf/black/issues/2964

We therefore now use a newer version of black (22.3.0). Another option proposed on the issue is to use black 22.1.0 and explicitly pin the click dependency to version 8.0.4

## How Has This Been Tested?
If the pre-commit CI tests pass now, we are good to go.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds or improves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation improvement (updates to user guides, docstrings, or developer docs)

## Checklist:
<!-- Put an `x` in all the boxes that apply. If you're unsure about any of
     these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [**CONTRIBUTING**](https://github.com/glotzerlab/freud/blob/master/CONTRIBUTING.md) document.
- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation (if relevant).
- [ ] I have added tests that cover my changes (if relevant).
- [ ] All new and existing tests passed.
- [ ] I have updated the [credits](https://github.com/glotzerlab/freud/blob/master/doc/source/reference/credits.rst).
- [ ] I have updated the [Changelog](https://github.com/glotzerlab/freud/blob/master/ChangeLog.md).
