### PR TITLE
RDF Normalization Mode Argument

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,11 @@ The format is based on
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v3.0.0 -- YYYY-MM-DD
+
+### Changed
+* The `normalize` argument to `freud.density.RDF` is now `normalization_mode`.
+
 ## v2.11.0 -- 2022-08-09
 
 ### Added

--- a/cpp/density/RDF.cc
+++ b/cpp/density/RDF.cc
@@ -12,7 +12,7 @@
 namespace freud { namespace density {
 
 RDF::RDF(unsigned int bins, float r_max, float r_min, NormalizationMode normalization_mode)
-    : BondHistogramCompute(), m_norm_mode(norm_mode)
+    : BondHistogramCompute(), m_norm_mode(normalization_mode)
 {
     if (bins == 0)
     {

--- a/cpp/density/RDF.cc
+++ b/cpp/density/RDF.cc
@@ -11,7 +11,7 @@
 
 namespace freud { namespace density {
 
-RDF::RDF(unsigned int bins, float r_max, float r_min, NormalizationMode norm_mode)
+RDF::RDF(unsigned int bins, float r_max, float r_min, NormalizationMode normalization_mode)
     : BondHistogramCompute(), m_norm_mode(norm_mode)
 {
     if (bins == 0)

--- a/cpp/density/RDF.cc
+++ b/cpp/density/RDF.cc
@@ -11,8 +11,8 @@
 
 namespace freud { namespace density {
 
-RDF::RDF(unsigned int bins, float r_max, float r_min, bool normalize)
-    : BondHistogramCompute(), m_normalize(normalize)
+RDF::RDF(unsigned int bins, float r_max, float r_min, NormalizationMode norm_mode)
+    : BondHistogramCompute(), m_norm_mode(norm_mode)
 {
     if (bins == 0)
     {
@@ -59,7 +59,7 @@ void RDF::reduce()
 
     // Define prefactors with appropriate types to simplify and speed later code.
     float number_density = float(m_n_query_points) / m_box.getVolume();
-    if (m_normalize)
+    if (m_norm_mode == NormalizationMode::infer)
     {
         number_density *= static_cast<float>(m_n_query_points - 1) / static_cast<float>(m_n_query_points);
     }

--- a/cpp/density/RDF.cc
+++ b/cpp/density/RDF.cc
@@ -59,7 +59,7 @@ void RDF::reduce()
 
     // Define prefactors with appropriate types to simplify and speed later code.
     float number_density = float(m_n_query_points) / m_box.getVolume();
-    if (m_norm_mode == NormalizationMode::infer)
+    if (m_norm_mode == NormalizationMode::finite_size)
     {
         number_density *= static_cast<float>(m_n_query_points - 1) / static_cast<float>(m_n_query_points);
     }

--- a/cpp/density/RDF.h
+++ b/cpp/density/RDF.h
@@ -16,8 +16,16 @@ namespace freud { namespace density {
 class RDF : public locality::BondHistogramCompute
 {
 public:
+
+    enum NormalizationMode
+    {
+        infer,
+        finite_size
+    };
+
     //! Constructor
-    RDF(unsigned int bins, float r_max, float r_min = 0, bool normalize = false);
+    RDF(unsigned int bins, float r_max, float r_min = 0,
+            NormalizationMode normalization_mode = NormalizationMode::infer);
 
     //! Destructor
     ~RDF() override = default;
@@ -51,7 +59,7 @@ public:
     }
 
 private:
-    bool m_normalize;                //!< Whether to enforce that the RDF should tend to 1 (instead of
+    NormalizationMode m_norm_mode;   //!< Whether to enforce that the RDF should tend to 1 (instead of
                                      //!< num_query_points/num_points).
     util::ManagedArray<float> m_pcf; //!< The computed pair correlation function.
     util::ManagedArray<float>

--- a/cpp/density/RDF.h
+++ b/cpp/density/RDF.h
@@ -16,7 +16,6 @@ namespace freud { namespace density {
 class RDF : public locality::BondHistogramCompute
 {
 public:
-
     enum NormalizationMode
     {
         infer,
@@ -25,7 +24,7 @@ public:
 
     //! Constructor
     RDF(unsigned int bins, float r_max, float r_min = 0,
-            NormalizationMode normalization_mode = NormalizationMode::infer);
+        NormalizationMode normalization_mode = NormalizationMode::infer);
 
     //! Destructor
     ~RDF() override = default;

--- a/cpp/density/RDF.h
+++ b/cpp/density/RDF.h
@@ -16,15 +16,16 @@ namespace freud { namespace density {
 class RDF : public locality::BondHistogramCompute
 {
 public:
+    //! Enum for each normalization mode
     enum NormalizationMode
     {
-        infer,
+        exact,
         finite_size
     };
 
     //! Constructor
     RDF(unsigned int bins, float r_max, float r_min = 0,
-        NormalizationMode normalization_mode = NormalizationMode::infer);
+        NormalizationMode normalization_mode = NormalizationMode::exact);
 
     //! Destructor
     ~RDF() override = default;

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -78,7 +78,7 @@ release = "2.11.0"
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = 'en'
+language = "en"
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -78,7 +78,7 @@ release = "2.11.0"
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = 'en'
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:

--- a/doc/source/gettingstarted/migration.rst
+++ b/doc/source/gettingstarted/migration.rst
@@ -1,0 +1,25 @@
+.. _migration:
+
+============================
+Migration to freud Version 3
+============================
+
+Version 3 of the freud library introduces a few breaking changes to make the API
+more intuitive and facilitate future development. This guide explains how to
+alter scripts which use freud v2 APIs so they can be used with freud version 3.
+
+Overview of API Changes
+=======================
+
+.. list-table::
+    :header-rows: 1
+
+    * - Goal
+      - v2 API
+      - v3 API
+    * - Use default RDF normalization.
+      - ``freud.density.RDF(..., normalize=False)``
+      - ``freud.density.RDF(..., normalization_mode='infer')``
+    * - Normalize small system RDFs to 1.
+      - ``freud.density.RDF(..., normalize=True)``
+      - ``freud.density.RDF(..., normalization_mode='finite_size')``

--- a/doc/source/gettingstarted/migration.rst
+++ b/doc/source/gettingstarted/migration.rst
@@ -6,7 +6,7 @@ Migration to freud Version 3
 
 Version 3 of the freud library introduces a few breaking changes to make the API
 more intuitive and facilitate future development. This guide explains how to
-alter scripts which use freud v2 APIs so they can be used with freud version 3.
+alter scripts which use freud v2 APIs so they can be used with freud v3.
 
 Overview of API Changes
 =======================
@@ -19,7 +19,7 @@ Overview of API Changes
       - v3 API
     * - Use default RDF normalization.
       - ``freud.density.RDF(..., normalize=False)``
-      - ``freud.density.RDF(..., normalization_mode='infer')``
+      - ``freud.density.RDF(..., normalization_mode='exact')``
     * - Normalize small system RDFs to 1.
       - ``freud.density.RDF(..., normalize=True)``
       - ``freud.density.RDF(..., normalization_mode='finite_size')``

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -10,6 +10,7 @@ Table of Contents
    gettingstarted/introduction
    gettingstarted/installation
    gettingstarted/quickstart
+   gettingstarted/migration
    gettingstarted/tutorial
    gettingstarted/examples
 

--- a/doc/source/reference/credits.rst
+++ b/doc/source/reference/credits.rst
@@ -332,6 +332,7 @@ Tommy Waltmann
 * ``DiffractionPattern`` now raises an error when used with non-cubic boxes.
 * Implement ``StaticStructureFactorDebye`` for 2D systems.
 * Add support for compilation with the C++17 standard.
+* Update and test the ``normalization_mode`` argument to ``freud.density.RDF`` class.
 
 Maya Martirossyan
 

--- a/freud/_density.pxd
+++ b/freud/_density.pxd
@@ -49,7 +49,12 @@ cdef extern from "LocalDensity.h" namespace "freud::density":
 
 cdef extern from "RDF.h" namespace "freud::density":
     cdef cppclass RDF(BondHistogramCompute):
-        RDF(float, float, float, bool) except +
+
+        ctypedef enum NormalizationMode "NormalizationMode":
+            infer "NormalizationMode::infer"
+            finite_size "NormalizationMode::finite_size"
+
+        RDF(float, float, float, NormalizationMode) except +
         const freud._box.Box & getBox() const
         void accumulate(const freud._locality.NeighborQuery*,
                         const vec3[float]*,

--- a/freud/_density.pxd
+++ b/freud/_density.pxd
@@ -51,7 +51,7 @@ cdef extern from "RDF.h" namespace "freud::density":
     cdef cppclass RDF(BondHistogramCompute):
 
         ctypedef enum NormalizationMode "NormalizationMode":
-            infer "freud::density::RDF::NormalizationMode::infer"
+            exact "freud::density::RDF::NormalizationMode::exact"
             finite_size "freud::density::RDF::NormalizationMode::finite_size"
 
         RDF(float, float, float, NormalizationMode) except +

--- a/freud/_density.pxd
+++ b/freud/_density.pxd
@@ -51,8 +51,8 @@ cdef extern from "RDF.h" namespace "freud::density":
     cdef cppclass RDF(BondHistogramCompute):
 
         ctypedef enum NormalizationMode "NormalizationMode":
-            infer "NormalizationMode::infer"
-            finite_size "NormalizationMode::finite_size"
+            infer "freud::density::RDF::NormalizationMode::infer"
+            finite_size "freud::density::RDF::NormalizationMode::finite_size"
 
         RDF(float, float, float, NormalizationMode) except +
         const freud._box.Box & getBox() const

--- a/freud/density.pyx
+++ b/freud/density.pyx
@@ -582,11 +582,15 @@ cdef class RDF(_SpatialHistogram1D):
     systems of 100 particles the RDF will differ by 1%).
 
     .. note::
-        The ``normalization_mode`` argument should not be used if
-        :code:`query_points` is provided as a different set of points, or if
-        unusual query arguments are provided to :meth:`~.compute`, specifically
-        if :code:`exclude_ii` is set to :code:`False`. This normalization is
-        not meaningful in such cases and will simply convolute the data.
+        For correct normalization behavior when using
+        ``normalization_mode='infer'``, let the set of points be either: 1) the
+        same as the set of query points or 2) completely disjoint from the set
+        of query points.
+
+    .. note::
+        For correct normalization behavior when using
+        ``normalization_mode='finite_size'``, do not allow particles to be their
+        own neighbor.
 
     .. note::
         **2D:** :class:`freud.density.RDF` properly handles 2D boxes.

--- a/freud/density.pyx
+++ b/freud/density.pyx
@@ -611,7 +611,7 @@ cdef class RDF(_SpatialHistogram1D):
             ``finite_size``, adds an extra rescaling factor of
             :math:`\frac{N_{query\_points}}{N_{query\_ponts} - 1}` so the RDF
             values will tend to 1 at large :math:`r` for small systems (Default
-            value = :code:`'infer'`).
+            value = :code:`'exact'`).
     """
     cdef freud._density.RDF * thisptr
 

--- a/freud/density.pyx
+++ b/freud/density.pyx
@@ -585,12 +585,12 @@ cdef class RDF(_SpatialHistogram1D):
         For correct normalization behavior when using
         ``normalization_mode='exact'``, let the set of points be either: 1) the
         same as the set of query points or 2) completely disjoint from the set
-        of query points.
+        of query points (points shouldn't contain any particles in query points).
 
     .. note::
         For correct normalization behavior when using
         ``normalization_mode='finite_size'``, do not allow particles to be their
-        own neighbor.
+        own neighbor (:code:`exclude_ii` must be set to :code:`False`).
 
     .. note::
         **2D:** :class:`freud.density.RDF` properly handles 2D boxes.

--- a/freud/density.pyx
+++ b/freud/density.pyx
@@ -610,10 +610,11 @@ cdef class RDF(_SpatialHistogram1D):
     cdef freud._density.RDF * thisptr
 
     def __cinit__(self, unsigned int bins, float r_max, float r_min=0,
-                  normalize=False):
+                  normalization_mode='infer'):
+        norm_mode = self._validate_normalization_mode(normalization_mode)
         if type(self) == RDF:
             self.thisptr = self.histptr = new freud._density.RDF(
-                bins, r_max, r_min, normalize)
+                bins, r_max, r_min, norm_mode)
 
             # r_max is left as an attribute rather than a property for now
             # since that change needs to happen at the _SpatialHistogram level
@@ -623,6 +624,14 @@ cdef class RDF(_SpatialHistogram1D):
     def __dealloc__(self):
         if type(self) == RDF:
             del self.thisptr
+
+    def _validate_normalization_mode(self, mode):
+        if mode == 'infer':
+            return freud._density.RDF.NormalizationMode.infer
+        elif mode == 'finite_size':
+            return freud._density.RDF.NormalizationMode.finite_size
+        else:
+            raise ValueError(f"invalid input {mode} for normalization_mode")
 
     def compute(self, system, query_points=None, neighbors=None,
                 reset=True):

--- a/freud/density.pyx
+++ b/freud/density.pyx
@@ -583,7 +583,7 @@ cdef class RDF(_SpatialHistogram1D):
 
     .. note::
         For correct normalization behavior when using
-        ``normalization_mode='infer'``, let the set of points be either: 1) the
+        ``normalization_mode='exact'``, let the set of points be either: 1) the
         same as the set of query points or 2) completely disjoint from the set
         of query points.
 
@@ -606,7 +606,7 @@ cdef class RDF(_SpatialHistogram1D):
             (Default value = :code:`0`).
         normalization_mode (str, optional):
             There are two valid string inputs for this argument. The first
-            option, ``infer``, handles the normalization as shown mathematically
+            option, ``exact``, handles the normalization as shown mathematically
             at the beginning of this class's docstring. The other option,
             ``finite_size``, adds an extra rescaling factor of
             :math:`\frac{N_{query\_points}}{N_{query\_ponts} - 1}` so the RDF
@@ -616,7 +616,7 @@ cdef class RDF(_SpatialHistogram1D):
     cdef freud._density.RDF * thisptr
 
     def __cinit__(self, unsigned int bins, float r_max, float r_min=0,
-                  normalization_mode='infer'):
+                  normalization_mode='exact'):
         norm_mode = self._validate_normalization_mode(normalization_mode)
         if type(self) == RDF:
             self.thisptr = self.histptr = new freud._density.RDF(
@@ -633,8 +633,8 @@ cdef class RDF(_SpatialHistogram1D):
 
     def _validate_normalization_mode(self, mode):
         """Ensure the normalization mode is one of the approved values."""
-        if mode == 'infer':
-            return freud._density.RDF.NormalizationMode.infer
+        if mode == 'exact':
+            return freud._density.RDF.NormalizationMode.exact
         elif mode == 'finite_size':
             return freud._density.RDF.NormalizationMode.finite_size
         else:

--- a/freud/density.pyx
+++ b/freud/density.pyx
@@ -582,15 +582,15 @@ cdef class RDF(_SpatialHistogram1D):
     systems of 100 particles the RDF will differ by 1%).
 
     .. note::
-        For correct normalization behavior when using
-        ``normalization_mode='exact'``, let the set of points be either: 1) the
-        same as the set of query points or 2) completely disjoint from the set
-        of query points (points shouldn't contain any particles in query points).
+        For correct normalization behavior, let the set of points be either: 1)
+        the same as the set of query points or 2) completely disjoint from the
+        set of query points (points shouldn't contain any particles in query
+        points).
 
     .. note::
         For correct normalization behavior when using
-        ``normalization_mode='finite_size'``, do not allow particles to be their
-        own neighbor (:code:`exclude_ii` must be set to :code:`False`).
+        ``normalization_mode='finite_size'``, the ``points`` _must_ be the same
+        as the ``query_points`` and ``exclude_ii`` must be set to ``False``.
 
     .. note::
         **2D:** :class:`freud.density.RDF` properly handles 2D boxes.

--- a/tests/test_density_RDF.py
+++ b/tests/test_density_RDF.py
@@ -71,6 +71,19 @@ class TestRDF:
             freud.density.RDF(r_max=1, bins=10, r_min=2)
         with pytest.raises(ValueError):
             freud.density.RDF(r_max=1, bins=10, r_min=-1)
+        with pytest.raises(ValueError):
+            freud.density.RDF(r_max=1, bins=10, r_min=-1, normalization_mode='blah')
+
+    @pytest.mark.parametrize("mode", ['infer', 'finite_size'])
+    def test_normalization_mode(self, mode):
+        """Make sure RDF can be computed with different normalization modes."""
+        r_max = 10.0
+        bins = 10
+        num_points = 100
+        box_size = r_max * 3.1
+        sys = freud.data.make_random_system(box_size, num_points, is2D=True)
+        rdf = freud.density.RDF(r_max=r_max, bins=bins, normalization_mode=mode)
+        rdf.compute(sys)
 
     @pytest.mark.parametrize("r_min", [0, 0.1, 3.0])
     def test_random_point(self, r_min):

--- a/tests/test_density_RDF.py
+++ b/tests/test_density_RDF.py
@@ -74,7 +74,7 @@ class TestRDF:
         with pytest.raises(ValueError):
             freud.density.RDF(r_max=1, bins=10, r_min=-1, normalization_mode="blah")
 
-    @pytest.mark.parametrize("mode", ["infer", "finite_size"])
+    @pytest.mark.parametrize("mode", ["exact", "finite_size"])
     def test_normalization_mode(self, mode):
         """Make sure RDF can be computed with different normalization modes."""
         r_max = 10.0

--- a/tests/test_density_RDF.py
+++ b/tests/test_density_RDF.py
@@ -72,9 +72,9 @@ class TestRDF:
         with pytest.raises(ValueError):
             freud.density.RDF(r_max=1, bins=10, r_min=-1)
         with pytest.raises(ValueError):
-            freud.density.RDF(r_max=1, bins=10, r_min=-1, normalization_mode='blah')
+            freud.density.RDF(r_max=1, bins=10, r_min=-1, normalization_mode="blah")
 
-    @pytest.mark.parametrize("mode", ['infer', 'finite_size'])
+    @pytest.mark.parametrize("mode", ["infer", "finite_size"])
     def test_normalization_mode(self, mode):
         """Make sure RDF can be computed with different normalization modes."""
         r_max = 10.0


### PR DESCRIPTION
## Description

This PR changes the `normalize` argument to `freud.density.RDF` to be more descriptive, and clarifies what the default value is.

## Motivation and Context

There was a lot of discussion about how the RDF should be normalized, what the options should be, and how the API should look in the issues linked below.

Resolves: #635 
Related to #396

## How Has This Been Tested?

I have added a test for both of the valid arguments, and a test case for the invalid arguments.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds or improves functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation improvement (updates to user guides, docstrings, or developer docs)

## Checklist:
<!-- Put an `x` in all the boxes that apply. If you're unsure about any of
     these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/glotzerlab/freud/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] I have updated the documentation (if relevant).
- [x] I have added tests that cover my changes (if relevant).
- [x] All new and existing tests passed.
- [ ] I have updated the [credits](https://github.com/glotzerlab/freud/blob/master/doc/source/reference/credits.rst).
- [ ] I have updated the [Changelog](https://github.com/glotzerlab/freud/blob/master/ChangeLog.md).
