### PR TITLE
Fix License Headers

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,6 +28,26 @@ repos:
       - id: check-yaml
       - id: debug-statements
       - id: requirements-txt-fixer
+      - id: fix-license-header
+        name: Fix License Headers (Python)
+        exclude: |
+          (?x)(
+              ^doc/|
+              ^extern/|
+              requirements/|
+              )
+        types_or: [python, cython]
+        args:
+          - --license-file=LICENSE
+          - --add=Part of freud, released under the BSD 3-Clause License.
+          - --keep-before=#!
+      - id: fix-license-header
+        name: Fix License Headers (C++)
+        types_or: [c, c++]
+        args:
+          - --license-file=LICENSE
+          - --add=Part of freud, released under the BSD 3-Clause License.
+          - --comment-prefix=//
   - repo: https://github.com/asottile/pyupgrade
     rev: 'v3.3.1'
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,7 +29,7 @@ repos:
       - id: debug-statements
       - id: requirements-txt-fixer
   - repo: https://github.com/glotzerlab/fix-license-header
-    rev: 43eb3ff2d02cba5e572f86af5c15337823fb2c66
+    rev: v0.2.0
     hooks:
       - id: fix-license-header
         name: Fix License Headers (Python)

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,33 +28,33 @@ repos:
       - id: check-yaml
       - id: debug-statements
       - id: requirements-txt-fixer
-- repo: https://github.com/glotzerlab/fix-license-header
-  rev: 43eb3ff2d02cba5e572f86af5c15337823fb2c66
-  hooks:
-    - id: fix-license-header
-      name: Fix License Headers (Python)
-      exclude: |
-        (?x)(
-            ^doc/|
-            ^extern/|
-            requirements/|
-            )
-      types_or: [python, cython]
-      args:
-        - --license-file=LICENSE
-        - --start=2
-        - --num=1
-        - --add="This file is from the freud project, released under the BSD 3-Clause License."
-        - --keep-before=#!
-    - id: fix-license-header
-      name: Fix License Headers (C++)
-      types_or: [c, c++]
-      args:
-        - --license-file=LICENSE
-        - --start=2
-        - --num=1
-        - --add="This file is from the freud project, released under the BSD 3-Clause License."
-        - --comment-prefix=//
+  - repo: https://github.com/glotzerlab/fix-license-header
+    rev: 43eb3ff2d02cba5e572f86af5c15337823fb2c66
+    hooks:
+      - id: fix-license-header
+        name: Fix License Headers (Python)
+        exclude: |
+          (?x)(
+              ^doc/|
+              ^extern/|
+              requirements/|
+              )
+        types_or: [python, cython]
+        args:
+          - --license-file=LICENSE
+          - --start=2
+          - --num=1
+          - --add="This file is from the freud project, released under the BSD 3-Clause License."
+          - --keep-before=#!
+      - id: fix-license-header
+        name: Fix License Headers (C++)
+        types_or: [c, c++]
+        args:
+          - --license-file=LICENSE
+          - --start=2
+          - --num=1
+          - --add="This file is from the freud project, released under the BSD 3-Clause License."
+          - --comment-prefix=//
   - repo: https://github.com/asottile/pyupgrade
     rev: 'v3.3.1'
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,7 +44,7 @@ repos:
           - --license-file=LICENSE
           - --start=2
           - --num=1
-          - --add="This file is from the freud project, released under the BSD 3-Clause License."
+          - --add=This file is from the freud project, released under the BSD 3-Clause License.
           - --keep-before=#!
       - id: fix-license-header
         name: Fix License Headers (C++)
@@ -53,7 +53,7 @@ repos:
           - --license-file=LICENSE
           - --start=2
           - --num=1
-          - --add="This file is from the freud project, released under the BSD 3-Clause License."
+          - --add=This file is from the freud project, released under the BSD 3-Clause License.
           - --comment-prefix=//
   - repo: https://github.com/asottile/pyupgrade
     rev: 'v3.3.1'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,14 +42,18 @@ repos:
       types_or: [python, cython]
       args:
         - --license-file=LICENSE
-        - --add=Part of freud, released under the BSD 3-Clause License.
+        - --start=2
+        - --num=1
+        - --add="This file is from the freud project, released under the BSD 3-Clause License."
         - --keep-before=#!
     - id: fix-license-header
       name: Fix License Headers (C++)
       types_or: [c, c++]
       args:
         - --license-file=LICENSE
-        - --add=Part of freud, released under the BSD 3-Clause License.
+        - --start=2
+        - --num=1
+        - --add="This file is from the freud project, released under the BSD 3-Clause License."
         - --comment-prefix=//
   - repo: https://github.com/asottile/pyupgrade
     rev: 'v3.3.1'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,7 +37,7 @@ repos:
           (?x)(
               ^doc/|
               ^extern/|
-              requirements/|
+              ^requirements/
               )
         types_or: [python, cython]
         args:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,26 +28,29 @@ repos:
       - id: check-yaml
       - id: debug-statements
       - id: requirements-txt-fixer
-      - id: fix-license-header
-        name: Fix License Headers (Python)
-        exclude: |
-          (?x)(
-              ^doc/|
-              ^extern/|
-              requirements/|
-              )
-        types_or: [python, cython]
-        args:
-          - --license-file=LICENSE
-          - --add=Part of freud, released under the BSD 3-Clause License.
-          - --keep-before=#!
-      - id: fix-license-header
-        name: Fix License Headers (C++)
-        types_or: [c, c++]
-        args:
-          - --license-file=LICENSE
-          - --add=Part of freud, released under the BSD 3-Clause License.
-          - --comment-prefix=//
+- repo: https://github.com/glotzerlab/fix-license-header
+  rev: 43eb3ff2d02cba5e572f86af5c15337823fb2c66
+  hooks:
+    - id: fix-license-header
+      name: Fix License Headers (Python)
+      exclude: |
+        (?x)(
+            ^doc/|
+            ^extern/|
+            requirements/|
+            )
+      types_or: [python, cython]
+      args:
+        - --license-file=LICENSE
+        - --add=Part of freud, released under the BSD 3-Clause License.
+        - --keep-before=#!
+    - id: fix-license-header
+      name: Fix License Headers (C++)
+      types_or: [c, c++]
+      args:
+        - --license-file=LICENSE
+        - --add=Part of freud, released under the BSD 3-Clause License.
+        - --comment-prefix=//
   - repo: https://github.com/asottile/pyupgrade
     rev: 'v3.3.1'
     hooks:
@@ -59,7 +62,7 @@ repos:
     hooks:
       - id: isort
   - repo: https://github.com/psf/black
-    rev: '22.12.0'
+    rev: '23.1.0'
     hooks:
       - id: black
   - repo: https://github.com/PyCQA/flake8
@@ -76,7 +79,7 @@ repos:
     hooks:
       - id: cmake-format
   - repo: https://github.com/pre-commit/mirrors-clang-format
-    rev: 'v15.0.6'
+    rev: 'v15.0.7'
     hooks:
       - id: clang-format
         types_or: [c, c++]

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License for freud
 
-Copyright (c) 2010-2020 The Regents of the University of Michigan
+Copyright (c) 2010-2023 The Regents of the University of Michigan
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/benchmarks/benchmark.py
+++ b/benchmarks/benchmark.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2010-2023 The Regents of the University of Michigan
+# This file is from the freud project, released under the BSD 3-Clause License.
+
 import cProfile
 import multiprocessing
 import os

--- a/benchmarks/benchmark_cluster_Cluster.py
+++ b/benchmarks/benchmark_cluster_Cluster.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2010-2023 The Regents of the University of Michigan
+# This file is from the freud project, released under the BSD 3-Clause License.
+
 import numpy as np
 from benchmark import Benchmark
 from benchmarker import run_benchmarks

--- a/benchmarks/benchmark_density_CorrelationFunction.py
+++ b/benchmarks/benchmark_density_CorrelationFunction.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2010-2023 The Regents of the University of Michigan
+# This file is from the freud project, released under the BSD 3-Clause License.
+
 import numpy as np
 from benchmark import Benchmark
 from benchmarker import run_benchmarks

--- a/benchmarks/benchmark_density_GaussianDensity.py
+++ b/benchmarks/benchmark_density_GaussianDensity.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2010-2023 The Regents of the University of Michigan
+# This file is from the freud project, released under the BSD 3-Clause License.
+
 import numpy as np
 from benchmark import Benchmark
 from benchmarker import run_benchmarks

--- a/benchmarks/benchmark_density_LocalDensity.py
+++ b/benchmarks/benchmark_density_LocalDensity.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2010-2023 The Regents of the University of Michigan
+# This file is from the freud project, released under the BSD 3-Clause License.
+
 import math
 
 import numpy as np

--- a/benchmarks/benchmark_density_RDF.py
+++ b/benchmarks/benchmark_density_RDF.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2010-2023 The Regents of the University of Michigan
+# This file is from the freud project, released under the BSD 3-Clause License.
+
 import numpy as np
 from benchmark import Benchmark
 from benchmarker import run_benchmarks

--- a/benchmarks/benchmark_environment_BondOrder.py
+++ b/benchmarks/benchmark_environment_BondOrder.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2010-2023 The Regents of the University of Michigan
+# This file is from the freud project, released under the BSD 3-Clause License.
+
 import numpy as np
 from benchmark import Benchmark
 from benchmarker import run_benchmarks

--- a/benchmarks/benchmark_locality_AABBQuery.py
+++ b/benchmarks/benchmark_locality_AABBQuery.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2010-2023 The Regents of the University of Michigan
+# This file is from the freud project, released under the BSD 3-Clause License.
+
 import numpy as np
 from benchmark import Benchmark
 from benchmarker import run_benchmarks

--- a/benchmarks/benchmark_locality_LinkCell.py
+++ b/benchmarks/benchmark_locality_LinkCell.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2010-2023 The Regents of the University of Michigan
+# This file is from the freud project, released under the BSD 3-Clause License.
+
 import numpy as np
 from benchmark import Benchmark
 from benchmarker import run_benchmarks

--- a/benchmarks/benchmark_locality_PeriodicBuffer.py
+++ b/benchmarks/benchmark_locality_PeriodicBuffer.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2010-2023 The Regents of the University of Michigan
+# This file is from the freud project, released under the BSD 3-Clause License.
+
 import numpy as np
 from benchmark import Benchmark
 from benchmarker import run_benchmarks

--- a/benchmarks/benchmark_msd_MSD.py
+++ b/benchmarks/benchmark_msd_MSD.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2010-2023 The Regents of the University of Michigan
+# This file is from the freud project, released under the BSD 3-Clause License.
+
 import numpy as np
 from benchmark import Benchmark
 from benchmarker import run_benchmarks

--- a/benchmarks/benchmark_order_Cubatic.py
+++ b/benchmarks/benchmark_order_Cubatic.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2010-2023 The Regents of the University of Michigan
+# This file is from the freud project, released under the BSD 3-Clause License.
+
 import numpy as np
 import rowan
 from benchmark import Benchmark

--- a/benchmarks/benchmark_order_Hexatic.py
+++ b/benchmarks/benchmark_order_Hexatic.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2010-2023 The Regents of the University of Michigan
+# This file is from the freud project, released under the BSD 3-Clause License.
+
 import numpy as np
 from benchmark import Benchmark
 from benchmarker import run_benchmarks

--- a/benchmarks/benchmark_order_Nematic.py
+++ b/benchmarks/benchmark_order_Nematic.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2010-2023 The Regents of the University of Michigan
+# This file is from the freud project, released under the BSD 3-Clause License.
+
 import numpy as np
 import rowan
 from benchmark import Benchmark

--- a/benchmarks/benchmark_order_RotationalAutocorrelation.py
+++ b/benchmarks/benchmark_order_RotationalAutocorrelation.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2010-2023 The Regents of the University of Michigan
+# This file is from the freud project, released under the BSD 3-Clause License.
+
 import numpy as np
 import rowan
 from benchmark import Benchmark

--- a/benchmarks/benchmark_order_SolidLiquid.py
+++ b/benchmarks/benchmark_order_SolidLiquid.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2010-2023 The Regents of the University of Michigan
+# This file is from the freud project, released under the BSD 3-Clause License.
+
 import numpy as np
 from benchmark import Benchmark
 from benchmarker import run_benchmarks

--- a/benchmarks/benchmark_order_SteinhardtQl.py
+++ b/benchmarks/benchmark_order_SteinhardtQl.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2010-2023 The Regents of the University of Michigan
+# This file is from the freud project, released under the BSD 3-Clause License.
+
 import numpy as np
 from benchmark import Benchmark
 from benchmarker import run_benchmarks

--- a/benchmarks/benchmark_order_SteinhardtWl.py
+++ b/benchmarks/benchmark_order_SteinhardtWl.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2010-2023 The Regents of the University of Michigan
+# This file is from the freud project, released under the BSD 3-Clause License.
+
 import numpy as np
 from benchmark import Benchmark
 from benchmarker import run_benchmarks

--- a/benchmarks/benchmark_order_Translational.py
+++ b/benchmarks/benchmark_order_Translational.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2010-2023 The Regents of the University of Michigan
+# This file is from the freud project, released under the BSD 3-Clause License.
+
 import numpy as np
 from benchmark import Benchmark
 from benchmarker import run_benchmarks

--- a/benchmarks/benchmark_pmft_PMFTR12.py
+++ b/benchmarks/benchmark_pmft_PMFTR12.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2010-2023 The Regents of the University of Michigan
+# This file is from the freud project, released under the BSD 3-Clause License.
+
 import numpy as np
 from benchmark import Benchmark
 from benchmarker import run_benchmarks

--- a/benchmarks/benchmark_pmft_PMFTXY.py
+++ b/benchmarks/benchmark_pmft_PMFTXY.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2010-2023 The Regents of the University of Michigan
+# This file is from the freud project, released under the BSD 3-Clause License.
+
 import numpy as np
 from benchmark import Benchmark
 from benchmarker import run_benchmarks

--- a/benchmarks/benchmark_pmft_PMFTXYT.py
+++ b/benchmarks/benchmark_pmft_PMFTXYT.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2010-2023 The Regents of the University of Michigan
+# This file is from the freud project, released under the BSD 3-Clause License.
+
 import numpy as np
 from benchmark import Benchmark
 from benchmarker import run_benchmarks

--- a/benchmarks/benchmark_pmft_PMFTXYZ.py
+++ b/benchmarks/benchmark_pmft_PMFTXYZ.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2010-2023 The Regents of the University of Michigan
+# This file is from the freud project, released under the BSD 3-Clause License.
+
 import numpy as np
 import rowan
 from benchmark import Benchmark

--- a/benchmarks/benchmarker.py
+++ b/benchmarks/benchmarker.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2010-2023 The Regents of the University of Michigan
+# This file is from the freud project, released under the BSD 3-Clause License.
+
 import argparse
 import importlib
 import json

--- a/cpp/box/Box.h
+++ b/cpp/box/Box.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2010-2020 The Regents of the University of Michigan
+// Copyright (c) 2010-2023 The Regents of the University of Michigan
 // This file is from the freud project, released under the BSD 3-Clause License.
 
 #ifndef BOX_H

--- a/cpp/cluster/Cluster.cc
+++ b/cpp/cluster/Cluster.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2010-2020 The Regents of the University of Michigan
+// Copyright (c) 2010-2023 The Regents of the University of Michigan
 // This file is from the freud project, released under the BSD 3-Clause License.
 
 #include <algorithm>

--- a/cpp/cluster/Cluster.h
+++ b/cpp/cluster/Cluster.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2010-2020 The Regents of the University of Michigan
+// Copyright (c) 2010-2023 The Regents of the University of Michigan
 // This file is from the freud project, released under the BSD 3-Clause License.
 
 #ifndef CLUSTER_H

--- a/cpp/cluster/ClusterProperties.cc
+++ b/cpp/cluster/ClusterProperties.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2010-2020 The Regents of the University of Michigan
+// Copyright (c) 2010-2023 The Regents of the University of Michigan
 // This file is from the freud project, released under the BSD 3-Clause License.
 
 #include <vector>

--- a/cpp/cluster/ClusterProperties.h
+++ b/cpp/cluster/ClusterProperties.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2010-2020 The Regents of the University of Michigan
+// Copyright (c) 2010-2023 The Regents of the University of Michigan
 // This file is from the freud project, released under the BSD 3-Clause License.
 
 #ifndef CLUSTER_PROPERTIES_H

--- a/cpp/density/CorrelationFunction.cc
+++ b/cpp/density/CorrelationFunction.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2010-2020 The Regents of the University of Michigan
+// Copyright (c) 2010-2023 The Regents of the University of Michigan
 // This file is from the freud project, released under the BSD 3-Clause License.
 
 #include <complex>

--- a/cpp/density/CorrelationFunction.h
+++ b/cpp/density/CorrelationFunction.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2010-2020 The Regents of the University of Michigan
+// Copyright (c) 2010-2023 The Regents of the University of Michigan
 // This file is from the freud project, released under the BSD 3-Clause License.
 
 #ifndef CORRELATION_FUNCTION_H

--- a/cpp/density/GaussianDensity.cc
+++ b/cpp/density/GaussianDensity.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2010-2020 The Regents of the University of Michigan
+// Copyright (c) 2010-2023 The Regents of the University of Michigan
 // This file is from the freud project, released under the BSD 3-Clause License.
 
 #include <cmath>

--- a/cpp/density/GaussianDensity.h
+++ b/cpp/density/GaussianDensity.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2010-2020 The Regents of the University of Michigan
+// Copyright (c) 2010-2023 The Regents of the University of Michigan
 // This file is from the freud project, released under the BSD 3-Clause License.
 
 #ifndef GAUSSIAN_DENSITY_H

--- a/cpp/density/LocalDensity.cc
+++ b/cpp/density/LocalDensity.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2010-2020 The Regents of the University of Michigan
+// Copyright (c) 2010-2023 The Regents of the University of Michigan
 // This file is from the freud project, released under the BSD 3-Clause License.
 
 #include "LocalDensity.h"

--- a/cpp/density/LocalDensity.h
+++ b/cpp/density/LocalDensity.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2010-2020 The Regents of the University of Michigan
+// Copyright (c) 2010-2023 The Regents of the University of Michigan
 // This file is from the freud project, released under the BSD 3-Clause License.
 
 #ifndef LOCAL_DENSITY_H

--- a/cpp/density/RDF.cc
+++ b/cpp/density/RDF.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2010-2020 The Regents of the University of Michigan
+// Copyright (c) 2010-2023 The Regents of the University of Michigan
 // This file is from the freud project, released under the BSD 3-Clause License.
 
 #include <stdexcept>

--- a/cpp/density/RDF.h
+++ b/cpp/density/RDF.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2010-2020 The Regents of the University of Michigan
+// Copyright (c) 2010-2023 The Regents of the University of Michigan
 // This file is from the freud project, released under the BSD 3-Clause License.
 
 #ifndef RDF_H

--- a/cpp/density/SphereVoxelization.cc
+++ b/cpp/density/SphereVoxelization.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2010-2020 The Regents of the University of Michigan
+// Copyright (c) 2010-2023 The Regents of the University of Michigan
 // This file is from the freud project, released under the BSD 3-Clause License.
 
 #include <cmath>

--- a/cpp/density/SphereVoxelization.h
+++ b/cpp/density/SphereVoxelization.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2010-2020 The Regents of the University of Michigan
+// Copyright (c) 2010-2023 The Regents of the University of Michigan
 // This file is from the freud project, released under the BSD 3-Clause License.
 
 #ifndef SPHERE_VOXELIZATION_H

--- a/cpp/diffraction/StaticStructureFactor.cc
+++ b/cpp/diffraction/StaticStructureFactor.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2010-2020 The Regents of the University of Michigan
+// Copyright (c) 2010-2023 The Regents of the University of Michigan
 // This file is from the freud project, released under the BSD 3-Clause License.
 
 #include <stdexcept>

--- a/cpp/diffraction/StaticStructureFactor.h
+++ b/cpp/diffraction/StaticStructureFactor.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2010-2020 The Regents of the University of Michigan
+// Copyright (c) 2010-2023 The Regents of the University of Michigan
 // This file is from the freud project, released under the BSD 3-Clause License.
 
 #ifndef STATIC_STRUCTURE_FACTOR_H

--- a/cpp/diffraction/StaticStructureFactorDebye.cc
+++ b/cpp/diffraction/StaticStructureFactorDebye.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2010-2020 The Regents of the University of Michigan
+// Copyright (c) 2010-2023 The Regents of the University of Michigan
 // This file is from the freud project, released under the BSD 3-Clause License.
 
 #ifdef __clang__

--- a/cpp/diffraction/StaticStructureFactorDebye.h
+++ b/cpp/diffraction/StaticStructureFactorDebye.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2010-2020 The Regents of the University of Michigan
+// Copyright (c) 2010-2023 The Regents of the University of Michigan
 // This file is from the freud project, released under the BSD 3-Clause License.
 
 #ifndef STATIC_STRUCTURE_FACTOR_DEBYE_H

--- a/cpp/diffraction/StaticStructureFactorDirect.cc
+++ b/cpp/diffraction/StaticStructureFactorDirect.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2010-2020 The Regents of the University of Michigan
+// Copyright (c) 2010-2023 The Regents of the University of Michigan
 // This file is from the freud project, released under the BSD 3-Clause License.
 
 #include <cmath>

--- a/cpp/diffraction/StaticStructureFactorDirect.h
+++ b/cpp/diffraction/StaticStructureFactorDirect.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2010-2020 The Regents of the University of Michigan
+// Copyright (c) 2010-2023 The Regents of the University of Michigan
 // This file is from the freud project, released under the BSD 3-Clause License.
 
 #ifndef STATIC_STRUCTURE_FACTOR_DIRECT_H

--- a/cpp/environment/AngularSeparation.cc
+++ b/cpp/environment/AngularSeparation.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2010-2020 The Regents of the University of Michigan
+// Copyright (c) 2010-2023 The Regents of the University of Michigan
 // This file is from the freud project, released under the BSD 3-Clause License.
 
 #include "AngularSeparation.h"

--- a/cpp/environment/AngularSeparation.h
+++ b/cpp/environment/AngularSeparation.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2010-2020 The Regents of the University of Michigan
+// Copyright (c) 2010-2023 The Regents of the University of Michigan
 // This file is from the freud project, released under the BSD 3-Clause License.
 
 #ifndef ANGULAR_SEPARATION_H

--- a/cpp/environment/BondOrder.cc
+++ b/cpp/environment/BondOrder.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2010-2020 The Regents of the University of Michigan
+// Copyright (c) 2010-2023 The Regents of the University of Michigan
 // This file is from the freud project, released under the BSD 3-Clause License.
 
 #include <cmath>

--- a/cpp/environment/BondOrder.h
+++ b/cpp/environment/BondOrder.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2010-2020 The Regents of the University of Michigan
+// Copyright (c) 2010-2023 The Regents of the University of Michigan
 // This file is from the freud project, released under the BSD 3-Clause License.
 
 #ifndef BOND_ORDER_H

--- a/cpp/environment/LocalBondProjection.cc
+++ b/cpp/environment/LocalBondProjection.cc
@@ -1,5 +1,5 @@
-// Copyright (c) 2010-2020 The Regents of the University of Michigan
-// This file is part of the freud project, released under the BSD 3-Clause License.
+// Copyright (c) 2010-2023 The Regents of the University of Michigan
+// This file is from the freud project, released under the BSD 3-Clause License.
 
 #include "LocalBondProjection.h"
 #include "NeighborComputeFunctional.h"

--- a/cpp/environment/LocalBondProjection.h
+++ b/cpp/environment/LocalBondProjection.h
@@ -1,5 +1,5 @@
-// Copyright (c) 2010-2020 The Regents of the University of Michigan
-// This file is part of the freud project, released under the BSD 3-Clause License.
+// Copyright (c) 2010-2023 The Regents of the University of Michigan
+// This file is from the freud project, released under the BSD 3-Clause License.
 
 #ifndef LOCAL_BOND_PROJECTION_H
 #define LOCAL_BOND_PROJECTION_H

--- a/cpp/environment/LocalDescriptors.cc
+++ b/cpp/environment/LocalDescriptors.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2010-2020 The Regents of the University of Michigan
+// Copyright (c) 2010-2023 The Regents of the University of Michigan
 // This file is from the freud project, released under the BSD 3-Clause License.
 
 #include <vector>

--- a/cpp/environment/LocalDescriptors.h
+++ b/cpp/environment/LocalDescriptors.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2010-2020 The Regents of the University of Michigan
+// Copyright (c) 2010-2023 The Regents of the University of Michigan
 // This file is from the freud project, released under the BSD 3-Clause License.
 
 #ifndef LOCAL_DESCRIPTORS_H

--- a/cpp/environment/MatchEnv.cc
+++ b/cpp/environment/MatchEnv.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2010-2020 The Regents of the University of Michigan
+// Copyright (c) 2010-2023 The Regents of the University of Michigan
 // This file is from the freud project, released under the BSD 3-Clause License.
 
 #include <algorithm>

--- a/cpp/environment/MatchEnv.h
+++ b/cpp/environment/MatchEnv.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2010-2020 The Regents of the University of Michigan
+// Copyright (c) 2010-2023 The Regents of the University of Michigan
 // This file is from the freud project, released under the BSD 3-Clause License.
 
 #ifndef MATCH_ENV_H

--- a/cpp/environment/Registration.h
+++ b/cpp/environment/Registration.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2010-2020 The Regents of the University of Michigan
+// Copyright (c) 2010-2023 The Regents of the University of Michigan
 // This file is from the freud project, released under the BSD 3-Clause License.
 
 #ifndef REGISTRATION_H

--- a/cpp/locality/AABB.h
+++ b/cpp/locality/AABB.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2010-2020 The Regents of the University of Michigan
+// Copyright (c) 2010-2023 The Regents of the University of Michigan
 // This file is from the freud project, released under the BSD 3-Clause License.
 
 #ifndef AABB_H

--- a/cpp/locality/AABBQuery.cc
+++ b/cpp/locality/AABBQuery.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2010-2020 The Regents of the University of Michigan
+// Copyright (c) 2010-2023 The Regents of the University of Michigan
 // This file is from the freud project, released under the BSD 3-Clause License.
 
 #include <algorithm>

--- a/cpp/locality/AABBQuery.h
+++ b/cpp/locality/AABBQuery.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2010-2020 The Regents of the University of Michigan
+// Copyright (c) 2010-2023 The Regents of the University of Michigan
 // This file is from the freud project, released under the BSD 3-Clause License.
 
 #ifndef AABBQUERY_H

--- a/cpp/locality/AABBTree.h
+++ b/cpp/locality/AABBTree.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2010-2020 The Regents of the University of Michigan
+// Copyright (c) 2010-2023 The Regents of the University of Michigan
 // This file is from the freud project, released under the BSD 3-Clause License.
 
 #ifndef AABB_TREE_H

--- a/cpp/locality/BondHistogramCompute.h
+++ b/cpp/locality/BondHistogramCompute.h
@@ -1,3 +1,6 @@
+// Copyright (c) 2010-2023 The Regents of the University of Michigan
+// This file is from the freud project, released under the BSD 3-Clause License.
+
 #ifndef BOND_HISTOGRAM_COMPUTE_H
 #define BOND_HISTOGRAM_COMPUTE_H
 

--- a/cpp/locality/Filter.h
+++ b/cpp/locality/Filter.h
@@ -1,3 +1,6 @@
+// Copyright (c) 2010-2023 The Regents of the University of Michigan
+// This file is from the freud project, released under the BSD 3-Clause License.
+
 #ifndef __FILTER_H__
 #define __FILTER_H__
 

--- a/cpp/locality/FilterSANN.cc
+++ b/cpp/locality/FilterSANN.cc
@@ -1,3 +1,6 @@
+// Copyright (c) 2010-2023 The Regents of the University of Michigan
+// This file is from the freud project, released under the BSD 3-Clause License.
+
 #include "FilterSANN.h"
 #include "NeighborBond.h"
 #include "NeighborComputeFunctional.h"

--- a/cpp/locality/FilterSANN.h
+++ b/cpp/locality/FilterSANN.h
@@ -1,3 +1,6 @@
+// Copyright (c) 2010-2023 The Regents of the University of Michigan
+// This file is from the freud project, released under the BSD 3-Clause License.
+
 #ifndef __FILTERSANN_H__
 #define __FILTERSANN_H__
 

--- a/cpp/locality/LinkCell.cc
+++ b/cpp/locality/LinkCell.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2010-2020 The Regents of the University of Michigan
+// Copyright (c) 2010-2023 The Regents of the University of Michigan
 // This file is from the freud project, released under the BSD 3-Clause License.
 
 #include <algorithm>

--- a/cpp/locality/LinkCell.h
+++ b/cpp/locality/LinkCell.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2010-2020 The Regents of the University of Michigan
+// Copyright (c) 2010-2023 The Regents of the University of Michigan
 // This file is from the freud project, released under the BSD 3-Clause License.
 
 #ifndef LINKCELL_H

--- a/cpp/locality/NeighborBond.h
+++ b/cpp/locality/NeighborBond.h
@@ -1,3 +1,6 @@
+// Copyright (c) 2010-2023 The Regents of the University of Michigan
+// This file is from the freud project, released under the BSD 3-Clause License.
+
 #ifndef NEIGHBOR_BOND_H
 #define NEIGHBOR_BOND_H
 

--- a/cpp/locality/NeighborComputeFunctional.cc
+++ b/cpp/locality/NeighborComputeFunctional.cc
@@ -1,3 +1,6 @@
+// Copyright (c) 2010-2023 The Regents of the University of Michigan
+// This file is from the freud project, released under the BSD 3-Clause License.
+
 #include "NeighborComputeFunctional.h"
 
 /*! \file NeighborComputeFunctional.h

--- a/cpp/locality/NeighborComputeFunctional.h
+++ b/cpp/locality/NeighborComputeFunctional.h
@@ -1,3 +1,6 @@
+// Copyright (c) 2010-2023 The Regents of the University of Michigan
+// This file is from the freud project, released under the BSD 3-Clause License.
+
 #ifndef NEIGHBOR_COMPUTE_FUNCTIONAL_H
 #define NEIGHBOR_COMPUTE_FUNCTIONAL_H
 

--- a/cpp/locality/NeighborList.cc
+++ b/cpp/locality/NeighborList.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2010-2020 The Regents of the University of Michigan
+// Copyright (c) 2010-2023 The Regents of the University of Michigan
 // This file is from the freud project, released under the BSD 3-Clause License.
 
 #include <algorithm>

--- a/cpp/locality/NeighborList.h
+++ b/cpp/locality/NeighborList.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2010-2020 The Regents of the University of Michigan
+// Copyright (c) 2010-2023 The Regents of the University of Michigan
 // This file is from the freud project, released under the BSD 3-Clause License.
 
 #ifndef NEIGHBOR_LIST_H

--- a/cpp/locality/NeighborPerPointIterator.h
+++ b/cpp/locality/NeighborPerPointIterator.h
@@ -1,3 +1,6 @@
+// Copyright (c) 2010-2023 The Regents of the University of Michigan
+// This file is from the freud project, released under the BSD 3-Clause License.
+
 #ifndef NEIGHBOR_PER_POINT_ITERATOR_H
 #define NEIGHBOR_PER_POINT_ITERATOR_H
 

--- a/cpp/locality/NeighborQuery.h
+++ b/cpp/locality/NeighborQuery.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2010-2020 The Regents of the University of Michigan
+// Copyright (c) 2010-2023 The Regents of the University of Michigan
 // This file is from the freud project, released under the BSD 3-Clause License.
 
 #ifndef NEIGHBOR_QUERY_H

--- a/cpp/locality/PeriodicBuffer.cc
+++ b/cpp/locality/PeriodicBuffer.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2010-2020 The Regents of the University of Michigan
+// Copyright (c) 2010-2023 The Regents of the University of Michigan
 // This file is from the freud project, released under the BSD 3-Clause License.
 
 #include <stdexcept>

--- a/cpp/locality/PeriodicBuffer.h
+++ b/cpp/locality/PeriodicBuffer.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2010-2020 The Regents of the University of Michigan
+// Copyright (c) 2010-2023 The Regents of the University of Michigan
 // This file is from the freud project, released under the BSD 3-Clause License.
 
 #ifndef PERIODIC_BUFFER_H

--- a/cpp/locality/RawPoints.h
+++ b/cpp/locality/RawPoints.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2010-2020 The Regents of the University of Michigan
+// Copyright (c) 2010-2023 The Regents of the University of Michigan
 // This file is from the freud project, released under the BSD 3-Clause License.
 
 #ifndef RAW_POINTS_H

--- a/cpp/locality/Voronoi.cc
+++ b/cpp/locality/Voronoi.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2010-2020 The Regents of the University of Michigan
+// Copyright (c) 2010-2023 The Regents of the University of Michigan
 // This file is from the freud project, released under the BSD 3-Clause License.
 
 #include <cmath>

--- a/cpp/locality/Voronoi.h
+++ b/cpp/locality/Voronoi.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2010-2020 The Regents of the University of Michigan
+// Copyright (c) 2010-2023 The Regents of the University of Michigan
 // This file is from the freud project, released under the BSD 3-Clause License.
 
 #ifndef VORONOI_H

--- a/cpp/order/Cubatic.cc
+++ b/cpp/order/Cubatic.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2010-2020 The Regents of the University of Michigan
+// Copyright (c) 2010-2023 The Regents of the University of Michigan
 // This file is from the freud project, released under the BSD 3-Clause License.
 
 #include <cstring>

--- a/cpp/order/Cubatic.h
+++ b/cpp/order/Cubatic.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2010-2020 The Regents of the University of Michigan
+// Copyright (c) 2010-2023 The Regents of the University of Michigan
 // This file is from the freud project, released under the BSD 3-Clause License.
 
 #ifndef CUBATIC_H

--- a/cpp/order/HexaticTranslational.cc
+++ b/cpp/order/HexaticTranslational.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2010-2020 The Regents of the University of Michigan
+// Copyright (c) 2010-2023 The Regents of the University of Michigan
 // This file is from the freud project, released under the BSD 3-Clause License.
 
 #include "HexaticTranslational.h"

--- a/cpp/order/HexaticTranslational.h
+++ b/cpp/order/HexaticTranslational.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2010-2020 The Regents of the University of Michigan
+// Copyright (c) 2010-2023 The Regents of the University of Michigan
 // This file is from the freud project, released under the BSD 3-Clause License.
 
 #ifndef HEXATIC_TRANSLATIONAL_H

--- a/cpp/order/Nematic.cc
+++ b/cpp/order/Nematic.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2010-2020 The Regents of the University of Michigan
+// Copyright (c) 2010-2023 The Regents of the University of Michigan
 // This file is from the freud project, released under the BSD 3-Clause License.
 
 #include <stdexcept>

--- a/cpp/order/Nematic.h
+++ b/cpp/order/Nematic.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2010-2020 The Regents of the University of Michigan
+// Copyright (c) 2010-2023 The Regents of the University of Michigan
 // This file is from the freud project, released under the BSD 3-Clause License.
 
 #ifndef NEMATIC_H

--- a/cpp/order/RotationalAutocorrelation.cc
+++ b/cpp/order/RotationalAutocorrelation.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2010-2020 The Regents of the University of Michigan
+// Copyright (c) 2010-2023 The Regents of the University of Michigan
 // This file is from the freud project, released under the BSD 3-Clause License.
 
 #include "RotationalAutocorrelation.h"

--- a/cpp/order/RotationalAutocorrelation.h
+++ b/cpp/order/RotationalAutocorrelation.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2010-2020 The Regents of the University of Michigan
+// Copyright (c) 2010-2023 The Regents of the University of Michigan
 // This file is from the freud project, released under the BSD 3-Clause License.
 
 #ifndef ROTATIONAL_AUTOCORRELATION_H

--- a/cpp/order/SolidLiquid.cc
+++ b/cpp/order/SolidLiquid.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2010-2020 The Regents of the University of Michigan
+// Copyright (c) 2010-2023 The Regents of the University of Michigan
 // This file is from the freud project, released under the BSD 3-Clause License.
 
 #include <stdexcept>

--- a/cpp/order/SolidLiquid.h
+++ b/cpp/order/SolidLiquid.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2010-2020 The Regents of the University of Michigan
+// Copyright (c) 2010-2023 The Regents of the University of Michigan
 // This file is from the freud project, released under the BSD 3-Clause License.
 
 #ifndef SOLID_LIQUID_H

--- a/cpp/order/Steinhardt.cc
+++ b/cpp/order/Steinhardt.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2010-2020 The Regents of the University of Michigan
+// Copyright (c) 2010-2023 The Regents of the University of Michigan
 // This file is from the freud project, released under the BSD 3-Clause License.
 
 #include "Steinhardt.h"

--- a/cpp/order/Steinhardt.h
+++ b/cpp/order/Steinhardt.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2010-2020 The Regents of the University of Michigan
+// Copyright (c) 2010-2023 The Regents of the University of Michigan
 // This file is from the freud project, released under the BSD 3-Clause License.
 
 #ifndef STEINHARDT_H

--- a/cpp/order/Wigner3j.cc
+++ b/cpp/order/Wigner3j.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2010-2020 The Regents of the University of Michigan
+// Copyright (c) 2010-2023 The Regents of the University of Michigan
 // This file is from the freud project, released under the BSD 3-Clause License.
 
 #include <algorithm>

--- a/cpp/order/Wigner3j.h
+++ b/cpp/order/Wigner3j.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2010-2020 The Regents of the University of Michigan
+// Copyright (c) 2010-2023 The Regents of the University of Michigan
 // This file is from the freud project, released under the BSD 3-Clause License.
 
 #ifndef WIGNER3J_H

--- a/cpp/parallel/tbb_config.cc
+++ b/cpp/parallel/tbb_config.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2010-2020 The Regents of the University of Michigan
+// Copyright (c) 2010-2023 The Regents of the University of Michigan
 // This file is from the freud project, released under the BSD 3-Clause License.
 
 #include "tbb_config.h"

--- a/cpp/parallel/tbb_config.h
+++ b/cpp/parallel/tbb_config.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2010-2020 The Regents of the University of Michigan
+// Copyright (c) 2010-2023 The Regents of the University of Michigan
 // This file is from the freud project, released under the BSD 3-Clause License.
 
 #ifndef TBB_CONFIG_H

--- a/cpp/pmft/PMFT.h
+++ b/cpp/pmft/PMFT.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2010-2020 The Regents of the University of Michigan
+// Copyright (c) 2010-2023 The Regents of the University of Michigan
 // This file is from the freud project, released under the BSD 3-Clause License.
 
 #ifndef PMFT_H

--- a/cpp/pmft/PMFTR12.cc
+++ b/cpp/pmft/PMFTR12.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2010-2020 The Regents of the University of Michigan
+// Copyright (c) 2010-2023 The Regents of the University of Michigan
 // This file is from the freud project, released under the BSD 3-Clause License.
 
 #include <stdexcept>

--- a/cpp/pmft/PMFTR12.h
+++ b/cpp/pmft/PMFTR12.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2010-2020 The Regents of the University of Michigan
+// Copyright (c) 2010-2023 The Regents of the University of Michigan
 // This file is from the freud project, released under the BSD 3-Clause License.
 
 #ifndef PMFTR12_H

--- a/cpp/pmft/PMFTXY.cc
+++ b/cpp/pmft/PMFTXY.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2010-2020 The Regents of the University of Michigan
+// Copyright (c) 2010-2023 The Regents of the University of Michigan
 // This file is from the freud project, released under the BSD 3-Clause License.
 
 #include <stdexcept>

--- a/cpp/pmft/PMFTXY.h
+++ b/cpp/pmft/PMFTXY.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2010-2020 The Regents of the University of Michigan
+// Copyright (c) 2010-2023 The Regents of the University of Michigan
 // This file is from the freud project, released under the BSD 3-Clause License.
 
 #ifndef PMFTXY_H

--- a/cpp/pmft/PMFTXYT.cc
+++ b/cpp/pmft/PMFTXYT.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2010-2020 The Regents of the University of Michigan
+// Copyright (c) 2010-2023 The Regents of the University of Michigan
 // This file is from the freud project, released under the BSD 3-Clause License.
 
 #include <stdexcept>

--- a/cpp/pmft/PMFTXYT.h
+++ b/cpp/pmft/PMFTXYT.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2010-2020 The Regents of the University of Michigan
+// Copyright (c) 2010-2023 The Regents of the University of Michigan
 // This file is from the freud project, released under the BSD 3-Clause License.
 
 #ifndef PMFTXYT_H

--- a/cpp/pmft/PMFTXYZ.cc
+++ b/cpp/pmft/PMFTXYZ.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2010-2020 The Regents of the University of Michigan
+// Copyright (c) 2010-2023 The Regents of the University of Michigan
 // This file is from the freud project, released under the BSD 3-Clause License.
 
 #include "PMFTXYZ.h"

--- a/cpp/pmft/PMFTXYZ.h
+++ b/cpp/pmft/PMFTXYZ.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2010-2020 The Regents of the University of Michigan
+// Copyright (c) 2010-2023 The Regents of the University of Michigan
 // This file is from the freud project, released under the BSD 3-Clause License.
 
 #ifndef PMFTXYZ_H

--- a/cpp/util/BiMap.h
+++ b/cpp/util/BiMap.h
@@ -1,3 +1,6 @@
+// Copyright (c) 2010-2023 The Regents of the University of Michigan
+// This file is from the freud project, released under the BSD 3-Clause License.
+
 #ifndef BIMAP_H
 #define BIMAP_H
 

--- a/cpp/util/Histogram.h
+++ b/cpp/util/Histogram.h
@@ -1,3 +1,6 @@
+// Copyright (c) 2010-2023 The Regents of the University of Michigan
+// This file is from the freud project, released under the BSD 3-Clause License.
+
 #ifndef HISTOGRAM_H
 #define HISTOGRAM_H
 

--- a/cpp/util/ManagedArray.h
+++ b/cpp/util/ManagedArray.h
@@ -1,3 +1,6 @@
+// Copyright (c) 2010-2023 The Regents of the University of Michigan
+// This file is from the freud project, released under the BSD 3-Clause License.
+
 #ifndef MANAGED_ARRAY_H
 #define MANAGED_ARRAY_H
 

--- a/cpp/util/ThreadStorage.h
+++ b/cpp/util/ThreadStorage.h
@@ -1,3 +1,6 @@
+// Copyright (c) 2010-2023 The Regents of the University of Michigan
+// This file is from the freud project, released under the BSD 3-Clause License.
+
 #ifndef THREADSTORAGE_H
 #define THREADSTORAGE_H
 

--- a/cpp/util/VectorMath.h
+++ b/cpp/util/VectorMath.h
@@ -1,6 +1,5 @@
-// Copyright (c) 2010-2020 The Regents of the University of Michigan
+// Copyright (c) 2010-2023 The Regents of the University of Michigan
 // This file is from the freud project, released under the BSD 3-Clause License.
-// This file is modified from the HOOMD-blue project, released under the BSD 3-Clause License.
 
 #ifndef VECTOR_MATH_H
 #define VECTOR_MATH_H

--- a/cpp/util/diagonalize.cc
+++ b/cpp/util/diagonalize.cc
@@ -1,3 +1,6 @@
+// Copyright (c) 2010-2023 The Regents of the University of Michigan
+// This file is from the freud project, released under the BSD 3-Clause License.
+
 #include "diagonalize.h"
 
 namespace freud { namespace util {

--- a/cpp/util/diagonalize.h
+++ b/cpp/util/diagonalize.h
@@ -1,3 +1,6 @@
+// Copyright (c) 2010-2023 The Regents of the University of Michigan
+// This file is from the freud project, released under the BSD 3-Clause License.
+
 #ifndef DIAGONALIZE_H
 #define DIAGONALIZE_H
 

--- a/cpp/util/utils.h
+++ b/cpp/util/utils.h
@@ -1,3 +1,6 @@
+// Copyright (c) 2010-2023 The Regents of the University of Michigan
+// This file is from the freud project, released under the BSD 3-Clause License.
+
 #ifndef UTILS_H
 #define UTILS_H
 

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -12,6 +12,7 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
+import datetime
 import os
 import sys
 
@@ -62,7 +63,8 @@ master_doc = "index"
 
 # General information about the project.
 project = "freud"
-copyright = "2010-2020 The Regents of the University of Michigan"
+year = datetime.date.today().year
+copyright = f"2010-{ year } The Regents of the University of Michigan"
 author = "The Regents of the University of Michigan"
 
 # The version info for the project you're documenting, acts as replacement for

--- a/freud/__init__.py
+++ b/freud/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2010-2020 The Regents of the University of Michigan
+# Copyright (c) 2010-2023 The Regents of the University of Michigan
 # This file is from the freud project, released under the BSD 3-Clause License.
 
 from . import (

--- a/freud/_box.pxd
+++ b/freud/_box.pxd
@@ -1,4 +1,4 @@
-# Copyright (c) 2010-2020 The Regents of the University of Michigan
+# Copyright (c) 2010-2023 The Regents of the University of Michigan
 # This file is from the freud project, released under the BSD 3-Clause License.
 
 from libcpp cimport bool

--- a/freud/_cluster.pxd
+++ b/freud/_cluster.pxd
@@ -1,4 +1,4 @@
-# Copyright (c) 2010-2020 The Regents of the University of Michigan
+# Copyright (c) 2010-2023 The Regents of the University of Michigan
 # This file is from the freud project, released under the BSD 3-Clause License.
 
 from libcpp.vector cimport vector

--- a/freud/_density.pxd
+++ b/freud/_density.pxd
@@ -1,4 +1,4 @@
-# Copyright (c) 2010-2020 The Regents of the University of Michigan
+# Copyright (c) 2010-2023 The Regents of the University of Michigan
 # This file is from the freud project, released under the BSD 3-Clause License.
 
 from libcpp cimport bool

--- a/freud/_diffraction.pxd
+++ b/freud/_diffraction.pxd
@@ -1,4 +1,4 @@
-# Copyright (c) 2010-2020 The Regents of the University of Michigan
+# Copyright (c) 2010-2023 The Regents of the University of Michigan
 # This file is from the freud project, released under the BSD 3-Clause License.
 
 from libcpp cimport bool

--- a/freud/_environment.pxd
+++ b/freud/_environment.pxd
@@ -1,4 +1,4 @@
-# Copyright (c) 2010-2020 The Regents of the University of Michigan
+# Copyright (c) 2010-2023 The Regents of the University of Michigan
 # This file is from the freud project, released under the BSD 3-Clause License.
 
 from libcpp cimport bool

--- a/freud/_locality.pxd
+++ b/freud/_locality.pxd
@@ -1,4 +1,4 @@
-# Copyright (c) 2010-2020 The Regents of the University of Michigan
+# Copyright (c) 2010-2023 The Regents of the University of Michigan
 # This file is from the freud project, released under the BSD 3-Clause License.
 
 from libcpp cimport bool

--- a/freud/_order.pxd
+++ b/freud/_order.pxd
@@ -1,4 +1,4 @@
-# Copyright (c) 2010-2020 The Regents of the University of Michigan
+# Copyright (c) 2010-2023 The Regents of the University of Michigan
 # This file is from the freud project, released under the BSD 3-Clause License.
 
 from libcpp cimport bool

--- a/freud/_parallel.pxd
+++ b/freud/_parallel.pxd
@@ -1,4 +1,4 @@
-# Copyright (c) 2010-2020 The Regents of the University of Michigan
+# Copyright (c) 2010-2023 The Regents of the University of Michigan
 # This file is from the freud project, released under the BSD 3-Clause License.
 
 cdef extern from "tbb_config.h" namespace "freud::parallel":

--- a/freud/_pmft.pxd
+++ b/freud/_pmft.pxd
@@ -1,4 +1,4 @@
-# Copyright (c) 2010-2020 The Regents of the University of Michigan
+# Copyright (c) 2010-2023 The Regents of the University of Michigan
 # This file is from the freud project, released under the BSD 3-Clause License.
 
 cimport freud._locality

--- a/freud/_util.pxd
+++ b/freud/_util.pxd
@@ -1,4 +1,4 @@
-# Copyright (c) 2010-2020 The Regents of the University of Michigan
+# Copyright (c) 2010-2023 The Regents of the University of Michigan
 # This file is from the freud project, released under the BSD 3-Clause License.
 
 cimport numpy

--- a/freud/box.pxd
+++ b/freud/box.pxd
@@ -1,4 +1,4 @@
-# Copyright (c) 2010-2020 The Regents of the University of Michigan
+# Copyright (c) 2010-2023 The Regents of the University of Michigan
 # This file is from the freud project, released under the BSD 3-Clause License.
 
 cimport freud._box

--- a/freud/box.pyx
+++ b/freud/box.pyx
@@ -1,4 +1,4 @@
-# Copyright (c) 2010-2020 The Regents of the University of Michigan
+# Copyright (c) 2010-2023 The Regents of the University of Michigan
 # This file is from the freud project, released under the BSD 3-Clause License.
 
 r"""

--- a/freud/cluster.pyx
+++ b/freud/cluster.pyx
@@ -1,4 +1,4 @@
-# Copyright (c) 2010-2020 The Regents of the University of Michigan
+# Copyright (c) 2010-2023 The Regents of the University of Michigan
 # This file is from the freud project, released under the BSD 3-Clause License.
 
 r"""

--- a/freud/data.py
+++ b/freud/data.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2010-2020 The Regents of the University of Michigan
+# Copyright (c) 2010-2023 The Regents of the University of Michigan
 # This file is from the freud project, released under the BSD 3-Clause License.
 
 r"""

--- a/freud/density.pyx
+++ b/freud/density.pyx
@@ -1,4 +1,4 @@
-# Copyright (c) 2010-2020 The Regents of the University of Michigan
+# Copyright (c) 2010-2023 The Regents of the University of Michigan
 # This file is from the freud project, released under the BSD 3-Clause License.
 
 r"""

--- a/freud/diffraction.pyx
+++ b/freud/diffraction.pyx
@@ -1,4 +1,4 @@
-# Copyright (c) 2010-2020 The Regents of the University of Michigan
+# Copyright (c) 2010-2023 The Regents of the University of Michigan
 # This file is from the freud project, released under the BSD 3-Clause License.
 
 r"""

--- a/freud/environment.pyx
+++ b/freud/environment.pyx
@@ -1,4 +1,4 @@
-# Copyright (c) 2010-2020 The Regents of the University of Michigan
+# Copyright (c) 2010-2023 The Regents of the University of Michigan
 # This file is from the freud project, released under the BSD 3-Clause License.
 
 r"""

--- a/freud/errors.py
+++ b/freud/errors.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2010-2020 The Regents of the University of Michigan
+# Copyright (c) 2010-2023 The Regents of the University of Michigan
 # This file is from the freud project, released under the BSD 3-Clause License.
 
 # \package freud.errors

--- a/freud/interface.pyx
+++ b/freud/interface.pyx
@@ -1,4 +1,4 @@
-# Copyright (c) 2010-2020 The Regents of the University of Michigan
+# Copyright (c) 2010-2023 The Regents of the University of Michigan
 # This file is from the freud project, released under the BSD 3-Clause License.
 
 r"""

--- a/freud/locality.pxd
+++ b/freud/locality.pxd
@@ -1,4 +1,4 @@
-# Copyright (c) 2010-2020 The Regents of the University of Michigan
+# Copyright (c) 2010-2023 The Regents of the University of Michigan
 # This file is from the freud project, released under the BSD 3-Clause License.
 
 cimport freud._locality

--- a/freud/locality.pyx
+++ b/freud/locality.pyx
@@ -1,4 +1,4 @@
-# Copyright (c) 2010-2020 The Regents of the University of Michigan
+# Copyright (c) 2010-2023 The Regents of the University of Michigan
 # This file is from the freud project, released under the BSD 3-Clause License.
 
 r"""

--- a/freud/msd.pyx
+++ b/freud/msd.pyx
@@ -1,4 +1,4 @@
-# Copyright (c) 2010-2020 The Regents of the University of Michigan
+# Copyright (c) 2010-2023 The Regents of the University of Michigan
 # This file is from the freud project, released under the BSD 3-Clause License.
 
 r"""

--- a/freud/order.pyx
+++ b/freud/order.pyx
@@ -1,4 +1,4 @@
-# Copyright (c) 2010-2020 The Regents of the University of Michigan
+# Copyright (c) 2010-2023 The Regents of the University of Michigan
 # This file is from the freud project, released under the BSD 3-Clause License.
 
 r"""

--- a/freud/parallel.pyx
+++ b/freud/parallel.pyx
@@ -1,4 +1,4 @@
-# Copyright (c) 2010-2020 The Regents of the University of Michigan
+# Copyright (c) 2010-2023 The Regents of the University of Michigan
 # This file is from the freud project, released under the BSD 3-Clause License.
 
 r"""

--- a/freud/plot.py
+++ b/freud/plot.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2010-2020 The Regents of the University of Michigan
+# Copyright (c) 2010-2023 The Regents of the University of Michigan
 # This file is from the freud project, released under the BSD 3-Clause License.
 
 import io

--- a/freud/pmft.pyx
+++ b/freud/pmft.pyx
@@ -1,4 +1,4 @@
-# Copyright (c) 2010-2020 The Regents of the University of Michigan
+# Copyright (c) 2010-2023 The Regents of the University of Michigan
 # This file is from the freud project, released under the BSD 3-Clause License.
 
 r"""

--- a/freud/util.pxd
+++ b/freud/util.pxd
@@ -1,4 +1,4 @@
-# Copyright (c) 2010-2020 The Regents of the University of Michigan
+# Copyright (c) 2010-2023 The Regents of the University of Michigan
 # This file is from the freud project, released under the BSD 3-Clause License.
 
 # Directly expose vec3 and quat since they're ubiquitous in constructing

--- a/freud/util.pyx
+++ b/freud/util.pyx
@@ -1,4 +1,4 @@
-# Copyright (c) 2010-2020 The Regents of the University of Michigan
+# Copyright (c) 2010-2023 The Regents of the University of Michigan
 # This file is from the freud project, released under the BSD 3-Clause License.
 
 from functools import wraps

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2010-2020 The Regents of the University of Michigan
+# Copyright (c) 2010-2023 The Regents of the University of Michigan
 # This file is from the freud project, released under the BSD 3-Clause License.
 
 import os

--- a/tests/SphereVoxelization_fft.py
+++ b/tests/SphereVoxelization_fft.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2010-2023 The Regents of the University of Michigan
+# This file is from the freud project, released under the BSD 3-Clause License.
+
 import numpy as np
 
 

--- a/tests/integration/files/lj/lj.py
+++ b/tests/integration/files/lj/lj.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2010-2023 The Regents of the University of Michigan
+# This file is from the freud project, released under the BSD 3-Clause License.
+
 import hoomd
 from hoomd import md
 

--- a/tests/integration/test_reader_integrations.py
+++ b/tests/integration/test_reader_integrations.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2010-2023 The Regents of the University of Michigan
+# This file is from the freud project, released under the BSD 3-Clause License.
+
 import os
 import sys
 

--- a/tests/test_box_Box.py
+++ b/tests/test_box_Box.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2010-2023 The Regents of the University of Michigan
+# This file is from the freud project, released under the BSD 3-Clause License.
+
 import warnings
 from collections import namedtuple
 

--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2010-2023 The Regents of the University of Michigan
+# This file is from the freud project, released under the BSD 3-Clause License.
+
 import matplotlib
 import matplotlib.pyplot as plt
 import numpy as np

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2010-2023 The Regents of the University of Michigan
+# This file is from the freud project, released under the BSD 3-Clause License.
+
 import numpy as np
 import numpy.testing as npt
 import pytest

--- a/tests/test_density_CorrelationFunction.py
+++ b/tests/test_density_CorrelationFunction.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2010-2023 The Regents of the University of Michigan
+# This file is from the freud project, released under the BSD 3-Clause License.
+
 import matplotlib
 import matplotlib.pyplot as plt
 import numpy as np

--- a/tests/test_density_GaussianDensity.py
+++ b/tests/test_density_GaussianDensity.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2010-2023 The Regents of the University of Michigan
+# This file is from the freud project, released under the BSD 3-Clause License.
+
 import matplotlib
 import matplotlib.pyplot as plt
 import numpy as np

--- a/tests/test_density_LocalDensity.py
+++ b/tests/test_density_LocalDensity.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2010-2023 The Regents of the University of Michigan
+# This file is from the freud project, released under the BSD 3-Clause License.
+
 import numpy as np
 import numpy.testing as npt
 import pytest

--- a/tests/test_density_RDF.py
+++ b/tests/test_density_RDF.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2010-2023 The Regents of the University of Michigan
+# This file is from the freud project, released under the BSD 3-Clause License.
+
 import matplotlib
 import matplotlib.pyplot as plt
 import numpy as np

--- a/tests/test_density_SphereVoxelization.py
+++ b/tests/test_density_SphereVoxelization.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2010-2023 The Regents of the University of Michigan
+# This file is from the freud project, released under the BSD 3-Clause License.
+
 import matplotlib
 import matplotlib.pyplot as plt
 import numpy as np

--- a/tests/test_diffraction_DiffractionPattern.py
+++ b/tests/test_diffraction_DiffractionPattern.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2010-2023 The Regents of the University of Michigan
+# This file is from the freud project, released under the BSD 3-Clause License.
+
 import matplotlib
 import numpy as np
 import numpy.testing as npt

--- a/tests/test_diffraction_StaticStructureFactor.py
+++ b/tests/test_diffraction_StaticStructureFactor.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2010-2023 The Regents of the University of Michigan
+# This file is from the freud project, released under the BSD 3-Clause License.
+
 import numpy as np
 import numpy.testing as npt
 import pytest

--- a/tests/test_doctests.py
+++ b/tests/test_doctests.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2010-2023 The Regents of the University of Michigan
+# This file is from the freud project, released under the BSD 3-Clause License.
+
 import doctest
 import inspect
 

--- a/tests/test_environment_AngularSeparation.py
+++ b/tests/test_environment_AngularSeparation.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2010-2023 The Regents of the University of Michigan
+# This file is from the freud project, released under the BSD 3-Clause License.
+
 import numpy as np
 import numpy.testing as npt
 import pytest

--- a/tests/test_environment_BondOrder.py
+++ b/tests/test_environment_BondOrder.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2010-2023 The Regents of the University of Michigan
+# This file is from the freud project, released under the BSD 3-Clause License.
+
 import numpy as np
 import pytest
 import rowan

--- a/tests/test_environment_LocalBondProjection.py
+++ b/tests/test_environment_LocalBondProjection.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2010-2023 The Regents of the University of Michigan
+# This file is from the freud project, released under the BSD 3-Clause License.
+
 import numpy as np
 import numpy.testing as npt
 import pytest

--- a/tests/test_environment_LocalDescriptors.py
+++ b/tests/test_environment_LocalDescriptors.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2010-2023 The Regents of the University of Michigan
+# This file is from the freud project, released under the BSD 3-Clause License.
+
 from functools import lru_cache
 
 import numpy as np

--- a/tests/test_environment_MatchEnv.py
+++ b/tests/test_environment_MatchEnv.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2010-2023 The Regents of the University of Michigan
+# This file is from the freud project, released under the BSD 3-Clause License.
+
 import os
 
 import matplotlib

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2010-2023 The Regents of the University of Michigan
+# This file is from the freud project, released under the BSD 3-Clause License.
+
 import numpy as np
 import pytest
 

--- a/tests/test_locality_Filter.py
+++ b/tests/test_locality_Filter.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2010-2023 The Regents of the University of Michigan
+# This file is from the freud project, released under the BSD 3-Clause License.
+
 from abc import abstractmethod
 
 import numpy as np

--- a/tests/test_locality_NeighborList.py
+++ b/tests/test_locality_NeighborList.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2010-2023 The Regents of the University of Michigan
+# This file is from the freud project, released under the BSD 3-Clause License.
+
 import numpy as np
 import numpy.testing as npt
 import pytest
@@ -127,7 +130,7 @@ class TestNeighborList:
 
     def test_find_first_index(self):
         nlist = self.nlist
-        for (idx, i) in enumerate(nlist.query_point_indices):
+        for idx, i in enumerate(nlist.query_point_indices):
             assert nlist.find_first_index(i) <= idx
 
     def test_segments(self):

--- a/tests/test_locality_NeighborQuery.py
+++ b/tests/test_locality_NeighborQuery.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2010-2023 The Regents of the University of Michigan
+# This file is from the freud project, released under the BSD 3-Clause License.
+
 import itertools
 from collections import Counter
 

--- a/tests/test_locality_PeriodicBuffer.py
+++ b/tests/test_locality_PeriodicBuffer.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2010-2023 The Regents of the University of Michigan
+# This file is from the freud project, released under the BSD 3-Clause License.
+
 import numpy as np
 import numpy.testing as npt
 import pytest

--- a/tests/test_locality_Voronoi.py
+++ b/tests/test_locality_Voronoi.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2010-2023 The Regents of the University of Michigan
+# This file is from the freud project, released under the BSD 3-Clause License.
+
 import matplotlib
 import matplotlib.pyplot as plt
 import numpy as np

--- a/tests/test_managedarray.py
+++ b/tests/test_managedarray.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2010-2023 The Regents of the University of Michigan
+# This file is from the freud project, released under the BSD 3-Clause License.
+
 import numpy as np
 import numpy.testing as npt
 

--- a/tests/test_msd_MSD.py
+++ b/tests/test_msd_MSD.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2010-2023 The Regents of the University of Michigan
+# This file is from the freud project, released under the BSD 3-Clause License.
+
 import matplotlib
 import numpy as np
 import numpy.testing as npt

--- a/tests/test_order_Cubatic.py
+++ b/tests/test_order_Cubatic.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2010-2023 The Regents of the University of Michigan
+# This file is from the freud project, released under the BSD 3-Clause License.
+
 import numpy as np
 import numpy.testing as npt
 import pytest

--- a/tests/test_order_Hexatic.py
+++ b/tests/test_order_Hexatic.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2010-2023 The Regents of the University of Michigan
+# This file is from the freud project, released under the BSD 3-Clause License.
+
 import matplotlib
 import matplotlib.pyplot as plt
 import numpy as np

--- a/tests/test_order_Nematic.py
+++ b/tests/test_order_Nematic.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2010-2023 The Regents of the University of Michigan
+# This file is from the freud project, released under the BSD 3-Clause License.
+
 import numpy as np
 import numpy.testing as npt
 import pytest

--- a/tests/test_order_RotationalAutocorrelation.py
+++ b/tests/test_order_RotationalAutocorrelation.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2010-2023 The Regents of the University of Michigan
+# This file is from the freud project, released under the BSD 3-Clause License.
+
 import math
 import os
 

--- a/tests/test_order_SolidLiquid.py
+++ b/tests/test_order_SolidLiquid.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2010-2023 The Regents of the University of Michigan
+# This file is from the freud project, released under the BSD 3-Clause License.
+
 import matplotlib
 import numpy.testing as npt
 import pytest

--- a/tests/test_order_Steinhardt.py
+++ b/tests/test_order_Steinhardt.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2010-2023 The Regents of the University of Michigan
+# This file is from the freud project, released under the BSD 3-Clause License.
+
 import matplotlib
 import matplotlib.pyplot as plt
 import numpy as np

--- a/tests/test_order_Translational.py
+++ b/tests/test_order_Translational.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2010-2023 The Regents of the University of Michigan
+# This file is from the freud project, released under the BSD 3-Clause License.
+
 import itertools
 
 import numpy as np

--- a/tests/test_parallel.py
+++ b/tests/test_parallel.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2010-2023 The Regents of the University of Michigan
+# This file is from the freud project, released under the BSD 3-Clause License.
+
 import freud
 
 

--- a/tests/test_pmft.py
+++ b/tests/test_pmft.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2010-2023 The Regents of the University of Michigan
+# This file is from the freud project, released under the BSD 3-Clause License.
+
 import warnings
 
 import matplotlib

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2010-2023 The Regents of the University of Michigan
+# This file is from the freud project, released under the BSD 3-Clause License.
+
 from collections import namedtuple
 
 import numpy as np

--- a/tests/util.py
+++ b/tests/util.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2010-2023 The Regents of the University of Michigan
+# This file is from the freud project, released under the BSD 3-Clause License.
+
 import numpy as np
 
 import freud

--- a/tests/validation/__init__.py
+++ b/tests/validation/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (c) 2010-2023 The Regents of the University of Michigan
+# This file is from the freud project, released under the BSD 3-Clause License.

--- a/tests/validation/test_Minkowski_Structure_Metrics.py
+++ b/tests/validation/test_Minkowski_Structure_Metrics.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2010-2023 The Regents of the University of Michigan
+# This file is from the freud project, released under the BSD 3-Clause License.
+
 import os
 
 import garnett
@@ -40,7 +43,6 @@ class TestMinkowski:
         voro = freud.locality.Voronoi()
         voro.compute(snap)
         for sph_l in range(expected_ql.shape[1]):
-
             # These tests fail for unknown (probably numerical) reasons.
             if structure == "hcp" and sph_l in [3, 5]:
                 continue

--- a/tests/validation/test_Steinhardt_Average.py
+++ b/tests/validation/test_Steinhardt_Average.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2010-2023 The Regents of the University of Michigan
+# This file is from the freud project, released under the BSD 3-Clause License.
+
 import os
 
 import gsd.hoomd


### PR DESCRIPTION
## Description

This PR adds a pre-commit hooks which updates the license headers on every file in freud to be consistent with the header in the `LICENSE` file. This PR also updates the year in freud's license file to be 2023

## Motivation and Context

The year on the license headers in freud is still 2020. This PR will create an easy to maintain solution to the problem of updating the headers every year.

Resolves: #1084 

## How Has This Been Tested?

I have run `pre-commit` and it seems that all necessary files have had their headers updated correctly.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds or improves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation improvement (updates to user guides, docstrings, or developer docs)

## Checklist:
<!-- Put an `x` in all the boxes that apply. If you're unsure about any of
     these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [**CONTRIBUTING**](https://github.com/glotzerlab/freud/blob/master/CONTRIBUTING.md) document.
- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation (if relevant).
- [ ] I have added tests that cover my changes (if relevant).
- [ ] All new and existing tests passed.
- [ ] I have updated the [credits](https://github.com/glotzerlab/freud/blob/master/doc/source/reference/credits.rst).
- [ ] I have updated the [Changelog](https://github.com/glotzerlab/freud/blob/master/ChangeLog.md).
