### PR TITLE
Remove CMake build type "ReleaseWithDocs".

### DIFF
--- a/.circleci/ci-oldest-reqs.txt
+++ b/.circleci/ci-oldest-reqs.txt
@@ -9,6 +9,6 @@ numpy==1.14.0
 pillow==6.2.0
 pytest==6.2.2
 rowan==1.2.1
-scikit-build==0.10.0
+scikit-build==0.13.1
 scipy==1.1.0
 sympy==1.0

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,9 @@
 # object libraries like _cluster. This is also the oldest version tested in CI.
 cmake_minimum_required(VERSION 3.12.0)
 
-set(DEFAULT_BUILD_TYPE "ReleaseWithDocs")
+project(freud)
+
+set(DEFAULT_BUILD_TYPE "Release")
 
 # Set a default build type if none was specified
 if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
@@ -11,41 +13,10 @@ if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
       "Setting build type to '${DEFAULT_BUILD_TYPE}' since none was specified.")
   set(CMAKE_BUILD_TYPE
       "${DEFAULT_BUILD_TYPE}"
-      CACHE STRING
-            "Choose the type of build. The default value is ReleaseWithDocs."
-            FORCE)
-  set_property(
-    CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "ReleaseWithDocs" "Debug" "Release"
-                                    "MinSizeRel" "RelWithDebInfo")
+      CACHE STRING "Choose the type of build." FORCE)
+  set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug" "Release"
+                                               "MinSizeRel" "RelWithDebInfo")
 endif()
-
-# We define a custom ReleaseWithDocs configuration, to avoid overlap with any
-# configuration handled in UseCython.cmake. See this issue for details:
-# https://github.com/scikit-build/scikit-build/issues/518
-set(CMAKE_CONFIGURATION_TYPES
-    "ReleaseWithDocs;Debug;Release;MinSizeRel;RelWithDebInfo"
-    CACHE STRING "List of supported configurations." FORCE)
-
-# CMake looks for these variables to be defined for the custom configuration.
-set(CMAKE_CXX_FLAGS_RELEASEWITHDOCS
-    "${CMAKE_CXX_FLAGS_RELEASE} -DNDEBUG -O3"
-    CACHE STRING "")
-set(CMAKE_C_FLAGS_RELEASEWITHDOCS
-    "${CMAKE_C_FLAGS_RELEASE} -DNDEBUG -O3"
-    CACHE STRING "")
-set(CMAKE_EXE_LINKER_FLAGS_RELEASEWITHDOCS
-    ${CMAKE_EXE_LINKER_FLAGS_RELEASE}
-    CACHE STRING "")
-set(CMAKE_SHARED_LINKER_FLAGS_RELEASEWITHDOCS
-    ${CMAKE_SHARED_LINKER_FLAGS_RELEASE}
-    CACHE STRING "")
-mark_as_advanced(
-  CMAKE_CXX_FLAGS_RELEASEWITHDOCS CMAKE_C_FLAGS_RELEASEWITHDOCS
-  CMAKE_EXE_LINKER_FLAGS_RELEASEWITHDOCS
-  CMAKE_SHARED_LINKER_FLAGS_RELEASEWITHDOCS)
-
-# We must define the project after adding the custom configuration.
-project(freud)
 
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -12,6 +12,9 @@ and this project adheres to
 ### Fixed
 * `freud.diffraction.StaticStructureFactorDebye` implementation now gives `S_k[0] = N`.
 
+### Removed
+* Custom CMake build type `ReleaseWithDocs`.
+
 ## v2.8.0 -- 2022-01-25
 
 ### Added

--- a/doc/source/gettingstarted/installation.rst
+++ b/doc/source/gettingstarted/installation.rst
@@ -87,12 +87,6 @@ The scikit-build tool allows setup.py to accept three different sets of options 
 For example, the command ``python setup.py build_ext --inplace -- -DCOVERAGE=ON -G Ninja -- -j 4`` tell scikit-build to perform an in-place build, it tells CMake to turn on the ``COVERAGE`` option and use Ninja for compilation, and it tells Ninja to compile with 4 parallel threads.
 For more information on these options, see the `scikit-build docs <scikit-build.readthedocs.io/>`__.
 
-.. note::
-
-    The default CMake build configuration for freud is ``ReleaseWithDocs`` (not a standard build configuration like ``Release`` or ``RelWithDebInfo``).
-    On installation, ``setup.py`` assumes ``--build-type=ReleaseWithDocs`` by default if no build type is specified.
-    Using this build configuration is a workaround for `this issue <https://github.com/scikit-build/scikit-build/issues/518>`__ with scikit-build and Cython embedding docstrings.
-
 In addition to standard CMake flags, the following CMake options are available for **freud**:
 
 .. glossary::

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools", "wheel", "oldest-supported-numpy", "cython", "scikit-build", "cmake"]
+requires = ["setuptools", "wheel", "oldest-supported-numpy", "cython", "scikit-build>=0.13.1", "cmake"]
 
 [tool.black]
 target-version = ['py36']

--- a/requirements/requirements-test-compatible.txt
+++ b/requirements/requirements-test-compatible.txt
@@ -13,6 +13,6 @@ pillow>=6.2.0 --only-binary=pillow
 pytest>=6.2.2
 pytest-cov>=3.0.0
 rowan>=1.2.1
-scikit-build>=0.10.0
+scikit-build>=0.13.1
 scipy>=1.1.0
 sympy>=1.0

--- a/setup.py
+++ b/setup.py
@@ -2,9 +2,8 @@
 # This file is from the freud project, released under the BSD 3-Clause License.
 
 import os
-import sys
 
-from skbuild import setup as skbuild_setup
+from skbuild import setup
 
 version = "2.8.0"
 
@@ -16,32 +15,6 @@ try:
         readme = f.read()
 except ImportError:
     readme = description
-
-
-def setup(*args, **kwargs):
-    """This wrapper exists to force the option --build-type=ReleaseWithDocs.
-
-    Neither Release nor RelWithDebInfo will work, due to hard-coded options in
-    scikit-build's UseCython.cmake that disable docstrings. The choice of
-    ReleaseWithDocs is arbitrary, as a string that won't overlap with any build
-    type handled in UseCython.cmake. See this issue for details:
-    https://github.com/scikit-build/scikit-build/issues/518
-    """
-    BUILD_TYPE = "--build-type=ReleaseWithDocs"
-    for index, arg in enumerate(sys.argv):
-        if arg == "--":
-            # Insert at the end of the options that go to scikit-build
-            break
-        elif arg.startswith("--build-type"):
-            # Don't override user-specified build type
-            index = False
-            break
-    else:
-        # Insert at the end of the provided arguments
-        index = len(sys.argv)
-    if index:
-        sys.argv.insert(index, BUILD_TYPE)
-    skbuild_setup(*args, **kwargs)
 
 
 setup(


### PR DESCRIPTION
## Description
Removes CMake build type "ReleaseWithDocs". scikit-build 0.13.1 can include Cython docstrings, so this workaround is no longer needed. The scikit-build requirement has been bumped to 0.13.1.

## Motivation and Context
Resolves: #924

## How Has This Been Tested?
I checked that the documentation builds and renders correctly on ReadTheDocs and in local builds.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds or improves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation improvement (updates to user guides, docstrings, or developer docs)

## Checklist:
- [x] I have read the [**CONTRIBUTING**](https://github.com/glotzerlab/freud/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] I have updated the documentation (if relevant).
- [x] I have added tests that cover my changes (if relevant).
- [x] All new and existing tests passed.
- [ ] I have updated the [credits](https://github.com/glotzerlab/freud/blob/master/doc/source/reference/credits.rst).
- [ ] I have updated the [Changelog](https://github.com/glotzerlab/freud/blob/master/ChangeLog.md).
