### PR TITLE
Remove cython from install_requires.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -11,6 +11,7 @@ and this project adheres to
 
 ### Fixed
 * `freud.diffraction.StaticStructureFactorDebye` implementation now gives `S_k[0] = N`.
+* Cython is no longer listed as an install requirement in `setup.py`.
 
 ## v2.8.0 -- 2022-01-25
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools", "wheel", "oldest-supported-numpy", "cython", "scikit-build", "cmake"]
+requires = ["setuptools", "wheel", "oldest-supported-numpy", "cython>=0.29.14", "scikit-build", "cmake"]
 
 [tool.black]
 target-version = ['py36']

--- a/setup.py
+++ b/setup.py
@@ -85,7 +85,6 @@ setup(
     },
     python_requires=">=3.6",
     install_requires=[
-        "cython>=0.29.14",
         "numpy>=1.14",
         "rowan>=1.2.1",
         "scipy>=1.1",


### PR DESCRIPTION
## Description
Cython is not a runtime requirement for freud. It is only a build requirement. This PR removes it from `setup.py`'s `install_requires` to fix this issue reported on the conda-forge feedstock: https://github.com/conda-forge/freud-feedstock/issues/46

## Motivation and Context
Resolves: https://github.com/conda-forge/freud-feedstock/issues/46

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds or improves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation improvement (updates to user guides, docstrings, or developer docs)

## Checklist:
- [x] I have read the [**CONTRIBUTING**](https://github.com/glotzerlab/freud/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] I have updated the documentation (if relevant).
- [x] I have added tests that cover my changes (if relevant).
- [x] All new and existing tests passed.
- [ ] I have updated the [credits](https://github.com/glotzerlab/freud/blob/master/doc/source/reference/credits.rst).
- [ ] I have updated the [Changelog](https://github.com/glotzerlab/freud/blob/master/ChangeLog.md).
