### PR TITLE
Fix EnvironmentMatch Seg Fault

### DIFF
--- a/cpp/environment/MatchEnv.cc
+++ b/cpp/environment/MatchEnv.cc
@@ -14,7 +14,8 @@ namespace freud { namespace environment {
 /*****************
  * EnvDisjoinSet *
  *****************/
-EnvDisjointSet::EnvDisjointSet(unsigned int Np) : s(std::vector<Environment>()), rank(std::vector<unsigned int>(Np, 0)), m_max_num_neigh(0)
+EnvDisjointSet::EnvDisjointSet(unsigned int Np)
+    : s(std::vector<Environment>()), rank(std::vector<unsigned int>(Np, 0)), m_max_num_neigh(0)
 {
     s.reserve(Np);
 }

--- a/cpp/environment/MatchEnv.cc
+++ b/cpp/environment/MatchEnv.cc
@@ -14,8 +14,10 @@ namespace freud { namespace environment {
 /*****************
  * EnvDisjoinSet *
  *****************/
-EnvDisjointSet::EnvDisjointSet(unsigned int Np) : rank(std::vector<unsigned int>(Np, 0)), m_max_num_neigh(0)
-{}
+EnvDisjointSet::EnvDisjointSet(unsigned int Np) : s(std::vector<Environment>()), rank(std::vector<unsigned int>(Np, 0)), m_max_num_neigh(0)
+{
+    s.reserve(Np);
+}
 
 void EnvDisjointSet::merge(const unsigned int a, const unsigned int b,
                            BiMap<unsigned int, unsigned int> vec_map, rotmat3<float>& rotation)


### PR DESCRIPTION
## Description

This fixes the segfault in the script reported in #633

## Motivation and Context

There was a vector which was initialized by default, and for whatever reason, was not able to properly allocate more memory when it needed to.

Resolves: #633

## How Has This Been Tested?
I have run the script reported in #633 locally, and the segfault does not occur anymore. @Charlottez112 please run this on the system you have seen the segfault for as well to make sure this fixes it for everyone.

## Checklist:
<!-- Put an `x` in all the boxes that apply. If you're unsure about any of
     these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [**CONTRIBUTING**](https://github.com/glotzerlab/freud/blob/master/CONTRIBUTING.md) document.
- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation (if relevant).
- [ ] I have added tests that cover my changes (if relevant).
- [ ] All new and existing tests passed.
- [ ] I have updated the [credits](https://github.com/glotzerlab/freud/blob/master/doc/source/reference/credits.rst).
- [ ] I have updated the [Changelog](https://github.com/glotzerlab/freud/blob/master/ChangeLog.md).
