### PR TITLE
Stabilize diffraction module

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -9,6 +9,9 @@ and this project adheres to
 ### Added
 * (breaking) Some `freud.diffraction.StaticStructureFactorDebye` property names changed to be more descriptive.
 
+### Changed
+* The API in the `freud.diffraction` module is now stable.
+
 ### Fixed
 * `freud.diffraction.StaticStructureFactorDebye` implementation now gives `S_k[0] = N`.
 

--- a/freud/diffraction.pyx
+++ b/freud/diffraction.pyx
@@ -4,12 +4,6 @@
 r"""
 The :class:`freud.diffraction` module provides functions for computing the
 diffraction pattern of particles in systems with long range order.
-
-.. rubric:: Stability
-
-:mod:`freud.diffraction` is **unstable**. When upgrading from version 2.x to
-2.y (y > x), existing freud scripts may need to be updated. The API will be
-finalized in a future release.
 """
 
 from libcpp cimport bool as cbool


### PR DESCRIPTION
## Description

This PR removes the notice saying the diffraction module is unstable, and updates the changelog with a statement saying the API is now stable.

## Motivation and Context
This PR should be the last one merged before the 2.9.0 release, which I plan to make in the near future. The actual changes that stabilize the diffraction module's API were completed in #937 , so this PR is here to alert users to the slight API changes before the next release goes out.

## How Has This Been Tested?
No tests needed for this PR.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds or improves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation improvement (updates to user guides, docstrings, or developer docs)

## Checklist:
<!-- Put an `x` in all the boxes that apply. If you're unsure about any of
     these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/glotzerlab/freud/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] I have updated the documentation (if relevant).
- [ ] I have added tests that cover my changes (if relevant).
- [ ] All new and existing tests passed.
- [ ] I have updated the [credits](https://github.com/glotzerlab/freud/blob/master/doc/source/reference/credits.rst).
- [x] I have updated the [Changelog](https://github.com/glotzerlab/freud/blob/master/ChangeLog.md).
