### PR TITLE
Pin scikit-build

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04, macos-12] #, windows-2019]
-        pyver: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
+        pyver: ["3.7", "3.8", "3.9", "3.10", "3.11"]
 
     steps:
       - uses: actions/checkout@v3.5.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools", "wheel", "oldest-supported-numpy", "cython>=0.29.14", "scikit-build==0.17.0", "cmake"]
+requires = ["setuptools", "wheel", "oldest-supported-numpy", "cython>=0.29.14", "scikit-build==0.17.1", "cmake"]
 
 [tool.black]
 target-version = ['py36']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools", "wheel", "oldest-supported-numpy", "cython>=0.29.14", "scikit-build==0.17.2", "cmake"]
+requires = ["setuptools", "wheel", "oldest-supported-numpy", "cython>=0.29.14", "scikit-build==0.17.1", "cmake"]
 
 [tool.black]
 target-version = ['py36']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools", "wheel", "oldest-supported-numpy", "cython>=0.29.14", "scikit-build==0.16.7", "cmake"]
+requires = ["setuptools", "wheel", "oldest-supported-numpy", "cython>=0.29.14", "scikit-build==0.17.0", "cmake"]
 
 [tool.black]
 target-version = ['py36']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools", "wheel", "oldest-supported-numpy", "cython>=0.29.14", "scikit-build>=0.13.1", "cmake"]
+requires = ["setuptools", "wheel", "oldest-supported-numpy", "cython>=0.29.14", "scikit-build==0.16.7", "cmake"]
 
 [tool.black]
 target-version = ['py36']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools", "wheel", "oldest-supported-numpy", "cython>=0.29.14", "scikit-build==0.17.1", "cmake"]
+requires = ["setuptools", "wheel", "oldest-supported-numpy", "cython>=0.29.14", "scikit-build==0.17.2", "cmake"]
 
 [tool.black]
 target-version = ['py36']


### PR DESCRIPTION
## Description

This PR pins the version of scikit-build in `pyproject.toml`

## Motivation and Context

A recent release of scikit-build may have changed how cmake looks for the python library, which may be the source of some cibuildwheel builds failing in a docker image which provides a statically linked python library. This PR is a test so we can see what happens in the build_wheels environment.

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to
     see how your changes affect other areas of the code, etc. -->

## Screenshots
<!-- (if appropriate) -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds or improves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation improvement (updates to user guides, docstrings, or developer docs)

## Checklist:
<!-- Put an `x` in all the boxes that apply. If you're unsure about any of
     these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [**CONTRIBUTING**](https://github.com/glotzerlab/freud/blob/master/CONTRIBUTING.md) document.
- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation (if relevant).
- [ ] I have added tests that cover my changes (if relevant).
- [ ] All new and existing tests passed.
- [ ] I have updated the [credits](https://github.com/glotzerlab/freud/blob/master/doc/source/reference/credits.rst).
- [ ] I have updated the [Changelog](https://github.com/glotzerlab/freud/blob/master/ChangeLog.md).
