### PR TITLE
Document replicating per-site properties of a lattice

### DIFF
--- a/freud/data.py
+++ b/freud/data.py
@@ -80,8 +80,8 @@ class UnitCell:
                     N = np.product(n_repeats)
                 indices = np.repeat(np.arange(len(uc.basis_positions)), N)
 
-        Below is an example of expanding basis position properties such as type
-        to a replicated lattice.
+        Below is an example of expanding basis position properties such as (in
+        this case, types) to a replicated lattice.
 
         Example::
 

--- a/freud/data.py
+++ b/freud/data.py
@@ -87,8 +87,9 @@ class UnitCell:
 
             >>> uc = freud.data.UnitCell.bcc()
             >>> n_repeats = (10, 5, 4)
-            >>> system = uc.generate_system(N)
-            >>> indices = np.repeat(np.arange(len(uc.basis_positions)), np.product(N))
+            >>> system = uc.generate_system(n_repeats)
+            >>> N = np.product(n_repeats)
+            >>> indices = np.repeat(np.arange(len(uc.basis_positions)), N)
             >>> # An array of types for all points
             >>> types = np.array([0, 1])[indices]
             >>> len(types)

--- a/freud/data.py
+++ b/freud/data.py
@@ -70,21 +70,29 @@ class UnitCell:
             Positions are generated in the order of the instance's
             ``basis_positions``. The first :math:`N_{replica}` positions come
             from the first basis position, the next :math:`N_{replica}` the
-            second, etc. A NumPy one-liner that generates the list of indices is
-            ``np.repeat(np.arange(len(uc.basis_positions)), np.product(N))``.
+            second, etc. To generate the indices use the following expression.
+
+            .. code-block:: python
+
+                if isinstance(n_repeats, int):
+                    N = n_repeats ** dimension
+                else:
+                    N = np.product(n_repeats)
+                indices = np.repeat(np.arange(len(uc.basis_positions)), N)
 
         Below is an example of expanding basis position properties such as type
         to a replicated lattice.
 
-        .. code-block:: python
+        Example::
 
-            uc = freud.data.UnitCell.bcc()
-            N = (10, 5, 4)
-            system = uc.generate_system(N)
-            indices = np.repeat(
-                np.arange(len(uc.basis_positions)), np.product(N))
-            # An array of types for all points
-            types = np.array([0, 1])[indices]
+            >>> uc = freud.data.UnitCell.bcc()
+            >>> n_repeats = (10, 5, 4)
+            >>> system = uc.generate_system(N)
+            >>> indices = np.repeat(np.arange(len(uc.basis_positions)), np.product(N))
+            >>> # An array of types for all points
+            >>> types = np.array([0, 1])[indices]
+            >>> len(types)
+            400
 
         """
         try:

--- a/freud/data.py
+++ b/freud/data.py
@@ -70,7 +70,9 @@ class UnitCell:
             Positions are generated in the order of the instance's
             ``basis_positions``. The first :math:`N_{replica}` positions come
             from the first basis position, the next :math:`N_{replica}` the
-            second, etc. To generate the indices use the following expression.
+            second, etc. This behavior is analoguous to `numpy.repeat` rather
+            than `numpy.tile`. To generate the indices use the following
+            expression.
 
             .. code-block:: python
 

--- a/freud/data.py
+++ b/freud/data.py
@@ -82,8 +82,8 @@ class UnitCell:
                     N = np.product(n_repeats)
                 indices = np.repeat(np.arange(len(uc.basis_positions)), N)
 
-        Below is an example of expanding basis position properties such as (in
-        this case, types) to a replicated lattice.
+        Below is an example of expanding basis position properties (in this
+        case, types) to a replicated lattice.
 
         Example::
 

--- a/freud/data.py
+++ b/freud/data.py
@@ -68,9 +68,24 @@ class UnitCell:
 
         Note:
             Positions are generated in the order of the instance's
-            ``basis_positions``. The first :math:`N_{replica}`
-            positions come from the first basis position, the next
-            :math:`N_{replica}` the second, etc.
+            ``basis_positions``. The first :math:`N_{replica}` positions come
+            from the first basis position, the next :math:`N_{replica}` the
+            second, etc. A NumPy one-liner that generates the list of indices is
+            ``np.repeat(np.arange(len(uc.basis_positions)), np.product(N))``.
+
+        Below is an example of expanding basis position properties such as type
+        to a replicated lattice.
+
+        .. code-block:: python
+
+            uc = freud.data.UnitCell.bcc()
+            N = (10, 5, 4)
+            system = uc.generate_system(N)
+            indices = np.repeat(
+                np.arange(len(uc.basis_positions)), np.product(N))
+            # An array of types for all points
+            types = np.array([0, 1])[indices]
+
         """
         try:
             nx, ny, nz = num_replicas


### PR DESCRIPTION
## Description
Documents how to replicate properties like orientation, type, etc. when using `freud.data.Unitcell.generate_system`.

## Motivation and Context
Resolves: #963

## How Has This Been Tested?
Unnecessary

## Screenshots
<!-- (if appropriate) -->

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds or improves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation improvement (updates to user guides, docstrings, or developer docs)

## Checklist:
- [x] I have read the [**CONTRIBUTING**](https://github.com/glotzerlab/freud/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] I have updated the documentation (if relevant).
- [ ] I have added tests that cover my changes (if relevant).
- [x] All new and existing tests passed.
- [ ] I have updated the [credits](https://github.com/glotzerlab/freud/blob/master/doc/source/reference/credits.rst).
- [ ] I have updated the [Changelog](https://github.com/glotzerlab/freud/blob/master/ChangeLog.md).
