### PR TITLE
Fix docs links

### DIFF
--- a/doc/source/gettingstarted/installation.rst
+++ b/doc/source/gettingstarted/installation.rst
@@ -85,7 +85,7 @@ CMake Options
 
 The scikit-build tool allows setup.py to accept three different sets of options separated by ``--``, where each set is provided directly to scikit-build, to CMake, or to the code generator of choice, respectively.
 For example, the command ``python setup.py build_ext --inplace -- -DCOVERAGE=ON -G Ninja -- -j 4`` tell scikit-build to perform an in-place build, it tells CMake to turn on the ``COVERAGE`` option and use Ninja for compilation, and it tells Ninja to compile with 4 parallel threads.
-For more information on these options, see the `scikit-build docs <scikit-build.readthedocs.io/>`__.
+For more information on these options, see the `scikit-build docs <https://scikit-build.readthedocs.io/>`__.
 
 In addition to standard CMake flags, the following CMake options are available for **freud**:
 

--- a/freud/box.pyx
+++ b/freud/box.pyx
@@ -855,8 +855,9 @@ cdef class Box:
     def from_matrix(cls, box_matrix, dimensions=None):
         r"""Initialize a Box instance from a box matrix.
 
-        For more information and the source for this code,
-        see: https://hoomd-blue.readthedocs.io/en/stable/box.html
+        For more information and the source for this code, see:
+        `HOOMD-blue's box documentation \
+        <https://hoomd-blue.readthedocs.io/en/stable/package-hoomd.html#hoomd.Box>`_.
 
         Args:
             box_matrix (array-like):


### PR DESCRIPTION
## Description

This PR fixes a couple of broken links in freud's documentation.

## Motivation and Context
Resolves: #948 #941 

## How Has This Been Tested?

CI will build the docs and we can inspect from there. I have tested locally as well.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds or improves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation improvement (updates to user guides, docstrings, or developer docs)

## Checklist:
<!-- Put an `x` in all the boxes that apply. If you're unsure about any of
     these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/glotzerlab/freud/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] I have updated the documentation (if relevant).
- [ ] I have added tests that cover my changes (if relevant).
- [x] All new and existing tests passed.
- [x] I have updated the [credits](https://github.com/glotzerlab/freud/blob/master/doc/source/reference/credits.rst).
- [x] I have updated the [Changelog](https://github.com/glotzerlab/freud/blob/master/ChangeLog.md).
