### PR TITLE
Update Name of Debye Properties

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,14 @@ The format is based on
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## vX.Y.Z -- XXXX-XX-XX
+
+### Added
+* (breaking) Some `freud.diffraction.StaticStructureFactorDebye` property names changed to be more descriptive.
+
+### Fixed
+* `freud.diffraction.StaticStructureFactorDebye` implementation now gives `S_k[0] = N`.
+
 ## v2.8.0 -- 2022-01-25
 
 ### Added

--- a/doc/source/reference/credits.rst
+++ b/doc/source/reference/credits.rst
@@ -326,7 +326,9 @@ Tommy Waltmann
 * Contributed code, design, and testing for ``StaticStructureFactorDirect`` class.
 * Refactor tests for ``StaticStructureFactor`` classes.
 * Improve CMake build system to use more modern style.
-* Remove CI build configurations from CircleCI which were already covered by CIBuildWheel
+* Remove CI build configurations from CircleCI which were already covered by CIBuildWheel.
+* Change property names in ``StaticStructureFactorDebye`` class.
+* Reformat static structure factor tests.
 
 Maya Martirossyan
 

--- a/freud/diffraction.pyx
+++ b/freud/diffraction.pyx
@@ -167,7 +167,7 @@ cdef class StaticStructureFactorDebye(_StaticStructureFactor):
 
             >>> box, points = freud.data.make_random_system(10, 100, seed=0)
             >>> sf = freud.diffraction.StaticStructureFactorDebye(
-            ...     bins=100, k_max=10, k_min=0
+            ...     num_k_values=100, k_max=10, k_min=0
             ... )
             >>> sf.compute((box, points))
             freud.diffraction.StaticStructureFactorDebye(...)
@@ -182,7 +182,7 @@ cdef class StaticStructureFactorDebye(_StaticStructureFactor):
             >>> A_points = points[:N_particles//2]
             >>> B_points = points[N_particles//2:]
             >>> sf = freud.diffraction.StaticStructureFactorDebye(
-            ...     bins=100, k_max=10, k_min=0
+            ...     num_k_values=100, k_max=10, k_min=0
             ... )
             >>> sf.compute(
             ...     system=(box, A_points),

--- a/freud/diffraction.pyx
+++ b/freud/diffraction.pyx
@@ -258,10 +258,10 @@ cdef class StaticStructureFactorDebye(_StaticStructureFactor):
         return self.thisptr.getMinValidK()
 
     def __repr__(self):
-        return ("freud.diffraction.{cls}(num_k_points={num_k_points}, "
+        return ("freud.diffraction.{cls}(num_k_values={num_k_values}, "
                 "k_max={k_max}, k_min={k_min})").format(
                     cls=type(self).__name__,
-                    num_k_points=self.num_k_points,
+                    num_k_values=self.num_k_values,
                     k_max=self.k_max,
                     k_min=self.k_min)
 

--- a/freud/diffraction.pyx
+++ b/freud/diffraction.pyx
@@ -51,16 +51,6 @@ cdef class _StaticStructureFactor(_Compute):
             freud.util.arr_type_t.FLOAT)
 
     @property
-    def bin_centers(self):
-        """:class:`numpy.ndarray`: The centers of each bin of :math:`k`."""
-        return np.array(self.ssfptr.getBinCenters(), copy=True)
-
-    @property
-    def nbins(self):
-        """int: The number of bins in the histogram."""
-        return len(self.bin_centers)
-
-    @property
     def k_max(self):
         """float: Maximum value of k at which to calculate the structure
         factor."""
@@ -75,29 +65,6 @@ cdef class _StaticStructureFactor(_Compute):
     @_Compute._computed_property
     def min_valid_k(self):
         return self.ssfptr.getMinValidK()
-
-    def plot(self, ax=None, **kwargs):
-        r"""Plot static structure factor.
-
-        .. note::
-            This function plots :math:`S(k)` for values above
-            :py:attr:`min_valid_k`.
-
-        Args:
-            ax (:class:`matplotlib.axes.Axes`, optional): Axis to plot on. If
-                :code:`None`, make a new figure and axis.
-                (Default value = :code:`None`)
-
-        Returns:
-            (:class:`matplotlib.axes.Axes`): Axis with the plot.
-        """
-        import freud.plot
-        return freud.plot.line_plot(self.bin_centers[self.bin_centers>self.min_valid_k],
-                                    self.S_k[self.bin_centers>self.min_valid_k],
-                                    title="Static Structure Factor",
-                                    xlabel=r"$k$",
-                                    ylabel=r"$S(k)$",
-                                    ax=ax)
 
     def _repr_png_(self):
         try:
@@ -129,12 +96,9 @@ cdef class StaticStructureFactorDebye(_StaticStructureFactor):
     <https://en.wikipedia.org/wiki/Structure_factor>`__. For a full derivation
     see :cite:`Farrow2009`. Note that the definition requires :math:`S(0) = N`.
 
-    This implementation uses ``k_min`` and ``k_max`` as bin *centers*, instead
-    of lower / upper bin *edges*, because the Debye formula is evaluated at
-    these bin centers. For this reason, this class does not expose a
-    ``bin_edges`` property like most histogram-like classes in freud. This also
-    means that if ``k_min`` is set to 0, the computed structure factor will
-    show :math:`S(0) = N`.
+    This implementation uses an evenly spaced number of :math:`k` points between
+    `k_min`` and ``k_max``. If ``k_min`` is set to 0 (the default behavior), the
+    computed structure factor will show :math:`S(0) = N`.
 
     The Debye implementation provides a much faster algorithm, but gives worse
     results than :py:attr:`freud.diffraction.StaticStructureFactorDirect`
@@ -156,8 +120,8 @@ cdef class StaticStructureFactorDebye(_StaticStructureFactor):
         N_{\beta}}{N_{total}^2} \left(S_{\alpha \beta}(k) - 1\right)
 
     Args:
-        bins (unsigned int):
-            Number of bins in :math:`k` space.
+        num_k_values (unsigned int):
+            Number of values to use in :math:`k` space.
         k_max (float):
             Maximum :math:`k` value to include in the calculation.
         k_min (float, optional):
@@ -168,10 +132,10 @@ cdef class StaticStructureFactorDebye(_StaticStructureFactor):
     """
     cdef freud._diffraction.StaticStructureFactorDebye * thisptr
 
-    def __cinit__(self, unsigned int bins, float k_max, float k_min=0):
+    def __cinit__(self, unsigned int num_k_values, float k_max, float k_min=0):
         if type(self) == StaticStructureFactorDebye:
             self.thisptr = self.ssfptr = new \
-                freud._diffraction.StaticStructureFactorDebye(bins,
+                freud._diffraction.StaticStructureFactorDebye(num_k_values,
                                                               k_max,
                                                               k_min)
 
@@ -180,11 +144,21 @@ cdef class StaticStructureFactorDebye(_StaticStructureFactor):
             del self.thisptr
 
     @property
+    def num_k_values(self):
+        """int: The number of k values used."""
+        return len(self.k_values)
+
+    @property
+    def k_values(self):
+        """:class:`numpy.ndarray`: The :math:`k` values for the calculation."""
+        return np.array(self.ssfptr.getBinCenters(), copy=True)
+
+    @property
     def bounds(self):
-        """tuple: A tuple indicating upper and lower bounds of the
-        histogram."""
-        bin_centers = self.bin_centers
-        return (bin_centers[0], bin_centers[len(bin_centers)-1])
+        """tuple: A tuple indicating the smallest and largest :math:`k` values
+        used."""
+        k_values = self.k_values
+        return (k_values[0], k_values[len(k_values)-1])
 
     def compute(self, system, query_points=None, N_total=None, reset=True):
         r"""Computes static structure factor.
@@ -284,12 +258,35 @@ cdef class StaticStructureFactorDebye(_StaticStructureFactor):
         return self.thisptr.getMinValidK()
 
     def __repr__(self):
-        return ("freud.diffraction.{cls}(bins={bins}, "
+        return ("freud.diffraction.{cls}(num_k_points={num_k_points}, "
                 "k_max={k_max}, k_min={k_min})").format(
                     cls=type(self).__name__,
-                    bins=self.nbins,
+                    num_k_points=self.num_k_points,
                     k_max=self.k_max,
                     k_min=self.k_min)
+
+    def plot(self, ax=None, **kwargs):
+        r"""Plot static structure factor.
+
+        .. note::
+            This function plots :math:`S(k)` for values above
+            :py:attr:`min_valid_k`.
+
+        Args:
+            ax (:class:`matplotlib.axes.Axes`, optional): Axis to plot on. If
+                :code:`None`, make a new figure and axis.
+                (Default value = :code:`None`)
+
+        Returns:
+            (:class:`matplotlib.axes.Axes`): Axis with the plot.
+        """
+        import freud.plot
+        return freud.plot.line_plot(self.k_values[self.k_values>self.min_valid_k],
+                                    self.S_k[self.k_values>self.min_valid_k],
+                                    title="Static Structure Factor",
+                                    xlabel=r"$k$",
+                                    ylabel=r"$S(k)$",
+                                    ax=ax)
 
 
 cdef class StaticStructureFactorDirect(_StaticStructureFactor):
@@ -370,9 +367,19 @@ cdef class StaticStructureFactorDirect(_StaticStructureFactor):
             del self.thisptr
 
     @property
+    def nbins(self):
+        """float: Number of bins in the histogram."""
+        return len(self.bin_centers)
+
+    @property
     def bin_edges(self):
         """:class:`numpy.ndarray`: The edges of each bin of :math:`k`."""
         return np.array(self.ssfptr.getBinEdges(), copy=True)
+
+    @property
+    def bin_centers(self):
+        """:class:`numpy.ndarray`: The centers of each bin of :math:`k`."""
+        return np.array(self.ssfptr.getBinCenters(), copy=True)
 
     @property
     def bounds(self):
@@ -503,6 +510,29 @@ cdef class StaticStructureFactorDirect(_StaticStructureFactor):
                     k_max=self.k_max,
                     k_min=self.k_min,
                     num_sampled_k_points=self.num_sampled_k_points)
+
+    def plot(self, ax=None, **kwargs):
+        r"""Plot static structure factor.
+
+        .. note::
+            This function plots :math:`S(k)` for values above
+            :py:attr:`min_valid_k`.
+
+        Args:
+            ax (:class:`matplotlib.axes.Axes`, optional): Axis to plot on. If
+                :code:`None`, make a new figure and axis.
+                (Default value = :code:`None`)
+
+        Returns:
+            (:class:`matplotlib.axes.Axes`): Axis with the plot.
+        """
+        import freud.plot
+        return freud.plot.line_plot(self.bin_centers[self.bin_centers>self.min_valid_k],
+                                    self.S_k[self.bin_centers>self.min_valid_k],
+                                    title="Static Structure Factor",
+                                    xlabel=r"$k$",
+                                    ylabel=r"$S(k)$",
+                                    ax=ax)
 
 
 cdef class DiffractionPattern(_Compute):

--- a/tests/test_diffraction_StaticStructureFactor.py
+++ b/tests/test_diffraction_StaticStructureFactor.py
@@ -131,15 +131,22 @@ class StaticStructureFactorTest:
         sf.compute(system)
         npt.assert_allclose(np.mean(sf.S_k), 1, rtol=1e-5, atol=2e-2)
 
+    ATTRIBUTE_ACCESS_PARAMS = dict(bins=100,
+                                   k_max=123,
+                                   k_min=0.1,
+                                   num_sampled_k_points=10000)
+
     def test_attribute_access(self):
-        bins = 100
-        k_max = 123
-        k_min = 0.1
-        num_sampled_k_points = 10000
+        bins = self.ATTRIBUTE_ACCESS_PARAMS['bins']
+        k_max = self.ATTRIBUTE_ACCESS_PARAMS['k_max']
+        k_min = self.ATTRIBUTE_ACCESS_PARAMS['k_min']
+        num_sampled_k_points = self.ATTRIBUTE_ACCESS_PARAMS['num_sampled_k_points']
+
         sf = self.build_structure_factor_object(
             bins, k_max, k_min, num_sampled_k_points
         )
-        assert sf.nbins == bins
+
+        # only test common attribute in the super implementation
         assert np.isclose(sf.k_max, k_max)
         assert np.isclose(sf.k_min, k_min)
         if hasattr(sf, "num_sampled_k_points"):
@@ -268,6 +275,20 @@ class TestStaticStructureFactorDebye(StaticStructureFactorTest):
     LARGE_K_PARAMS = {"bins": 5, "k_max": 1e6, "k_min": 1e5}
     DEBYE = True
 
+    def test_attribute_access(self):
+        super().test_attribute_access()
+
+        bins = self.ATTRIBUTE_ACCESS_PARAMS['bins']
+        k_max = self.ATTRIBUTE_ACCESS_PARAMS['k_max']
+        k_min = self.ATTRIBUTE_ACCESS_PARAMS['k_min']
+        num_sampled_k_points = self.ATTRIBUTE_ACCESS_PARAMS['num_sampled_k_points']
+
+        sf = self.build_structure_factor_object(
+            bins, k_max, k_min, num_sampled_k_points
+        )
+
+        assert sf.num_k_values == bins
+
     @classmethod
     def build_structure_factor_object(
         cls, bins, k_max, k_min=0, num_sampled_k_points=None
@@ -318,7 +339,7 @@ class TestStaticStructureFactorDebye(StaticStructureFactorTest):
         system = freud.locality.NeighborQuery.from_system((box, points))
         sf.compute(system)
         Q, S = self._validate_debye_method(system, bins, k_max, k_min)
-        npt.assert_allclose(sf.bin_centers, Q, rtol=1e-5, atol=1e-5)
+        npt.assert_allclose(sf.k_values, Q, rtol=1e-5, atol=1e-5)
         npt.assert_allclose(sf.S_k, S, rtol=1e-5, atol=1e-5)
 
     def test_debye_ase(self):
@@ -342,7 +363,7 @@ class TestStaticStructureFactorDebye(StaticStructureFactorTest):
             atoms=atoms, wavelength=1.0, method=None, damping=0.0, alpha=1.0
         )
         # calculate S_k for given set of k values
-        S_ase = xrd.calc_pattern(sf.bin_centers, mode="SAXS") / len(points)
+        S_ase = xrd.calc_pattern(sf.k_values, mode="SAXS") / len(points)
         npt.assert_allclose(sf.S_k, S_ase, rtol=1e-5, atol=1e-5)
 
 
@@ -354,6 +375,22 @@ class TestStaticStructureFactorDirect(StaticStructureFactorTest):
         "k_min": 400,
         "num_sampled_k_points": 200000,
     }
+
+    def test_attribute_access(self):
+        super().test_attribute_access()
+
+        bins = self.ATTRIBUTE_ACCESS_PARAMS['bins']
+        k_max = self.ATTRIBUTE_ACCESS_PARAMS['k_max']
+        k_min = self.ATTRIBUTE_ACCESS_PARAMS['k_min']
+        num_sampled_k_points = self.ATTRIBUTE_ACCESS_PARAMS['num_sampled_k_points']
+
+        sf = self.build_structure_factor_object(
+            bins, k_max, k_min, num_sampled_k_points
+        )
+
+        assert sf.num_sampled_k_points == num_sampled_k_points
+        with pytest.raises(AttributeError):
+            sf.k_points
 
     @classmethod
     def build_structure_factor_object(

--- a/tests/test_diffraction_StaticStructureFactor.py
+++ b/tests/test_diffraction_StaticStructureFactor.py
@@ -170,35 +170,10 @@ class StaticStructureFactorTest:
         sf.compute((box2, positions2))
         assert not np.array_equal(sf.S_k, S_k)
 
-    @pytest.mark.skipif(
-        NumpyVersion(np.__version__) < "1.15.0", reason="Requires numpy>=1.15.0."
-    )
-    def test_bin_precision(self):
-        # Ensure bin edges and bounds are precise
-        bins = 100
-        k_max = 123
-        k_min = 0.1
-        num_sampled_k_points = 10000
-        sf = self.build_structure_factor_object(
-            bins, k_max, k_min, num_sampled_k_points
-        )
-        if self.DEBYE:
-            expected_bin_centers = np.linspace(k_min, k_max, bins)
-        else:
-            expected_bin_edges = np.histogram_bin_edges(
-                np.array([0], dtype=np.float32), bins=bins, range=[k_min, k_max]
-            )
-            npt.assert_allclose(sf.bin_edges, expected_bin_edges, rtol=1e-5, atol=1e-5)
-            expected_bin_centers = (
-                expected_bin_edges[:-1] + expected_bin_edges[1:]
-            ) / 2
-        npt.assert_allclose(sf.bin_centers, expected_bin_centers, rtol=1e-5, atol=1e-5)
-        npt.assert_allclose(
-            sf.bounds,
-            ([k_min, k_max]),
-            atol=1e-5,
-            rtol=1e-5,
-        )
+    BIN_PRECISION_PARAMS = dict(bins=100,
+                                k_max=123,
+                                k_min=0.1,
+                                num_sampled_k_points=10000)
 
     def test_min_valid_k(self):
         Lx = 10
@@ -288,6 +263,25 @@ class TestStaticStructureFactorDebye(StaticStructureFactorTest):
         )
 
         assert sf.num_k_values == bins
+
+    def test_bin_precision(self):
+        # Ensure bin edges and bounds are precise
+        bins = self.BIN_PRECISION_PARAMS["bins"]
+        k_max = self.BIN_PRECISION_PARAMS["k_max"]
+        k_min = self.BIN_PRECISION_PARAMS["k_min"]
+        num_sampled_k_points = self.BIN_PRECISION_PARAMS["num_sampled_k_points"]
+
+        sf = self.build_structure_factor_object(
+            bins, k_max, k_min, num_sampled_k_points
+        )
+        expected_k_values = np.linspace(k_min, k_max, bins)
+        npt.assert_allclose(sf.k_values, expected_k_values, rtol=1e-5, atol=1e-5)
+        npt.assert_allclose(
+            sf.bounds,
+            ([k_min, k_max]),
+            atol=1e-5,
+            rtol=1e-5,
+        )
 
     @classmethod
     def build_structure_factor_object(
@@ -391,6 +385,34 @@ class TestStaticStructureFactorDirect(StaticStructureFactorTest):
         assert sf.num_sampled_k_points == num_sampled_k_points
         with pytest.raises(AttributeError):
             sf.k_points
+
+    @pytest.mark.skipif(
+        NumpyVersion(np.__version__) < "1.15.0", reason="Requires numpy>=1.15.0."
+    )
+    def test_bin_precision(self):
+        # Ensure bin edges and bounds are precise
+        bins = self.BIN_PRECISION_PARAMS["bins"]
+        k_max = self.BIN_PRECISION_PARAMS["k_max"]
+        k_min = self.BIN_PRECISION_PARAMS["k_min"]
+        num_sampled_k_points = self.BIN_PRECISION_PARAMS["num_sampled_k_points"]
+
+        sf = self.build_structure_factor_object(
+            bins, k_max, k_min, num_sampled_k_points
+        )
+        expected_bin_edges = np.histogram_bin_edges(
+            np.array([0], dtype=np.float32), bins=bins, range=[k_min, k_max]
+        )
+        npt.assert_allclose(sf.bin_edges, expected_bin_edges, rtol=1e-5, atol=1e-5)
+        expected_bin_centers = (
+            expected_bin_edges[:-1] + expected_bin_edges[1:]
+        ) / 2
+        npt.assert_allclose(sf.bin_centers, expected_bin_centers, rtol=1e-5, atol=1e-5)
+        npt.assert_allclose(
+            sf.bounds,
+            ([k_min, k_max]),
+            atol=1e-5,
+            rtol=1e-5,
+        )
 
     @classmethod
     def build_structure_factor_object(

--- a/tests/test_diffraction_StaticStructureFactor.py
+++ b/tests/test_diffraction_StaticStructureFactor.py
@@ -15,7 +15,7 @@ def _sf_params():
     return params_list
 
 
-@pytest.fixture(scope='module', params=_sf_params())
+@pytest.fixture(scope="module", params=_sf_params())
 def sf_params(request):
     """tuple: bins, k_max, k_min, num_sampled_k_points."""
     return request.param
@@ -30,14 +30,13 @@ def _sf_params_kmin_zero():
     return params_list
 
 
-@pytest.fixture(scope='module', params=_sf_params_kmin_zero())
+@pytest.fixture(scope="module", params=_sf_params_kmin_zero())
 def sf_params_kmin_zero(request):
     """tuple: bins, k_max, k_min=0, num_sampled_k_points."""
     return request.param
 
 
 class StaticStructureFactorTest:
-
     @classmethod
     def build_structure_factor_object(
         cls, bins, k_max, k_min=0, num_sampled_k_points=None
@@ -224,7 +223,6 @@ class StaticStructureFactorTest:
 
 
 class TestStaticStructureFactorDebye(StaticStructureFactorTest):
-
     @pytest.fixture
     def large_k_params(self):
         """tuple: bins, k_max, k_min."""
@@ -250,8 +248,10 @@ class TestStaticStructureFactorDebye(StaticStructureFactorTest):
         system = freud.AABBQuery.from_system((box, points))
         sf1.compute(system)
         sf2.compute(system)
-        npt.assert_allclose(sf1.k_values[bins // 2:], sf2.k_values, rtol=1e-6, atol=1e-6)
-        npt.assert_allclose(sf1.S_k[bins // 2:], sf2.S_k, rtol=1e-6, atol=1e-6)
+        npt.assert_allclose(
+            sf1.k_values[bins // 2 :], sf2.k_values, rtol=1e-6, atol=1e-6
+        )
+        npt.assert_allclose(sf1.S_k[bins // 2 :], sf2.S_k, rtol=1e-6, atol=1e-6)
 
     def test_attribute_access(self, sf_params):
         """Ensure parameters are initialized properly."""
@@ -359,7 +359,6 @@ class TestStaticStructureFactorDebye(StaticStructureFactorTest):
 
 
 class TestStaticStructureFactorDirect(StaticStructureFactorTest):
-
     @pytest.fixture
     def large_k_params(self):
         """tuple: bins, k_max, k_min, num_sampled_k_points."""
@@ -379,9 +378,13 @@ class TestStaticStructureFactorDirect(StaticStructureFactorTest):
         system = freud.AABBQuery.from_system((box, points))
         sf1.compute(system)
         sf2.compute(system)
-        npt.assert_allclose(sf1.bin_centers[bins // 2:], sf2.bin_centers, rtol=1e-6, atol=1e-6)
-        npt.assert_allclose(sf1.bin_edges[bins // 2:], sf2.bin_edges, rtol=1e-6, atol=1e-6)
-        npt.assert_allclose(sf1.S_k[bins // 2:], sf2.S_k, rtol=1e-6, atol=1e-6)
+        npt.assert_allclose(
+            sf1.bin_centers[bins // 2 :], sf2.bin_centers, rtol=1e-6, atol=1e-6
+        )
+        npt.assert_allclose(
+            sf1.bin_edges[bins // 2 :], sf2.bin_edges, rtol=1e-6, atol=1e-6
+        )
+        npt.assert_allclose(sf1.S_k[bins // 2 :], sf2.S_k, rtol=1e-6, atol=1e-6)
 
     def test_attribute_access(self, sf_params):
         """Ensure parameters are initialized properly."""
@@ -404,9 +407,7 @@ class TestStaticStructureFactorDirect(StaticStructureFactorTest):
             np.array([0], dtype=np.float32), bins=bins, range=[k_min, k_max]
         )
         npt.assert_allclose(sf.bin_edges, expected_bin_edges, rtol=1e-5, atol=1e-5)
-        expected_bin_centers = (
-            expected_bin_edges[:-1] + expected_bin_edges[1:]
-        ) / 2
+        expected_bin_centers = (expected_bin_edges[:-1] + expected_bin_edges[1:]) / 2
         npt.assert_allclose(sf.bin_centers, expected_bin_centers, rtol=1e-5, atol=1e-5)
         npt.assert_allclose(
             sf.bounds,

--- a/tests/test_diffraction_StaticStructureFactor.py
+++ b/tests/test_diffraction_StaticStructureFactor.py
@@ -19,6 +19,16 @@ class StaticStructureFactorTest:
         # bins must be an even number
         return 10, 100, 100, 10
 
+    @pytest.fixture
+    def bin_precision_params(self):
+        """tuple: bins, k_max, k_min, num_sampled_k_points"""
+        return 100, 123, 0.1, 1e4
+
+    @pytest.fixture
+    def attribute_shape_params(self):
+        """tuple: bins, k_max, k_min, num_sampled_k_points."""
+        return 100, 123, 0.456, 1e4
+
     @classmethod
     def build_structure_factor_object(
         cls, bins, k_max, k_min=0, num_sampled_k_points=None
@@ -147,11 +157,6 @@ class StaticStructureFactorTest:
         sf.compute((box2, positions2))
         assert not np.array_equal(sf.S_k, S_k)
 
-    BIN_PRECISION_PARAMS = dict(bins=100,
-                                k_max=123,
-                                k_min=0.1,
-                                num_sampled_k_points=10000)
-
     def test_min_valid_k(self):
         Lx = 10
         Ly = 8
@@ -171,20 +176,10 @@ class StaticStructureFactorTest:
         sf.compute((box, points))
         assert np.isclose(sf.min_valid_k, min_valid_k)
 
-    ATTRIBUTE_SHAPE_PARAMS = dict(bins=100,
-                                  k_max=123,
-                                  k_min=0.456,
-                                  num_sampled_k_points=10000)
+    def test_attribute_shapes(self, attribute_shape_params):
+        bins, k_max, k_min, num_sampled_k_points = attribute_shape_params
 
-    def test_attribute_shapes(self):
-        bins = self.ATTRIBUTE_SHAPE_PARAMS["bins"]
-        k_max = self.ATTRIBUTE_SHAPE_PARAMS["k_max"]
-        k_min = self.ATTRIBUTE_SHAPE_PARAMS["k_min"]
-        num_sampled_k_points = self.ATTRIBUTE_SHAPE_PARAMS["num_sampled_k_points"]
-
-        sf = self.build_structure_factor_object(
-            bins, k_max, k_min, num_sampled_k_points
-        )
+        sf = self.build_structure_factor_object(*attribute_shape_params)
 
         # only test the common attributes in the super implementation
         npt.assert_allclose(sf.bounds, (k_min, k_max), rtol=1e-5, atol=1e-5)
@@ -243,6 +238,7 @@ class TestStaticStructureFactorDebye(StaticStructureFactorTest):
         super().test_k_min(k_min_params)
 
         L, N, bins, k_max = k_min_params
+        bins = bins + 1
         upper_bins = bins // 2 + 1
         k_min = k_max / 2
 
@@ -262,16 +258,10 @@ class TestStaticStructureFactorDebye(StaticStructureFactorTest):
         sf = self.build_structure_factor_object(*attribute_access_params)
         assert sf.num_k_values == bins
 
-    def test_bin_precision(self):
-        # Ensure bin edges and bounds are precise
-        bins = self.BIN_PRECISION_PARAMS["bins"]
-        k_max = self.BIN_PRECISION_PARAMS["k_max"]
-        k_min = self.BIN_PRECISION_PARAMS["k_min"]
-        num_sampled_k_points = self.BIN_PRECISION_PARAMS["num_sampled_k_points"]
-
-        sf = self.build_structure_factor_object(
-            bins, k_max, k_min, num_sampled_k_points
-        )
+    def test_bin_precision(self, bin_precision_params):
+        """Ensure bin edges and bounds are precise."""
+        bins, k_max, k_min, num_sampled_k_points = bin_precision_params
+        sf = self.build_structure_factor_object(*bin_precision_params)
         expected_k_values = np.linspace(k_min, k_max, bins)
         npt.assert_allclose(sf.k_values, expected_k_values, rtol=1e-5, atol=1e-5)
         npt.assert_allclose(
@@ -281,17 +271,11 @@ class TestStaticStructureFactorDebye(StaticStructureFactorTest):
             rtol=1e-5,
         )
 
-    def test_attribute_shapes(self):
-        super().test_attribute_shapes()
+    def test_attribute_shapes(self, attribute_shape_params):
+        super().test_attribute_shapes(attribute_shape_params)
 
-        bins = self.ATTRIBUTE_SHAPE_PARAMS["bins"]
-        k_max = self.ATTRIBUTE_SHAPE_PARAMS["k_max"]
-        k_min = self.ATTRIBUTE_SHAPE_PARAMS["k_min"]
-        num_sampled_k_points = self.ATTRIBUTE_SHAPE_PARAMS["num_sampled_k_points"]
-
-        sf = self.build_structure_factor_object(
-            bins, k_max, k_min, num_sampled_k_points
-        )
+        bins, k_max, k_min, num_sampled_k_points = attribute_shape_params
+        sf = self.build_structure_factor_object(*attribute_shape_params)
 
         assert sf.k_values.shape == (bins,)
 
@@ -409,16 +393,10 @@ class TestStaticStructureFactorDirect(StaticStructureFactorTest):
     @pytest.mark.skipif(
         NumpyVersion(np.__version__) < "1.15.0", reason="Requires numpy>=1.15.0."
     )
-    def test_bin_precision(self):
-        # Ensure bin edges and bounds are precise
-        bins = self.BIN_PRECISION_PARAMS["bins"]
-        k_max = self.BIN_PRECISION_PARAMS["k_max"]
-        k_min = self.BIN_PRECISION_PARAMS["k_min"]
-        num_sampled_k_points = self.BIN_PRECISION_PARAMS["num_sampled_k_points"]
-
-        sf = self.build_structure_factor_object(
-            bins, k_max, k_min, num_sampled_k_points
-        )
+    def test_bin_precision(self, bin_precision_params):
+        """Ensure bin edges and bounds are precise."""
+        bins, k_max, k_min, num_sampled_k_points = bin_precision_params
+        sf = self.build_structure_factor_object(*bin_precision_params)
         expected_bin_edges = np.histogram_bin_edges(
             np.array([0], dtype=np.float32), bins=bins, range=[k_min, k_max]
         )
@@ -434,17 +412,11 @@ class TestStaticStructureFactorDirect(StaticStructureFactorTest):
             rtol=1e-5,
         )
 
-    def test_attribute_shapes(self):
-        super().test_attribute_shapes()
+    def test_attribute_shapes(self, attribute_shape_params):
+        super().test_attribute_shapes(attribute_shape_params)
 
-        bins = self.ATTRIBUTE_SHAPE_PARAMS["bins"]
-        k_max = self.ATTRIBUTE_SHAPE_PARAMS["k_max"]
-        k_min = self.ATTRIBUTE_SHAPE_PARAMS["k_min"]
-        num_sampled_k_points = self.ATTRIBUTE_SHAPE_PARAMS["num_sampled_k_points"]
-
-        sf = self.build_structure_factor_object(
-            bins, k_max, k_min, num_sampled_k_points
-        )
+        bins, k_max, k_min, num_sampled_k_points = attribute_shape_params
+        sf = self.build_structure_factor_object(*attribute_shape_params)
 
         assert sf.bin_centers.shape == (bins,)
         assert sf.bin_edges.shape == (bins + 1,)

--- a/tests/test_diffraction_StaticStructureFactor.py
+++ b/tests/test_diffraction_StaticStructureFactor.py
@@ -194,17 +194,22 @@ class StaticStructureFactorTest:
         sf.compute((box, points))
         assert np.isclose(sf.min_valid_k, min_valid_k)
 
+    ATTRIBUTE_SHAPE_PARAMS = dict(bins=100,
+                                  k_max=123,
+                                  k_min=0.456,
+                                  num_sampled_k_points=10000)
+
     def test_attribute_shapes(self):
-        bins = 100
-        k_max = 123
-        k_min = 0.456
-        num_sampled_k_points = 10000
+        bins = self.ATTRIBUTE_SHAPE_PARAMS["bins"]
+        k_max = self.ATTRIBUTE_SHAPE_PARAMS["k_max"]
+        k_min = self.ATTRIBUTE_SHAPE_PARAMS["k_min"]
+        num_sampled_k_points = self.ATTRIBUTE_SHAPE_PARAMS["num_sampled_k_points"]
+
         sf = self.build_structure_factor_object(
             bins, k_max, k_min, num_sampled_k_points
         )
-        assert sf.bin_centers.shape == (bins,)
-        if not self.DEBYE:
-            assert sf.bin_edges.shape == (bins + 1,)
+
+        # only test the common attributes in the super implementation
         npt.assert_allclose(sf.bounds, (k_min, k_max), rtol=1e-5, atol=1e-5)
         box, positions = freud.data.UnitCell.fcc().generate_system(4)
         sf.compute((box, positions))
@@ -282,6 +287,20 @@ class TestStaticStructureFactorDebye(StaticStructureFactorTest):
             atol=1e-5,
             rtol=1e-5,
         )
+
+    def test_attribute_shapes(self):
+        super().test_attribute_shapes()
+
+        bins = self.ATTRIBUTE_SHAPE_PARAMS["bins"]
+        k_max = self.ATTRIBUTE_SHAPE_PARAMS["k_max"]
+        k_min = self.ATTRIBUTE_SHAPE_PARAMS["k_min"]
+        num_sampled_k_points = self.ATTRIBUTE_SHAPE_PARAMS["num_sampled_k_points"]
+
+        sf = self.build_structure_factor_object(
+            bins, k_max, k_min, num_sampled_k_points
+        )
+
+        assert sf.k_values.shape == (bins,)
 
     @classmethod
     def build_structure_factor_object(
@@ -413,6 +432,21 @@ class TestStaticStructureFactorDirect(StaticStructureFactorTest):
             atol=1e-5,
             rtol=1e-5,
         )
+
+    def test_attribute_shapes(self):
+        super().test_attribute_shapes()
+
+        bins = self.ATTRIBUTE_SHAPE_PARAMS["bins"]
+        k_max = self.ATTRIBUTE_SHAPE_PARAMS["k_max"]
+        k_min = self.ATTRIBUTE_SHAPE_PARAMS["k_min"]
+        num_sampled_k_points = self.ATTRIBUTE_SHAPE_PARAMS["num_sampled_k_points"]
+
+        sf = self.build_structure_factor_object(
+            bins, k_max, k_min, num_sampled_k_points
+        )
+
+        assert sf.bin_centers.shape == (bins,)
+        assert sf.bin_edges.shape == (bins + 1,)
 
     @classmethod
     def build_structure_factor_object(


### PR DESCRIPTION
## Description

this PR updates the names of some of the properties in the `StaticStructureFactorDebye` class. Since the calculation does not involve a histogram, those names are conceptually confusing and this PR updates the docs to remove histogram language as well.

This PR also does a significant re-work of the tests in `test_diffraction_StaticStructureFactor`, since the format in the previous version could not have handled changing property names well.

## Motivation and Context
There was discussion on changing the property names on #872 , and this PR implements those ideas

Resolves: #934 

## How Has This Been Tested?
Tests have been re-worked significantly to take advantage of pytest fixtures. No new tests have been added, but the tests have been re-worked to be more flexible and better parametrized.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds or improves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation improvement (updates to user guides, docstrings, or developer docs)

## Checklist:
<!-- Put an `x` in all the boxes that apply. If you're unsure about any of
     these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [**CONTRIBUTING**](https://github.com/glotzerlab/freud/blob/master/CONTRIBUTING.md) document.
- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation (if relevant).
- [ ] I have added tests that cover my changes (if relevant).
- [ ] All new and existing tests passed.
- [ ] I have updated the [credits](https://github.com/glotzerlab/freud/blob/master/doc/source/reference/credits.rst).
- [ ] I have updated the [Changelog](https://github.com/glotzerlab/freud/blob/master/ChangeLog.md).
