### PR TITLE
Fix Debye Structure Factor Implementation in 2D

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -2,6 +2,7 @@
 # misc-no-recursion: Rewriting things like the NeighborList to avoid recursion is out of scope for now.
 # misc-non-private-member-variables-in-classes: We make extensive use of protected members, for instance in PMFT* classes from BondHistogramCompute, and the argument that this is _never_ OK is not terribly convincing.
 # modernize-return-braced-init-list: This format for returning is less readable for inexperienced C++ programmers.
+# modernize-use-nodiscard: This warning is raised for every method that has a return value, which is an excessive overuse of this syntax.
 # modernize-use-trailing-return-type: This syntax is still generally unfamiliar to many developers and will make the code harder to maintain.
 # readability-avoid-const-params-in-decls: While it may be semantically confusing, it's easier to read when declaration and definition consts match.
 # readability-function-cognitive-complexity: Some heavily nested functions trigger this, it could be possible to rewrite these but that's out of scope at the moment.
@@ -20,6 +21,7 @@ Checks: 'bugprone-*,
          -misc-no-recursion,
          -misc-non-private-member-variables-in-classes,
          -modernize-return-braced-init-list,
+         -modernize-use-nodiscard,
          -modernize-use-trailing-return-type,
          -readability-avoid-const-params-in-decls,
          -readability-function-cognitive-complexity,

--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,6 @@
 [submodule "doc/source/gettingstarted/examples"]
 	path = doc/source/gettingstarted/examples
 	url = https://github.com/glotzerlab/freud-examples.git
+[submodule "extern/bessel-library"]
+	path = extern/bessel-library
+	url = https://github.com/jodesarro/bessel-library.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -10,6 +10,3 @@
 [submodule "doc/source/gettingstarted/examples"]
 	path = doc/source/gettingstarted/examples
 	url = https://github.com/glotzerlab/freud-examples.git
-[submodule "extern/bessel-library"]
-	path = extern/bessel-library
-	url = https://github.com/jodesarro/bessel-library.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
                                                "MinSizeRel" "RelWithDebInfo")
 endif()
 
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # This setting is required when building shared libraries from object libraries.

--- a/cpp/diffraction/StaticStructureFactorDebye.cc
+++ b/cpp/diffraction/StaticStructureFactorDebye.cc
@@ -87,7 +87,7 @@ void StaticStructureFactorDebye::accumulate(const freud::locality::NeighborQuery
                     // other library's implementation is unique only for complex
                     // numbers, otherwise it just tries to call
                     // std::cyl_bessel_j.
-                    S_k += bessel::cyl_j0(std::complex<double>(k * distance));
+                    S_k += std::real(bessel::cyl_j0(std::complex<double>(k * distance)));
 #else
                     S_k += std::cyl_bessel_j(0, k * distance);
 #endif

--- a/cpp/diffraction/StaticStructureFactorDebye.cc
+++ b/cpp/diffraction/StaticStructureFactorDebye.cc
@@ -4,6 +4,7 @@
 #include <cmath>
 #include <limits>
 #include <stdexcept>
+#include <bessel-library/bessel-library.hpp>
 
 #include "NeighborQuery.h"
 #include "StaticStructureFactorDebye.h"
@@ -80,7 +81,16 @@ void StaticStructureFactorDebye::accumulate(const freud::locality::NeighborQuery
             {
                 if (box.is2D())
                 {
+                    #ifdef __clang__
+                    // clang doesn't support the special math functions, use
+                    // other library instead. The cast is needed because the
+                    // other library's implementation is unique only for complex
+                    // numbers, otherwise it just tries to call
+                    // std::cyl_bessel_j.
+                    S_k += bessel::cyl_j0(std::complex<double>(k * distance));
+                    #else
                     S_k += std::cyl_bessel_j(0, k * distance);
+                    #endif
                 }
                 else
                 {

--- a/cpp/diffraction/StaticStructureFactorDebye.cc
+++ b/cpp/diffraction/StaticStructureFactorDebye.cc
@@ -1,10 +1,10 @@
 // Copyright (c) 2010-2020 The Regents of the University of Michigan
 // This file is from the freud project, released under the BSD 3-Clause License.
 
+#include <bessel-library/bessel-library.hpp>
 #include <cmath>
 #include <limits>
 #include <stdexcept>
-#include <bessel-library/bessel-library.hpp>
 
 #include "NeighborQuery.h"
 #include "StaticStructureFactorDebye.h"
@@ -81,16 +81,16 @@ void StaticStructureFactorDebye::accumulate(const freud::locality::NeighborQuery
             {
                 if (box.is2D())
                 {
-                    #ifdef __clang__
+#ifdef __clang__
                     // clang doesn't support the special math functions, use
                     // other library instead. The cast is needed because the
                     // other library's implementation is unique only for complex
                     // numbers, otherwise it just tries to call
                     // std::cyl_bessel_j.
                     S_k += bessel::cyl_j0(std::complex<double>(k * distance));
-                    #else
+#else
                     S_k += std::cyl_bessel_j(0, k * distance);
-                    #endif
+#endif
                 }
                 else
                 {

--- a/cpp/diffraction/StaticStructureFactorDebye.cc
+++ b/cpp/diffraction/StaticStructureFactorDebye.cc
@@ -78,7 +78,14 @@ void StaticStructureFactorDebye::accumulate(const freud::locality::NeighborQuery
             double S_k = 0.0;
             for (const auto& distance : distances)
             {
-                S_k += util::sinc(k * distance);
+                if (box.is2D())
+                {
+                    S_k += std::cyl_bessel_j(0, k * distance);
+                }
+                else
+                {
+                    S_k += util::sinc(k * distance);
+                }
             }
             S_k /= static_cast<double>(n_total);
             m_local_structure_factor.increment(k_index, S_k);

--- a/cpp/diffraction/StaticStructureFactorDebye.cc
+++ b/cpp/diffraction/StaticStructureFactorDebye.cc
@@ -1,7 +1,10 @@
 // Copyright (c) 2010-2020 The Regents of the University of Michigan
 // This file is from the freud project, released under the BSD 3-Clause License.
 
-#include <bessel-library/bessel-library.hpp>
+#ifdef __clang__
+#include <bessel-library.hpp>
+#else
+#endif
 #include <cmath>
 #include <limits>
 #include <stdexcept>

--- a/cpp/locality/AABBQuery.cc
+++ b/cpp/locality/AABBQuery.cc
@@ -93,8 +93,8 @@ void AABBIterator::updateImageVectors(float r_max, bool _check_r_max)
         m_image_list.resize(m_n_images);
     }
 
-    vec3<float> latt_a = vec3<float>(box.getLatticeVector(0));
-    vec3<float> latt_b = vec3<float>(box.getLatticeVector(1));
+    auto latt_a = vec3<float>(box.getLatticeVector(0));
+    auto latt_b = vec3<float>(box.getLatticeVector(1));
     vec3<float> latt_c = vec3<float>(0.0, 0.0, 0.0);
     if (!box.is2D())
     {

--- a/doc/source/reference/credits.rst
+++ b/doc/source/reference/credits.rst
@@ -330,6 +330,7 @@ Tommy Waltmann
 * Change property names in ``StaticStructureFactorDebye`` class.
 * Reformat static structure factor tests.
 * ``DiffractionPattern`` now raises an error when used with non-cubic boxes.
+* Implement ``StaticStructureFactorDebye`` for 2D systems.
 
 Maya Martirossyan
 
@@ -470,3 +471,27 @@ under the following license::
     royalty-free perpetual license to install, use, modify, prepare derivative
     works, incorporate into other computer software, distribute, and sublicense
     such enhancements or derivative works thereof, in binary and source code form.
+
+bessel-library (https://github.com/jodesarro/bessel-library) is a single header file
+which implements the cylindrical bessel functions used by freud to compute 2D static
+structure factors. It is made available under the MIT license::
+
+   Copyright (c) 2022 Jhonas Olivati de Sarro
+
+   Permission is hereby granted, free of charge, to any person obtaining a copy
+   of this software and associated documentation files (the "Software"), to deal
+   in the Software without restriction, including without limitation the rights
+   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+   copies of the Software, and to permit persons to whom the Software is
+   furnished to do so, subject to the following conditions:
+
+   The above copyright notice and this permission notice shall be included in all
+   copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+   SOFTWARE.

--- a/extern/bessel-library.hpp
+++ b/extern/bessel-library.hpp
@@ -1,0 +1,105 @@
+/*
+ * Taken from https://gtihub.com/jodesarro/bessel-library.git, distributed under
+ * the MIT license.
+ *
+ * */
+
+#pragma once
+
+#define C_1_SQRTPI 0.5641895835477562869480794515607725L
+
+#include <complex>
+#include <cmath>
+
+namespace bessel
+{
+
+/*
+template<typename T>
+T cyl_j0( T _z )
+{
+    // Implementation from C++17 standard library
+    return std::cyl_bessel_j(0, _z);
+}
+*/
+
+template<typename T>
+std::complex<T> __cyl_j0_ascending_series( const std::complex<T> _z )
+{
+    // Ascending Series from G. N. Watson 'A treatise on the
+    //  theory of Bessel functions', 2ed, Cambridge, 1996,
+    //  Chapter II, equation (3); or from Equation 9.1.12 of
+    //  M. Abramowitz, I. A. Stegun 'Handbook of Mathematical
+    //  Functions'.
+    const T epsilon = std::numeric_limits<T>::epsilon();
+    std::complex<T> j0 = T(1);
+    std::complex<T> sm = T(1);
+    for ( int m = 1; std::abs(sm/j0) >= epsilon; m++ )
+    {
+        sm *= - _z*_z * T(0.25) / ( T(m)*T(m) );
+        j0 += sm;
+    }
+    return j0;
+}
+
+template<typename T>
+std::complex<T> __cyl_j0_semiconvergent_series(
+                            const std::complex<T> _z, const int _m_max )
+{
+    // Stokes Semiconvergent Series from A. Gray, G. B. Mathews 'A
+    //  treatise on Bessel functions and their applications to
+    //  physics, 1895.
+    std::complex<T> Pm = T(1);
+    std::complex<T> Qm = T(0.125)/_z;
+    std::complex<T> P = Pm;
+    std::complex<T> Q = Qm;
+
+    for ( int m=1; m<=_m_max; m++ )
+    {
+        T pim = T(4*m-3)*T(4*m-3)*T(4*m-1)*T(4*m-1) / ( T(2*m-1)*T(128*m) );
+        Pm = -Pm*pim/(_z*_z);
+
+        T xim = T(4*m-1)*T(4*m-1)*T(4*m+1)*T(4*m+1) / ( T(2*m+1)*T(128*m) );
+        Qm = -Qm*xim/(_z*_z);
+
+        P += Pm;
+        Q += Qm;
+    }
+
+    return T(C_1_SQRTPI) * ( cos(_z)*(P-Q) + sin(_z)*(P+Q) ) / sqrt( _z );
+
+}
+
+template<typename T>
+std::complex<T> cyl_j0( std::complex<T> _z )
+{
+
+    if ( std::real(_z) < T(0) )
+    {
+        _z = -_z; // Since J0(-z) = J0(z)
+    }
+
+    if ( std::abs(_z) == T(0) )
+    {
+        return std::complex<T> ( T(1), T(0) );
+    }
+    else if ( std::real(_z) <= T(12) )
+    {
+        return __cyl_j0_ascending_series( _z );
+    }
+    else if ( std::real(_z) < T(35) )
+    {
+        return __cyl_j0_semiconvergent_series( _z, 12 );
+    }
+    else if ( std::real(_z) < T( 50 ) )
+    {
+        return __cyl_j0_semiconvergent_series( _z,  10 );
+    }
+    else
+    {
+        return __cyl_j0_semiconvergent_series( _z,  8 );
+    }
+
+}
+
+}

--- a/freud/diffraction.pyx
+++ b/freud/diffraction.pyx
@@ -97,15 +97,15 @@ cdef class StaticStructureFactorDebye(_StaticStructureFactor):
     see :cite:`Farrow2009`. Note that the definition requires :math:`S(0) = N`.
 
     .. note::
-        For true 2D systems the formula one should use is different to the one 
-        reported above. See this `link 
-        <http://www.scik.org/index.php/jmcs/article/viewFile/263/120>`__ 
-        for more information. For users wishing to calculate the structure 
-        factor of quasi 2D systems (when a 2D simulation is used to simulate 
-        a real system such as particles on a 2D interface or similar) the 3D 
+        For true 2D systems the formula one should use is different to the one
+        reported above. See this `link
+        <http://www.scik.org/index.php/jmcs/article/viewFile/263/120>`__
+        for more information. For users wishing to calculate the structure
+        factor of quasi 2D systems (when a 2D simulation is used to simulate
+        a real system such as particles on a 2D interface or similar) the 3D
         formula should be used. In these cases the users are advised to convert
         the 2D box to a 3D box with third dimension coordinates being set to 0.0
-        and length of third dimension being set to larger of the other two 
+        and length of third dimension being set to larger of the other two
         before using the method.
 
     This implementation uses an evenly spaced number of :math:`k` points between

--- a/freud/diffraction.pyx
+++ b/freud/diffraction.pyx
@@ -97,16 +97,16 @@ cdef class StaticStructureFactorDebye(_StaticStructureFactor):
     see :cite:`Farrow2009`. Note that the definition requires :math:`S(0) = N`.
 
     .. note::
-        For true 2D systems the formula one should use is different to the one
-        reported above. See this `link
+
+        For 2D systems freud uses the bessel function :math:`J_0` instead of the
+        :math:`\text{sinc}` function in the equation above. See this `link
         <http://www.scik.org/index.php/jmcs/article/viewFile/263/120>`__
         for more information. For users wishing to calculate the structure
-        factor of quasi 2D systems (when a 2D simulation is used to simulate
-        a real system such as particles on a 2D interface or similar) the 3D
-        formula should be used. In these cases the users are advised to convert
-        the 2D box to a 3D box with third dimension coordinates being set to 0.0
-        and length of third dimension being set to larger of the other two
-        before using the method.
+        factor of quasi 2D systems (i.e. a 2D simulation is used to model a real
+        system such as particles on a 2D interface or similar) the 3D
+        formula should be used. In these cases users should use a 3D box with
+        its longest dimension being in the z-direction and particle positions of
+        the form :math:`(x, y, 0)`.
 
     This implementation uses an evenly spaced number of :math:`k` points between
     `k_min`` and ``k_max``. If ``k_min`` is set to 0 (the default behavior), the

--- a/freud/diffraction.pyx
+++ b/freud/diffraction.pyx
@@ -96,6 +96,18 @@ cdef class StaticStructureFactorDebye(_StaticStructureFactor):
     <https://en.wikipedia.org/wiki/Structure_factor>`__. For a full derivation
     see :cite:`Farrow2009`. Note that the definition requires :math:`S(0) = N`.
 
+    .. note::
+        For true 2D systems the formula one should use is different to the one 
+        reported above. See this `link 
+        <http://www.scik.org/index.php/jmcs/article/viewFile/263/120>`__ 
+        for more information. For users wishing to calculate the structure 
+        factor of quasi 2D systems (when a 2D simulation is used to simulate 
+        a real system such as particles on a 2D interface or similar) the 3D 
+        formula should be used. In these cases the users are advised to convert
+        the 2D box to a 3D box with third dimension coordinates being set to 0.0
+        and length of third dimension being set to larger of the other two 
+        before using the method.
+
     This implementation uses an evenly spaced number of :math:`k` points between
     `k_min`` and ``k_max``. If ``k_min`` is set to 0 (the default behavior), the
     computed structure factor will show :math:`S(0) = N`.


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above. -->

## Description

This PR fixes the bug which was introduced in #936 which does not account for the change in geometry that occurs when going from 3D to 2D. The fix uses a cylindrical bessel function instead of a sinc function.

## Motivation and Context
Resolves: #985 

## How Has This Been Tested?

No new tests have been added yet, but they will. I am still looking for a library to compare to which will validate this calculation. ASE was used to validate the 3D case, but they can't handle 2D systems.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds or improves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation improvement (updates to user guides, docstrings, or developer docs)

## Checklist:
<!-- Put an `x` in all the boxes that apply. If you're unsure about any of
     these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [**CONTRIBUTING**](https://github.com/glotzerlab/freud/blob/master/CONTRIBUTING.md) document.
- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation (if relevant).
- [ ] I have added tests that cover my changes (if relevant).
- [ ] All new and existing tests passed.
- [ ] I have updated the [credits](https://github.com/glotzerlab/freud/blob/master/doc/source/reference/credits.rst).
- [ ] I have updated the [Changelog](https://github.com/glotzerlab/freud/blob/master/ChangeLog.md).
