### PR TITLE
changed name of neighbors argument

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -12,6 +12,8 @@ and this project adheres to
 
 ### Changed
 * The `normalize` argument to `freud.density.RDF` is now `normalization_mode`.
+* The ``neighbors`` argument to ``env_neighbors`` for ``EnvironmentMotifMatch`` class.
+* The ``neighbors`` argument to ``cluster_neighbors`` for ``EnvironmentCluster`` class.
 
 ## v2.12.1 -- 2022-12-05
 

--- a/cpp/environment/MatchEnv.h
+++ b/cpp/environment/MatchEnv.h
@@ -246,14 +246,15 @@ public:
     //! Determine clusters of particles with matching environments
     /*! This is the primary interface to EnvironmentCluster. It computes particle
      * environments and then attempts to cluster nearby particles with similar
-     * environments, unless global is set true. Otherwise, it performs a
-     * pairwise comparison of all particle environments to perform the match.
-     * WARNING: A global search can be extremely slow.
-     * This is taken from Cluster.cc and SolLiq.cc and LocalQlNear.cc
+     * environments. It performs a pairwise comparison of all particle environments
+     * to perform the match.
      *
-     * \param env_nlist The NeighborList used to build the environment of every particle.
-     * \param nlist The NeighborList used to determine the neighbors against which
-     *              to compare environments for every particle, if hard_r = False.
+     * \param nq The NeighborQuery used to hold system data and query for neighbors.
+     * \param nlist_arg The NeighborList used to determine the neighbors against which to
+     *                  compare environments.
+     * \param qargs Query arguments to build the cluster neighbors.
+     * \param env_nlist_arg The NeighborList used to build the environment of every particle.
+     * \param env_qargs Query arguments to build the env neighbors.
      * \param threshold This quantity is of the maximum magnitude of the
      *                  vector difference between two vectors, below which
      *                  you call them matching. Recommended values for the
@@ -323,25 +324,18 @@ class EnvironmentMotifMatch : public MatchEnv
 {
 public:
     //! Constructor
-    /*!
-     * \param box The system box.
-     * \param num_neighbors Number of nearest neighbors taken to define the local environment of any given
-     * particle.
-     */
     EnvironmentMotifMatch() : MatchEnv() {}
 
     //! Determine whether particles match a given input motif.
     /*! Given a motif composed of vectors that represent the vectors connecting
-     * a point to the neighbors that are part of the motif, matchMotif looks at
-     * every point in points and checks if its neighbors may match this motif.
-     * Any point whose local environment matches the motif is marked as part of
-     * cluster 0 in the clusters array. All others are ignored. The
-     * tot_environments array is updated with the vectors composing the
+     * a point to the neighbors that are part of the motif, the compute method looks
+     * at every point and checks if its neighbors may match this motif. The
+     * point_environments array is updated with the vectors composing the
      * environment of every particle.
      *
-     * \param nlist A NeighborList instance.
-     * \param points The points to test against the motif.
-     * \param Np The number of points.
+     * \param nq The NeighborQuery used to hold system data and query for neighbors.
+     * \param nlist_arg The NeighborList defining particle environments.
+     * \param qargs Query arguments used to define nlist_args.
      * \param motif The vectors characterizing the motif. Note that these are
      *              vectors, so for instance given a square motif composed of
      *              points at the corners of a square, the motif should not

--- a/doc/source/gettingstarted/migration.rst
+++ b/doc/source/gettingstarted/migration.rst
@@ -41,4 +41,3 @@ Overview of API Changes
     * - Use ``EnvironmentCluster`` with a set of neighbors that define the cluster
       - ``freud.environment.EnvironmentCluster().compute(..., neighbors=...)``
       - ``freud.environment.EnvironmentCluster().compute(..., cluster_neighbors=...)``
-

--- a/doc/source/gettingstarted/migration.rst
+++ b/doc/source/gettingstarted/migration.rst
@@ -32,3 +32,10 @@ Overview of API Changes
     * - Create a custom neighborlist from arrays.
       - ``freud.locality.NeighborList.from_arrays(..., distances=...)``
       - ``freud.locality.NeighborList.from_arrays(..., vectors=...)``
+    * - Use ``EnvironmentMotifMatch`` with a set of neighbors
+      - ``freud.environment.EnvironmentMotifMatch().compute(..., neighbors=...)``
+      - ``freud.environment.EnvironmentMotifMatch().compute(..., env_neighbors=...)``
+    * - Use ``EnvironmentCluster`` with a set of neighbors that define the cluster
+      - ``freud.environment.EnvironmentCluster().compute(..., neighbors=...)``
+      - ``freud.environment.EnvironmentCluster().compute(..., cluster_neighbors=...)``
+      

--- a/doc/source/gettingstarted/migration.rst
+++ b/doc/source/gettingstarted/migration.rst
@@ -41,4 +41,4 @@ Overview of API Changes
     * - Use ``EnvironmentCluster`` with a set of neighbors that define the cluster
       - ``freud.environment.EnvironmentCluster().compute(..., neighbors=...)``
       - ``freud.environment.EnvironmentCluster().compute(..., cluster_neighbors=...)``
-      
+

--- a/doc/source/reference/credits.rst
+++ b/doc/source/reference/credits.rst
@@ -379,6 +379,7 @@ Alain Kadar
 Melody Zhang
 
 * Changed ``neighbors`` argument to ``env_neighbors`` for ``EnvironmentMotifMatch`` class and to ``cluster_neighbors`` for ``EnvironmentCluster`` class.
+
 Source code
 -----------
 

--- a/doc/source/reference/credits.rst
+++ b/doc/source/reference/credits.rst
@@ -375,6 +375,9 @@ Alain Kadar
 
 * Introduced mass dependence for ``ClusterProperties`` class, inertia tensor and radius of gyration.
 
+Melody Zhang
+
+* Changed ``neighbors`` argument to ``env_neighbors`` for ``EnvironmentMotifMatch`` class and to ``cluster_neighbors`` for ``EnvironmentCluster`` class. 
 Source code
 -----------
 

--- a/freud/environment.pyx
+++ b/freud/environment.pyx
@@ -527,7 +527,7 @@ cdef class EnvironmentCluster(_MatchEnv):
     def __dealloc__(self):
         del self.thisptr
 
-    def compute(self, system, threshold, neighbors=None,
+    def compute(self, system, threshold, cluster_neighbors=None,
                 env_neighbors=None, registration=False,
                 global_search=False):
         r"""Determine clusters of particles with matching environments.
@@ -602,7 +602,7 @@ cdef class EnvironmentCluster(_MatchEnv):
             >>> env_cluster.compute(
             ...     system = (box, points),
             ...     threshold=0.2,
-            ...     neighbors={'num_neighbors': 6},
+            ...     cluster_neighbors={'num_neighbors': 6},
             ...     registration=False,
             ...     global_search=False)
             freud.environment.EnvironmentCluster()
@@ -616,7 +616,7 @@ cdef class EnvironmentCluster(_MatchEnv):
                 below which they are "matching". Typically, a good choice is
                 between 10% and 30% of the first well in the radial
                 distribution function (this has distance units).
-            neighbors (:class:`freud.locality.NeighborList` or dict, optional):
+            cluster_neighbors (:class:`freud.locality.NeighborList` or dict, optional):
                 Either a :class:`NeighborList <freud.locality.NeighborList>` of
                 neighbor pairs to use in the calculation, or a dictionary of
                 `query arguments
@@ -654,7 +654,7 @@ cdef class EnvironmentCluster(_MatchEnv):
             unsigned int num_query_points
 
         nq, nlist, qargs, l_query_points, num_query_points = \
-            self._preprocess_arguments(system, neighbors=neighbors)
+            self._preprocess_arguments(system, neighbors=cluster_neighbors)
 
         if env_neighbors is None:
             env_neighbors = neighbors
@@ -766,7 +766,7 @@ cdef class EnvironmentMotifMatch(_MatchEnv):
                 below which they are "matching". Typically, a good choice is
                 between 10% and 30% of the first well in the radial
                 distribution function (this has distance units).
-            neighbors (:class:`freud.locality.NeighborList` or dict, optional):
+            env_neighbors (:class:`freud.locality.NeighborList` or dict, optional):
                 Either a :class:`NeighborList <freud.locality.NeighborList>` of
                 neighbor pairs to use in the calculation, or a dictionary of
                 `query arguments

--- a/freud/environment.pyx
+++ b/freud/environment.pyx
@@ -787,7 +787,7 @@ cdef class EnvironmentMotifMatch(_MatchEnv):
             unsigned int num_query_points
 
         nq, nlist, qargs, l_query_points, num_query_points = \
-            self._preprocess_arguments(system, neighbors=neighbors)
+            self._preprocess_arguments(system, neighbors=env_neighbors)
 
         motif = freud.util._convert_array(motif, shape=(None, 3))
         if (motif == 0).all(axis=1).any():

--- a/freud/environment.pyx
+++ b/freud/environment.pyx
@@ -537,8 +537,8 @@ cdef class EnvironmentCluster(_MatchEnv):
         For example, :code:`env_neighbors= {'num_neighbors': 8}` means that every
         particle's local environment is defined by its 8 nearest neighbors.
         Then, each particle's environment is compared to the environments of
-        particles that satisfy a different cutoff parameter :code:`neighbors`.
-        For example, :code:`neighbors={'r_max': 3.0}`
+        particles that satisfy a different cutoff parameter :code:`cluster_neighbors`.
+        For example, :code:`cluster_neighbors={'r_max': 3.0}`
         means that the environment of each particle will be compared to the
         environment of every particle within a distance of 3.0.
 
@@ -664,7 +664,7 @@ cdef class EnvironmentCluster(_MatchEnv):
             warnings.warn(
                 "The global search option is deprecated and will be removed in "
                 "version 3.0. If you want this behavior, use a NeighborList "
-                "composed of all pairs of particles in the system as the `neighbors`.",
+                "composed of all pairs of particles in the system as the `cluster_neighbors`.",
                 FutureWarning
             )
 

--- a/freud/environment.pyx
+++ b/freud/environment.pyx
@@ -657,7 +657,7 @@ cdef class EnvironmentCluster(_MatchEnv):
             self._preprocess_arguments(system, neighbors=cluster_neighbors)
 
         if env_neighbors is None:
-            env_neighbors = neighbors
+            env_neighbors = cluster_neighbors
         env_nlist, env_qargs = self._resolve_neighbors(env_neighbors)
 
         if global_search:

--- a/freud/environment.pyx
+++ b/freud/environment.pyx
@@ -743,7 +743,7 @@ cdef class EnvironmentMotifMatch(_MatchEnv):
     def __init__(self):
         pass
 
-    def compute(self, system, motif, threshold, neighbors=None,
+    def compute(self, system, motif, threshold, env_neighbors=None,
                 registration=False):
         r"""Determine which particles have local environments
             matching the given environment motif.

--- a/tests/test_environment_MatchEnv.py
+++ b/tests/test_environment_MatchEnv.py
@@ -456,7 +456,7 @@ class TestEnvironmentMotifMatch:
         box = freud.box.Box.square(3)
         match = freud.environment.EnvironmentMotifMatch()
         query_args = dict(r_guess=r_max, num_neighbors=num_neighbors)
-        match.compute((box, points), motif, 0.1, neighbors=query_args)
+        match.compute((box, points), motif, 0.1, env_neighbors=query_args)
         matches = match.matches
 
         for i in range(len(motif)):
@@ -473,7 +473,7 @@ class TestEnvironmentMotifMatch:
         match = freud.environment.EnvironmentMotifMatch()
         query_args = dict(num_neighbors=num_neighbors)
         with pytest.warns(RuntimeWarning):
-            match.compute((box, motif), motif, 0.1, neighbors=query_args)
+            match.compute((box, motif), motif, 0.1, env_neighbors=query_args)
 
 
 class TestEnvironmentRMSDMinimizer:

--- a/tests/test_environment_MatchEnv.py
+++ b/tests/test_environment_MatchEnv.py
@@ -130,7 +130,9 @@ class TestCluster:
 
         match = freud.environment.EnvironmentCluster()
         query_args = dict(r_guess=r_max, num_neighbors=num_neighbors)
-        match.compute((box, xyz), threshold, registration=False, cluster_neighbors=query_args)
+        match.compute(
+            (box, xyz), threshold, registration=False, cluster_neighbors=query_args
+        )
 
         cluster_env = match.cluster_environments
 
@@ -175,7 +177,9 @@ class TestCluster:
 
         match = freud.environment.EnvironmentCluster()
         query_args = dict(r_max=r_max, num_neighbors=num_neighbors)
-        match.compute((box, xyz), threshold, registration=False, cluster_neighbors=query_args)
+        match.compute(
+            (box, xyz), threshold, registration=False, cluster_neighbors=query_args
+        )
         cluster_env = match.cluster_environments
 
         fn = os.path.join(self.test_folder, "bcc_env.npy")
@@ -437,7 +441,9 @@ class TestCluster:
         match = freud.environment.EnvironmentCluster()
         query_args = dict(num_neighbors=num_neighbors)
         with pytest.warns(FutureWarning):
-            match.compute((box, points), 0.1, cluster_neighbors=query_args, global_search=True)
+            match.compute(
+                (box, points), 0.1, cluster_neighbors=query_args, global_search=True
+            )
 
         assert (
             freud.__version__ < "3.0.0"

--- a/tests/test_environment_MatchEnv.py
+++ b/tests/test_environment_MatchEnv.py
@@ -41,7 +41,7 @@ class TestCluster:
             match.cluster_environments
 
         query_args = dict(r_guess=r_max, num_neighbors=num_neighbors)
-        match.compute((box, xyz), threshold, neighbors=query_args)
+        match.compute((box, xyz), threshold, cluster_neighbors=query_args)
 
         cluster_env = match.cluster_environments
 
@@ -85,7 +85,7 @@ class TestCluster:
 
         match = freud.environment.EnvironmentCluster()
         query_args = dict(r_guess=r_max, num_neighbors=num_neighbors)
-        match.compute((box, xyz), threshold, neighbors=query_args)
+        match.compute((box, xyz), threshold, cluster_neighbors=query_args)
 
         cluster_env = match.cluster_environments
 
@@ -130,7 +130,7 @@ class TestCluster:
 
         match = freud.environment.EnvironmentCluster()
         query_args = dict(r_guess=r_max, num_neighbors=num_neighbors)
-        match.compute((box, xyz), threshold, registration=False, neighbors=query_args)
+        match.compute((box, xyz), threshold, registration=False, cluster_neighbors=query_args)
 
         cluster_env = match.cluster_environments
 
@@ -175,7 +175,7 @@ class TestCluster:
 
         match = freud.environment.EnvironmentCluster()
         query_args = dict(r_max=r_max, num_neighbors=num_neighbors)
-        match.compute((box, xyz), threshold, registration=False, neighbors=query_args)
+        match.compute((box, xyz), threshold, registration=False, cluster_neighbors=query_args)
         cluster_env = match.cluster_environments
 
         fn = os.path.join(self.test_folder, "bcc_env.npy")
@@ -242,7 +242,7 @@ class TestCluster:
                 threshold,
                 registration=True,
                 global_search=True,
-                neighbors=query_args,
+                cluster_neighbors=query_args,
             )
         clusters = match.cluster_idx
 
@@ -423,7 +423,7 @@ class TestCluster:
         assert match._repr_png_() is None
 
         query_args = dict(r_guess=r_max, num_neighbors=num_neighbors)
-        match.compute((box, xyz), threshold, neighbors=query_args)
+        match.compute((box, xyz), threshold, cluster_neighbors=query_args)
         match._repr_png_()
         plt.close("all")
 
@@ -437,7 +437,7 @@ class TestCluster:
         match = freud.environment.EnvironmentCluster()
         query_args = dict(num_neighbors=num_neighbors)
         with pytest.warns(FutureWarning):
-            match.compute((box, points), 0.1, neighbors=query_args, global_search=True)
+            match.compute((box, points), 0.1, cluster_neighbors=query_args, global_search=True)
 
         assert (
             freud.__version__ < "3.0.0"


### PR DESCRIPTION
## Description
Changed `neighbors` to `env_neighbors` in `EnvironmentMotifMatch`. 
Changed `env_neighbors` to `cluster_neighbors` in `EnvironmentCluster`. 

## Motivation and Context
Resolves: #989

## How Has This Been Tested?
We will update tests for the right keyword arguments 

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds or improves functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation improvement (updates to user guides, docstrings, or developer docs)

## Checklist:
<!-- Put an `x` in all the boxes that apply. If you're unsure about any of
     these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/glotzerlab/freud/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] I have updated the documentation (if relevant).
- [x] I have added tests that cover my changes (if relevant).
- [x] All new and existing tests passed.
- [ ] I have updated the [credits](https://github.com/glotzerlab/freud/blob/master/doc/source/reference/credits.rst).
- [x] I have updated the [Changelog](https://github.com/glotzerlab/freud/blob/master/ChangeLog.md).
