### PR TITLE
Remove codecov

### DIFF
--- a/requirements/requirements-test-compatible.txt
+++ b/requirements/requirements-test-compatible.txt
@@ -1,6 +1,5 @@
 ase>=3.16.0
 cmake>=3.13.0
-codecov>=2.1.12
 coverage>=6.2
 cython>=0.29.14
 dynasor>=1.1b0; platform_system != "Windows"

--- a/requirements/requirements-test.txt
+++ b/requirements/requirements-test.txt
@@ -1,6 +1,5 @@
 ase==3.22.1
 cmake==3.26.1
-codecov==2.1.12
 coverage==7.2.2
 cython==0.29.33
 dynasor==1.1.1; platform_system != "Windows"


### PR DESCRIPTION
## Description

This PR removes `codecov` from freud's requirements files.

## Motivation and Context

The `codecov` package no longer exists on PyPI: https://about.codecov.io/blog/message-regarding-the-pypi-package/

freud doesn't use codecov to do anything anymore, so the requirement itself is vestigial.

I first noticed this on #1096 when CI failed for unknown reasons.

## How Has This Been Tested?

If CI tests pass, we are good to go.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds or improves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation improvement (updates to user guides, docstrings, or developer docs)

## Checklist:
<!-- Put an `x` in all the boxes that apply. If you're unsure about any of
     these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [**CONTRIBUTING**](https://github.com/glotzerlab/freud/blob/master/CONTRIBUTING.md) document.
- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation (if relevant).
- [ ] I have added tests that cover my changes (if relevant).
- [ ] All new and existing tests passed.
- [ ] I have updated the [credits](https://github.com/glotzerlab/freud/blob/master/doc/source/reference/credits.rst).
- [ ] I have updated the [Changelog](https://github.com/glotzerlab/freud/blob/master/ChangeLog.md).
