### PR TITLE
MDAnalysis Timestep Compatibility

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -9,6 +9,9 @@ and this project adheres to
 ### Added
 * Mass dependence in `freud.cluster.ClusterProperties` and calculation of inertia tensor and center of mass.
 
+### Fixed
+* Compatibility with new namespace for `MDAnalysis.coordinates.timestep.Timestep`.
+
 ## v2.11.0 -- 2022-08-09
 
 ### Added

--- a/freud/locality.pyx
+++ b/freud/locality.pyx
@@ -286,7 +286,7 @@ cdef class NeighborQuery:
         * A sequence of :code:`(box, points)` where :code:`box` is a
           :class:`~.box.Box` and :code:`points` is a :class:`numpy.ndarray`.
         * Objects with attributes :code:`box` and :code:`points`.
-        * :class:`MDAnalysis.coordinates.base.Timestep`
+        * :class:`MDAnalysis.coordinates.timestep.Timestep`
         * :class:`gsd.hoomd.Snapshot`
         * :class:`garnett.trajectory.Frame`
         * :class:`ovito.data.DataCollection`
@@ -315,7 +315,7 @@ cdef class NeighborQuery:
             return system
 
         # MDAnalysis compatibility
-        elif _match_class_path(system, 'MDAnalysis.coordinates.base.Timestep'):
+        elif _match_class_path(system, 'MDAnalysis.coordinates.timestep.Timestep'):
             system = (system.triclinic_dimensions, system.positions)
 
         # GSD and HOOMD-blue 3 snapshot compatibility

--- a/freud/locality.pyx
+++ b/freud/locality.pyx
@@ -315,7 +315,11 @@ cdef class NeighborQuery:
             return system
 
         # MDAnalysis compatibility
-        elif _match_class_path(system, 'MDAnalysis.coordinates.timestep.Timestep'):
+        # base namespace for mdanalysis<2.3.0
+        # timestep namespace for mdanalysis>=2.3.0
+        elif _match_class_path(system,
+                               'MDAnalysis.coordinates.base.Timestep',
+                               'MDAnalysis.coordinates.timestep.Timestep'):
             system = (system.triclinic_dimensions, system.positions)
 
         # GSD and HOOMD-blue 3 snapshot compatibility


### PR DESCRIPTION
## Description

The 2.3.0 release of `mdanalysis` changed the namespace of the Timestep object from `MDAnalysis.coordinates.base.Timestep` to `MDAnalysis.coordinates.timestep.Timestep`, leaving our code incompatible with the 2.3.0 release. This PR adds compatibility with the newer release of MDAnalysis, while retaining compatibility with older versions.

## Motivation and Context
Resolves: #1024 
May also fix the failing tests on glotzerlab/freud-examples#52 and glotzerlab/freud-examples#53

## How Has This Been Tested?

I have run tests locally in environments with mdanalysis 2.3.0 install and a different environment with mdanalysis 2.2.0 installed.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds or improves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation improvement (updates to user guides, docstrings, or developer docs)

## Checklist:
<!-- Put an `x` in all the boxes that apply. If you're unsure about any of
     these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [**CONTRIBUTING**](https://github.com/glotzerlab/freud/blob/master/CONTRIBUTING.md) document.
- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation (if relevant).
- [ ] I have added tests that cover my changes (if relevant).
- [ ] All new and existing tests passed.
- [ ] I have updated the [credits](https://github.com/glotzerlab/freud/blob/master/doc/source/reference/credits.rst).
- [ ] I have updated the [Changelog](https://github.com/glotzerlab/freud/blob/master/ChangeLog.md).
