### PR TITLE
Return self on all compute methods

### DIFF
--- a/freud/environment.pyx
+++ b/freud/environment.pyx
@@ -811,6 +811,7 @@ cdef class EnvironmentMotifMatch(_MatchEnv):
             <vec3[float]*>
             <vec3[float]*> &l_motif[0, 0], nRef,
             threshold, registration)
+        return self
 
     @_Compute._computed_property
     def matches(self):

--- a/freud/order.pyx
+++ b/freud/order.pyx
@@ -861,6 +861,7 @@ cdef class SolidLiquid(_PairCompute):
         self.thisptr.compute(nlist.get_ptr(),
                              nq.get_ptr(),
                              dereference(qargs.thisptr))
+        return self
 
     @property
     def l(self):  # noqa: E743

--- a/tests/test_environment_MatchEnv.py
+++ b/tests/test_environment_MatchEnv.py
@@ -454,9 +454,10 @@ class TestEnvironmentMotifMatch:
         num_neighbors = 4
 
         box = freud.box.Box.square(3)
-        match = freud.environment.EnvironmentMotifMatch()
         query_args = dict(r_guess=r_max, num_neighbors=num_neighbors)
-        match.compute((box, points), motif, 0.1, neighbors=query_args)
+        match = freud.environment.EnvironmentMotifMatch().compute(
+            (box, points), motif, 0.1, neighbors=query_args
+        )
         matches = match.matches
 
         for i in range(len(motif)):

--- a/tests/test_order_SolidLiquid.py
+++ b/tests/test_order_SolidLiquid.py
@@ -27,8 +27,9 @@ class TestSolidLiquid:
         box, positions = freud.data.make_random_system(L, N)
 
         query_args = dict(r_max=2.0, exclude_ii=True)
-        comp = freud.order.SolidLiquid(6, q_threshold=0.7, solid_threshold=6)
-        comp.compute((box, positions), neighbors=query_args)
+        comp = freud.order.SolidLiquid(6, q_threshold=0.7, solid_threshold=6).compute(
+            (box, positions), neighbors=query_args
+        )
 
         aq = freud.locality.AABBQuery(box, positions)
         nlist = aq.query(positions, query_args).toNeighborList()


### PR DESCRIPTION
## Description

This PR makes the necessary changes so that the `compute()` method of all compute objects return the calling object. The two classes that needed updating were `order.SolidLiquid` and `environment.EnvironmentMotifMatch`

## Motivation and Context
Resolves: #1060 

## How Has This Been Tested?

Two tests have been slightly modified to enforce this.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds or improves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation improvement (updates to user guides, docstrings, or developer docs)

## Checklist:
<!-- Put an `x` in all the boxes that apply. If you're unsure about any of
     these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [**CONTRIBUTING**](https://github.com/glotzerlab/freud/blob/master/CONTRIBUTING.md) document.
- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation (if relevant).
- [ ] I have added tests that cover my changes (if relevant).
- [ ] All new and existing tests passed.
- [ ] I have updated the [credits](https://github.com/glotzerlab/freud/blob/master/doc/source/reference/credits.rst).
- [ ] I have updated the [Changelog](https://github.com/glotzerlab/freud/blob/master/ChangeLog.md).
