### PR TITLE
Bump isort to 5.12.0 in pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,7 +35,7 @@ repos:
         args:
           - --py36-plus
   - repo: https://github.com/PyCQA/isort
-    rev: '5.11.4'
+    rev: '5.12.0'
     hooks:
       - id: isort
   - repo: https://github.com/psf/black


### PR DESCRIPTION
## Description

This PR bumps the version of `isort` used by our pre-commit config to version 5.12.0.

## Motivation and Context

pre-commit was failing in our CI due to upstream issues, the solution upstream is discussed in PyCQA/isort#2077

## How Has This Been Tested?

If pre-commit doesn't crash in our CI anymore, we are good to go.


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds or improves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation improvement (updates to user guides, docstrings, or developer docs)

## Checklist:
<!-- Put an `x` in all the boxes that apply. If you're unsure about any of
     these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [**CONTRIBUTING**](https://github.com/glotzerlab/freud/blob/master/CONTRIBUTING.md) document.
- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation (if relevant).
- [ ] I have added tests that cover my changes (if relevant).
- [ ] All new and existing tests passed.
- [ ] I have updated the [credits](https://github.com/glotzerlab/freud/blob/master/doc/source/reference/credits.rst).
- [ ] I have updated the [Changelog](https://github.com/glotzerlab/freud/blob/master/ChangeLog.md).
