### PR TITLE
Remove Garnett as a Testing Dependency

### DIFF
--- a/.github/workflows/oldest-test-reqs.txt
+++ b/.github/workflows/oldest-test-reqs.txt
@@ -2,7 +2,6 @@ ase==3.16.0
 cmake==3.13.0
 cython==0.29.14
 dynasor==1.1b0; platform_system != "Windows"
-garnett==0.7.1
 gsd==2.4.2
 matplotlib==3.0.0
 numpy==1.15.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools", "wheel", "oldest-supported-numpy", "cython>=0.29.14", "scikit-build>=0.17.3", "cmake"]
+requires = ["setuptools", "wheel", "oldest-supported-numpy", "cython>=0.29.14,<3.0.0", "scikit-build>=0.17.3", "cmake"]
 
 [tool.black]
 target-version = ['py36']

--- a/requirements/requirements-test-compatible.txt
+++ b/requirements/requirements-test-compatible.txt
@@ -3,7 +3,6 @@ cmake>=3.13.0
 coverage>=6.2
 cython>=0.29.14
 dynasor>=1.1b0; platform_system != "Windows"
-garnett>=0.7.1
 GitPython>=3.1.24
 gsd>=2.4.2, <3.0.0
 matplotlib>=3.0.0

--- a/requirements/requirements-test-compatible.txt
+++ b/requirements/requirements-test-compatible.txt
@@ -4,7 +4,7 @@ coverage>=6.2
 cython>=0.29.14, <3.0.0
 dynasor>=1.1b0; platform_system != "Windows"
 GitPython>=3.1.24
-gsd>=2.4.2, <3.0.0
+gsd>=2.4.2
 matplotlib>=3.0.0
 numpy>=1.14.0
 pillow>=6.2.0 --only-binary=pillow

--- a/requirements/requirements-test.txt
+++ b/requirements/requirements-test.txt
@@ -4,7 +4,7 @@ coverage==7.2.7
 cython==0.29.35
 dynasor==1.1.1; platform_system != "Windows"
 GitPython==3.1.32
-gsd==2.9.0
+gsd==3.1.0
 matplotlib>=3.0.0
 numpy==1.25.0
 pillow>=8.0.0 --only-binary=pillow

--- a/requirements/requirements-test.txt
+++ b/requirements/requirements-test.txt
@@ -3,7 +3,6 @@ cmake==3.26.4
 coverage==7.2.7
 cython==0.29.35
 dynasor==1.1.1; platform_system != "Windows"
-garnett==0.7.1
 GitPython==3.1.31
 gsd==2.9.0
 matplotlib>=3.0.0

--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,6 @@ setup(
     tests_require=[
         "ase>=3.16",
         "gsd>=2.0",
-        "garnett>=0.7.1",
         "matplotlib>=3.0",
         "sympy>=1.0",
     ],

--- a/tests/integration/test_reader_integrations.py
+++ b/tests/integration/test_reader_integrations.py
@@ -4,11 +4,20 @@
 import os
 import sys
 
+import gsd
+import gsd.hoomd
 import numpy as np
 import numpy.testing as npt
 import pytest
 
 import freud
+
+try:
+    GSD_VERSION = gsd.__version__
+    GSD_READ_FLAG = "rb"
+except AttributeError:
+    GSD_VERSION = gsd.version.version
+    GSD_READ_FLAG = "r"
 
 
 def _relative_path(*path):
@@ -44,9 +53,7 @@ class TestReaderIntegrations:
         self.run_analyses(reader)
 
     def test_gsd_gsd(self):
-        import gsd.hoomd
-
-        with gsd.hoomd.open(LJ_GSD, "rb") as traj:
+        with gsd.hoomd.open(LJ_GSD, GSD_READ_FLAG) as traj:
             self.run_analyses(traj)
 
     def test_ovito_gsd(self):

--- a/tests/integration/test_reader_integrations.py
+++ b/tests/integration/test_reader_integrations.py
@@ -49,19 +49,6 @@ class TestReaderIntegrations:
         with gsd.hoomd.open(LJ_GSD, "rb") as traj:
             self.run_analyses(traj)
 
-    def test_garnett_gsd(self):
-        import garnett
-
-        with garnett.read(LJ_GSD) as traj:
-            self.run_analyses(traj)
-
-    @pytest.mark.filterwarnings("ignore:Failed to import dcdreader")
-    def test_garnett_dcd(self):
-        import garnett
-
-        with garnett.read(LJ_DCD) as traj:
-            self.run_analyses(traj)
-
     def test_ovito_gsd(self):
         import_file = pytest.importorskip("ovito.io").import_file
         pipeline = import_file(LJ_GSD)

--- a/tests/validation/test_Minkowski_Structure_Metrics.py
+++ b/tests/validation/test_Minkowski_Structure_Metrics.py
@@ -36,7 +36,9 @@ class TestMinkowski:
                 "files",
                 "minkowski_structure_metrics",
                 f"{structure}.gsd",
-            ), mode='rb')[0]
+            ),
+            mode="rb",
+        )[0]
 
         voro = freud.locality.Voronoi()
         voro.compute(snap)

--- a/tests/validation/test_Minkowski_Structure_Metrics.py
+++ b/tests/validation/test_Minkowski_Structure_Metrics.py
@@ -3,7 +3,7 @@
 
 import os
 
-import garnett
+import gsd.hoomd
 import numpy as np
 import numpy.testing as npt
 import pytest
@@ -30,15 +30,13 @@ class TestMinkowski:
         expected_wl = _get_structure_data(structure, "w")
         expected_avwl = _get_structure_data(structure, "avw")
 
-        with garnett.read(
+        snap = gsd.hoomd.open(
             os.path.join(
                 os.path.dirname(__file__),
                 "files",
                 "minkowski_structure_metrics",
                 f"{structure}.gsd",
-            )
-        ) as traj:
-            snap = traj[0]
+            ), mode='rb')[0]
 
         voro = freud.locality.Voronoi()
         voro.compute(snap)

--- a/tests/validation/test_Minkowski_Structure_Metrics.py
+++ b/tests/validation/test_Minkowski_Structure_Metrics.py
@@ -3,12 +3,20 @@
 
 import os
 
+import gsd
 import gsd.hoomd
 import numpy as np
 import numpy.testing as npt
 import pytest
 
 import freud
+
+try:
+    GSD_VERSION = gsd.__version__
+    GSD_READ_FLAG = "rb"
+except AttributeError:
+    GSD_VERSION = gsd.version.version
+    GSD_READ_FLAG = "r"
 
 
 def _get_structure_data(structure, qtype):
@@ -37,7 +45,7 @@ class TestMinkowski:
                 "minkowski_structure_metrics",
                 f"{structure}.gsd",
             ),
-            mode="rb",
+            mode=GSD_READ_FLAG,
         )[0]
 
         voro = freud.locality.Voronoi()


### PR DESCRIPTION
## Description

This PR removes `garnett` from freud's test suite.

## Motivation and Context

We plan to support `gsd>=3.0.0` in the future and `garnett` cannot read `gsd>=3.0` files due to changes in gsd's read/write mode flags.

## How Has This Been Tested?

Garnett has been removed from usage in freud's tests, so if the remaining tests pass we are good to go.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds or improves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation improvement (updates to user guides, docstrings, or developer docs)

## Checklist:
<!-- Put an `x` in all the boxes that apply. If you're unsure about any of
     these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [**CONTRIBUTING**](https://github.com/glotzerlab/freud/blob/master/CONTRIBUTING.md) document.
- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation (if relevant).
- [ ] I have added tests that cover my changes (if relevant).
- [ ] All new and existing tests passed.
- [ ] I have updated the [credits](https://github.com/glotzerlab/freud/blob/master/doc/source/reference/credits.rst).
- [ ] I have updated the [Changelog](https://github.com/glotzerlab/freud/blob/master/ChangeLog.md).
