### PR TITLE
Fix disjoint set size in EnvironmentMotifMatch

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,11 @@ The format is based on
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v2.10.1 -- 2022-XX-YY
+
+### Fixed
+* `EnvironmentMotifMatch` correctly handles `NeighborList`s with more neighbors per particle than the motif.
+
 ## v2.10.0 -- 2022-05-18
 
 ### Added

--- a/cpp/environment/MatchEnv.cc
+++ b/cpp/environment/MatchEnv.cc
@@ -684,8 +684,8 @@ void EnvironmentMotifMatch::compute(const freud::locality::NeighborQuery* nq,
     // because we're inserting the motif into it.
     EnvDisjointSet dj(Np + 1);
     auto counts = nlist.getCounts();
-    auto begin = counts.get();
-    auto end = begin + counts.size();
+    auto* begin = counts.get();
+    auto* end = begin + counts.size();
     auto max_val = *std::max_element(begin, end);
     dj.m_max_num_neigh = max_val;
 

--- a/cpp/environment/MatchEnv.cc
+++ b/cpp/environment/MatchEnv.cc
@@ -1,6 +1,7 @@
 // Copyright (c) 2010-2020 The Regents of the University of Michigan
 // This file is from the freud project, released under the BSD 3-Clause License.
 
+#include <algorithm>
 #include <sstream>
 #include <stdexcept>
 
@@ -683,12 +684,9 @@ void EnvironmentMotifMatch::compute(const freud::locality::NeighborQuery* nq,
     // because we're inserting the motif into it.
     EnvDisjointSet dj(Np + 1);
     auto counts = nlist.getCounts();
-    unsigned int max_val = 0;
-    for (auto i = 0; i < counts.size(); ++i) {
-        if (counts[i] > max_val) {
-            max_val = counts[i];
-        }
-    }
+    auto begin = counts.get();
+    auto end = begin + counts.size();
+    auto max_val = *std::max_element(begin, end);
     dj.m_max_num_neigh = max_val;
 
     // reallocate the m_point_environments array

--- a/cpp/environment/MatchEnv.cc
+++ b/cpp/environment/MatchEnv.cc
@@ -682,10 +682,17 @@ void EnvironmentMotifMatch::compute(const freud::locality::NeighborQuery* nq,
     // this has to have ONE MORE environment than there are actual particles,
     // because we're inserting the motif into it.
     EnvDisjointSet dj(Np + 1);
-    dj.m_max_num_neigh = motif_size;
+    auto counts = nlist.getCounts();
+    unsigned int max_val = 0;
+    for (auto i = 0; i < counts.size(); ++i) {
+        if (counts[i] > max_val) {
+            max_val = counts[i];
+        }
+    }
+    dj.m_max_num_neigh = max_val;
 
     // reallocate the m_point_environments array
-    m_point_environments.prepare({Np, motif_size});
+    m_point_environments.prepare({Np, max_val});
 
     // create the environment characterized by motif. Index it as 0.
     // set the IGNORE flag to true, since this is not an environment we have

--- a/cpp/environment/MatchEnv.cc
+++ b/cpp/environment/MatchEnv.cc
@@ -683,6 +683,10 @@ void EnvironmentMotifMatch::compute(const freud::locality::NeighborQuery* nq,
     // this has to have ONE MORE environment than there are actual particles,
     // because we're inserting the motif into it.
     EnvDisjointSet dj(Np + 1);
+
+    // The NeighborList may contain different numbers of neighbors for each particle, so
+    // we must determine the maximum programmatically to ensure that the disjoint set
+    // operations always allocate enough memory for the largest possible local environment.
     auto counts = nlist.getCounts();
     auto* begin = counts.get();
     auto* end = begin + counts.size();

--- a/cpp/environment/MatchEnv.cc
+++ b/cpp/environment/MatchEnv.cc
@@ -686,11 +686,11 @@ void EnvironmentMotifMatch::compute(const freud::locality::NeighborQuery* nq,
     auto counts = nlist.getCounts();
     auto* begin = counts.get();
     auto* end = begin + counts.size();
-    auto max_val = *std::max_element(begin, end);
-    dj.m_max_num_neigh = max_val;
+    auto max_num_neigh = *std::max_element(begin, end);
+    dj.m_max_num_neigh = max_num_neigh;
 
     // reallocate the m_point_environments array
-    m_point_environments.prepare({Np, max_val});
+    m_point_environments.prepare({Np, max_num_neigh});
 
     // create the environment characterized by motif. Index it as 0.
     // set the IGNORE flag to true, since this is not an environment we have

--- a/freud/environment.pyx
+++ b/freud/environment.pyx
@@ -718,6 +718,19 @@ cdef class EnvironmentMotifMatch(_MatchEnv):
             self._preprocess_arguments(system, neighbors=neighbors)
 
         motif = freud.util._convert_array(motif, shape=(None, 3))
+        if (motif == 0).all(axis=1).any():
+            warnings.warn(
+                "You are attempting to match a motif containing the zero "
+                "vector. This is likely because you are providing a motif "
+                "created using EnvironmentCluster, which ensures that all "
+                "computed environments are the same size by padding smaller "
+                "environments with the 0 vector. You should remove these "
+                "vectors from the motif before running using "
+                "EnvironmentMotifMatch.compute, since these zero vectors are "
+                "likely to prevent you from finding a match.",
+                RuntimeWarning
+            )
+
         cdef const float[:, ::1] l_motif = motif
         cdef unsigned int nRef = l_motif.shape[0]
 

--- a/tests/test_environment_MatchEnv.py
+++ b/tests/test_environment_MatchEnv.py
@@ -443,6 +443,18 @@ class TestEnvironmentMotifMatch:
             assert not matches[i]
         assert matches[len(motif)]
 
+    def test_warning_motif_zeros(self):
+        """Test that using a motif containing the zero vector raises warnings."""
+        motif = [[1, 0, 0], [0, 1, 0], [-1, 0, 0], [0, -1, 0], [0, 0, 0]]
+
+        num_neighbors = 4
+
+        box = freud.box.Box.square(3)
+        match = freud.environment.EnvironmentMotifMatch()
+        query_args = dict(num_neighbors=num_neighbors)
+        with pytest.warns(RuntimeWarning):
+            match.compute((box, motif), motif, 0.1, neighbors=query_args)
+
 
 class TestEnvironmentRMSDMinimizer:
     def test_api(self):


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above. -->

## Description
<!-- Describe your changes in detail. -->
EnvironmentMotifMatch constructs an environment for each particle and matches it to the environment of a reference particle (the motif). The size of the local environment for each particle may, however, be larger than the motif size, since any subset of that environment may be sufficient to match the motif. Therefore, the `m_max_num_neigh` parameter cannot be set to the size of the motif, but must instead be computed dynamically from the NeighborList.

The underlying bug looks like it has always been present, but prior to freud 2.0 it was much harder to encounter because it would require a user to manually construct a NeighborList and then pass a value of `k` (the number of neighbors) to the constructor of the `MatchEnv` object that did not match the one used for constructing the `NeighborList`. The default constructed `NeighborList` within `MatchEnv` would always match the value of `k` correctly. With freud 2.0, it became much easier for users to specify alternative neighbor specifications with the new query syntax, and the value of `k` was no longer part of the class definition. #489 introduced the specific error that made it easy to hit this error case by always setting the value of `EnvDisjointSet.m_max_num_neigh` to the size of the motif, so any neighbor specification resulting in particles with more neighbors in the NeighborList than the size of the motif would trigger this error.

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- Replace ??? with the issue number that this pull request resolves, if applicable. -->
Resolves: #633

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to
     see how your changes affect other areas of the code, etc. -->
Both the original script in #633 (with the data included there) and the example documented by @Charlottez112 on #978 seg fault on my machine without this change, and both of them complete successfully once these changes are included.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds or improves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation improvement (updates to user guides, docstrings, or developer docs)

## Checklist:
<!-- Put an `x` in all the boxes that apply. If you're unsure about any of
     these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/glotzerlab/freud/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] I have updated the documentation (if relevant).
- [x] I have added tests that cover my changes (if relevant).
- [x] All new and existing tests passed.
- [ ] I have updated the [credits](https://github.com/glotzerlab/freud/blob/master/doc/source/reference/credits.rst).
- [x] I have updated the [Changelog](https://github.com/glotzerlab/freud/blob/master/ChangeLog.md).
