### PR TITLE
Fix/noncubic diffraction

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -8,6 +8,7 @@ and this project adheres to
 
 ### Added
 * (breaking) Some `freud.diffraction.StaticStructureFactorDebye` property names changed to be more descriptive.
+* `freud.diffraction.DiffractionPattern` now raises an exception when used with non-cubic boxes.
 
 ### Fixed
 * `freud.diffraction.StaticStructureFactorDebye` implementation now gives `S_k[0] = N`.

--- a/doc/source/reference/credits.rst
+++ b/doc/source/reference/credits.rst
@@ -329,6 +329,7 @@ Tommy Waltmann
 * Remove CI build configurations from CircleCI which were already covered by CIBuildWheel.
 * Change property names in ``StaticStructureFactorDebye`` class.
 * Reformat static structure factor tests.
+* ``DiffractionPattern`` now raises an error when used with non-cubic boxes.
 
 Maya Martirossyan
 

--- a/freud/box.pyx
+++ b/freud/box.pyx
@@ -595,8 +595,16 @@ cdef class Box:
     @property
     def cubic(self):
         """bool: Whether the box is a cube."""
-        return self.Lx == self.Ly and self.Ly == self.Lz and self.xy == self.yz\
-            and self.yz == self.xz and self.xz == 0
+    return (
+        not self.is2d
+        and np.allclose(
+            [self.Lx, self.Lx, self.Ly, self.Ly, self.Lz, self.Lz],
+            [self.Ly, self.Lz, self.Lx, self.Lz, self.Lx, self.Ly],
+            rtol=1e-5,
+            atol=1e-5,
+        )
+        and np.allclose(0, [self.xy, self.yz, self.xz], rtol=1e-5, atol=1e-5)
+    )
 
     @property
     def periodic(self):

--- a/freud/box.pyx
+++ b/freud/box.pyx
@@ -595,16 +595,16 @@ cdef class Box:
     @property
     def cubic(self):
         """bool: Whether the box is a cube."""
-    return (
-        not self.is2d
-        and np.allclose(
-            [self.Lx, self.Lx, self.Ly, self.Ly, self.Lz, self.Lz],
-            [self.Ly, self.Lz, self.Lx, self.Lz, self.Lx, self.Ly],
-            rtol=1e-5,
-            atol=1e-5,
+        return (
+            not self.is2d
+            and np.allclose(
+                [self.Lx, self.Lx, self.Ly, self.Ly, self.Lz, self.Lz],
+                [self.Ly, self.Lz, self.Lx, self.Lz, self.Lx, self.Ly],
+                rtol=1e-5,
+                atol=1e-5,
+            )
+            and np.allclose(0, [self.xy, self.yz, self.xz], rtol=1e-5, atol=1e-5)
         )
-        and np.allclose(0, [self.xy, self.yz, self.xz], rtol=1e-5, atol=1e-5)
-    )
 
     @property
     def periodic(self):

--- a/freud/box.pyx
+++ b/freud/box.pyx
@@ -593,6 +593,12 @@ cdef class Box:
         return np.array(l_contains_mask).astype(bool)
 
     @property
+    def cubic(self):
+        """bool: Whether the box is a cube."""
+        return self.Lx == self.Ly and self.Ly == self.Lz and self.xy == self.yz\
+            and self.yz == self.xz and self.xz == 0
+
+    @property
     def periodic(self):
         r""":math:`\left(3, \right)` :class:`numpy.ndarray`: Get or set the
         periodicity of the box in each dimension."""

--- a/freud/box.pyx
+++ b/freud/box.pyx
@@ -596,7 +596,7 @@ cdef class Box:
     def cubic(self):
         """bool: Whether the box is a cube."""
         return (
-            not self.is2d
+            not self.is2D
             and np.allclose(
                 [self.Lx, self.Lx, self.Ly, self.Ly, self.Lz, self.Lz],
                 [self.Ly, self.Lz, self.Lx, self.Lz, self.Lx, self.Ly],

--- a/freud/diffraction.pyx
+++ b/freud/diffraction.pyx
@@ -565,6 +565,9 @@ cdef class DiffractionPattern(_Compute):
     `GIXStapose application <https://github.com/cmelab/GIXStapose>`_ and its
     predecessor, diffractometer :cite:`Jankowski2017`.
 
+    Note:
+        freud only supports diffraction patterns for cubic boxes.
+
     Args:
         grid_size (unsigned int):
             Resolution of the diffraction grid (Default value = 512).
@@ -730,6 +733,10 @@ cdef class DiffractionPattern(_Compute):
             self._frame_counter = 0
 
         system = freud.locality.NeighborQuery.from_system(system)
+
+        if not system.box.cubic:
+            raise ValueError("freud.diffraction.DiffractionPattern only "
+                             "supports cubic boxes")
 
         if view_orientation is None:
             view_orientation = np.array([1., 0., 0., 0.])

--- a/tests/test_box_Box.py
+++ b/tests/test_box_Box.py
@@ -374,18 +374,20 @@ class TestBox:
         npt.assert_allclose(box.get_box_vector(2), [xz * Lz, yz * Lz, Lz])
         npt.assert_allclose(box.v3, [xz * Lz, yz * Lz, Lz])
 
-    @pytest.mark.parametrize("box_params, answer",
-                             [(dict(Lx=1, Ly=1, Lz=1), True),
-                              (dict(Lx=2, Ly=1, Lz=4), False),
-                              (dict(Lx=1, Ly=1, Lz=1, xz=0.25), False),
-                              (dict(Lx=3, Ly=3, Lz=3), True),
-                              (dict(Lx=3, Ly=3, Lz=3, yz=0.01), False),
-                              (dict(Lx=0.01, Ly=1, Lz=10000, xy=0.75), False),
-                              ])
+    @pytest.mark.parametrize(
+        "box_params, answer",
+        [
+            (dict(Lx=1, Ly=1, Lz=1), True),
+            (dict(Lx=2, Ly=1, Lz=4), False),
+            (dict(Lx=1, Ly=1, Lz=1, xz=0.25), False),
+            (dict(Lx=3, Ly=3, Lz=3), True),
+            (dict(Lx=3, Ly=3, Lz=3, yz=0.01), False),
+            (dict(Lx=0.01, Ly=1, Lz=10000, xy=0.75), False),
+        ],
+    )
     def test_cubic(self, box_params, answer):
         box = freud.box.Box(**box_params)
         assert box.cubic is answer
-
 
     def test_periodic(self):
         box = freud.box.Box(1, 2, 3, 0, 0, 0)

--- a/tests/test_box_Box.py
+++ b/tests/test_box_Box.py
@@ -374,6 +374,19 @@ class TestBox:
         npt.assert_allclose(box.get_box_vector(2), [xz * Lz, yz * Lz, Lz])
         npt.assert_allclose(box.v3, [xz * Lz, yz * Lz, Lz])
 
+    @pytest.mark.parametrize("box_params, answer",
+                             [(dict(Lx=1, Ly=1, Lz=1), True),
+                              (dict(Lx=2, Ly=1, Lz=4), False),
+                              (dict(Lx=1, Ly=1, Lz=1, xz=0.25), False),
+                              (dict(Lx=3, Ly=3, Lz=3), True),
+                              (dict(Lx=3, Ly=3, Lz=3, yz=0.01), False),
+                              (dict(Lx=0.01, Ly=1, Lz=10000, xy=0.75), False),
+                              ])
+    def test_cubic(self, box_params, answer):
+        box = freud.box.Box(**box_params)
+        assert box.cubic is answer
+
+
     def test_periodic(self):
         box = freud.box.Box(1, 2, 3, 0, 0, 0)
         npt.assert_array_equal(box.periodic, True)

--- a/tests/test_diffraction_DiffractionPattern.py
+++ b/tests/test_diffraction_DiffractionPattern.py
@@ -285,3 +285,13 @@ class TestDiffractionPattern:
                                 ideal_peaks[peak] = True
 
                     assert all(ideal_peaks.values())
+
+    @pytest.mark.parametrize(
+        "noncubic_box_params", [dict(Lx=3, Ly=4, Lz=1), dict(Lx=3, Ly=3, Lz=3, xy=0.21)]
+    )
+    def test_noncubic_system(self, noncubic_box_params):
+        box = freud.box.Box(**noncubic_box_params)
+        points = [[0, 0, 0]]
+        dp = freud.diffraction.DiffractionPattern()
+        with pytest.raises(ValueError):
+            dp.compute((box, points))


### PR DESCRIPTION
## Description

This PR disables the diffraction calculation for noncubic boxes

## Motivation and Context

The diffraction calculation doesn't give correct results if the box is not a cube, and we don't want users getting incorrect results and not realizing it. This is discussed on #940 and is a change that is overdue.

## How Has This Been Tested?

Tests have been added which assert that the proper exception is raised.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds or improves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation improvement (updates to user guides, docstrings, or developer docs)

## Checklist:
<!-- Put an `x` in all the boxes that apply. If you're unsure about any of
     these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [**CONTRIBUTING**](https://github.com/glotzerlab/freud/blob/master/CONTRIBUTING.md) document.
- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation (if relevant).
- [ ] I have added tests that cover my changes (if relevant).
- [ ] All new and existing tests passed.
- [ ] I have updated the [credits](https://github.com/glotzerlab/freud/blob/master/doc/source/reference/credits.rst).
- [ ] I have updated the [Changelog](https://github.com/glotzerlab/freud/blob/master/ChangeLog.md).
