### PR TITLE
Find python libraries in our cmake

### DIFF
--- a/freud/CMakeLists.txt
+++ b/freud/CMakeLists.txt
@@ -13,6 +13,7 @@ if(COVERAGE)
       CACHE STRING "The directives for Cython compilation." FORCE)
 endif()
 
+find_package(PythonLibs)
 find_package(PythonExtensions REQUIRED)
 find_package(Cython REQUIRED)
 find_package(NumPy REQUIRED)


### PR DESCRIPTION
## Description

This PR adds a call to `find_package(PythonLibs)` in freud's cmake code.

## Motivation and Context

The 0.17.3 release of `scikit-build` no longer calls `find_package(PythonLibs)` explicitly, so we need to do that in our cmake code now. We discovered this when our build_wheels jobs, some of which run on manylinux images, failed to compile.

## How Has This Been Tested?

If build_wheels is successful, we are good to go.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds or improves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation improvement (updates to user guides, docstrings, or developer docs)

## Checklist:
<!-- Put an `x` in all the boxes that apply. If you're unsure about any of
     these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [**CONTRIBUTING**](https://github.com/glotzerlab/freud/blob/master/CONTRIBUTING.md) document.
- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation (if relevant).
- [ ] I have added tests that cover my changes (if relevant).
- [ ] All new and existing tests passed.
- [ ] I have updated the [credits](https://github.com/glotzerlab/freud/blob/master/doc/source/reference/credits.rst).
- [ ] I have updated the [Changelog](https://github.com/glotzerlab/freud/blob/master/ChangeLog.md).
