### PR TITLE
Drop python 3.7

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04, macos-12] #, windows-2019]
-        pyver: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+        pyver: ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v4.1.0

--- a/.github/workflows/cibuildwheel-before-test.sh
+++ b/.github/workflows/cibuildwheel-before-test.sh
@@ -7,10 +7,10 @@ fi
 PACKAGE_DIR=$1
 
 if [[ $(python --version 2>&1) == *"3.8."* ]]; then
-  # Python 3.7 is only supported with oldest requirements
+  # Python 3.8 is only supported with oldest requirements
   pip install -U -r "${PACKAGE_DIR}/.github/workflows/oldest-test-reqs.txt" --progress-bar=off
 elif [[ $(python --version 2>&1) == *"3.9."* ]]; then
-  # Python 3.8 needs compatible requirements
+  # Python 3.9 needs compatible requirements
   pip install -U -r "${PACKAGE_DIR}/requirements/requirements-test-compatible.txt" --progress-bar=off
 else
   pip install -U -r "${PACKAGE_DIR}/requirements/requirements-test.txt" --progress-bar=off

--- a/.github/workflows/cibuildwheel-before-test.sh
+++ b/.github/workflows/cibuildwheel-before-test.sh
@@ -6,10 +6,10 @@ fi
 
 PACKAGE_DIR=$1
 
-if [[ $(python --version 2>&1) == *"3.7."* ]]; then
+if [[ $(python --version 2>&1) == *"3.8."* ]]; then
   # Python 3.7 is only supported with oldest requirements
   pip install -U -r "${PACKAGE_DIR}/.github/workflows/oldest-test-reqs.txt" --progress-bar=off
-elif [[ $(python --version 2>&1) == *"3.8."* ]]; then
+elif [[ $(python --version 2>&1) == *"3.9."* ]]; then
   # Python 3.8 needs compatible requirements
   pip install -U -r "${PACKAGE_DIR}/requirements/requirements-test-compatible.txt" --progress-bar=off
 else

--- a/.github/workflows/oldest-test-reqs.txt
+++ b/.github/workflows/oldest-test-reqs.txt
@@ -4,7 +4,7 @@ cython==3.0.2
 dynasor==1.1b0; platform_system != "Windows"
 gsd==2.4.2
 matplotlib==3.2.0
-numpy==1.15.0
+numpy==1.18.0
 pillow==7.0.0
 pytest==6.2.2
 rowan==1.2.1

--- a/.github/workflows/oldest-test-reqs.txt
+++ b/.github/workflows/oldest-test-reqs.txt
@@ -9,5 +9,5 @@ pillow==6.2.0
 pytest==6.2.2
 rowan==1.2.1
 scikit-build==0.13.1
-scipy==1.1.0
+scipy==1.4.0
 sympy==1.0

--- a/.github/workflows/oldest-test-reqs.txt
+++ b/.github/workflows/oldest-test-reqs.txt
@@ -5,7 +5,7 @@ dynasor==1.1b0; platform_system != "Windows"
 gsd==2.4.2
 matplotlib==3.2.0
 numpy==1.15.0
-pillow==6.2.0
+pillow==7.0.0
 pytest==6.2.2
 rowan==1.2.1
 scikit-build==0.13.1

--- a/.github/workflows/oldest-test-reqs.txt
+++ b/.github/workflows/oldest-test-reqs.txt
@@ -8,6 +8,6 @@ numpy==1.15.0
 pillow==6.2.0
 pytest==6.2.2
 rowan==1.2.1
-scikit-build==0.13.1
+scikit-build==0.14.0
 scipy==1.1.0
 sympy==1.0

--- a/.github/workflows/oldest-test-reqs.txt
+++ b/.github/workflows/oldest-test-reqs.txt
@@ -1,5 +1,5 @@
 ase==3.16.0
-cmake==3.13.0
+cmake==3.14.3
 cython==3.0.2
 dynasor==1.1b0; platform_system != "Windows"
 gsd==2.4.2
@@ -8,6 +8,6 @@ numpy==1.15.0
 pillow==6.2.0
 pytest==6.2.2
 rowan==1.2.1
-scikit-build==0.14.0
+scikit-build==0.13.1
 scipy==1.1.0
 sympy==1.0

--- a/.github/workflows/oldest-test-reqs.txt
+++ b/.github/workflows/oldest-test-reqs.txt
@@ -3,7 +3,7 @@ cmake==3.14.3
 cython==3.0.2
 dynasor==1.1b0; platform_system != "Windows"
 gsd==2.4.2
-matplotlib==3.0.0
+matplotlib==3.2.0
 numpy==1.15.0
 pillow==6.2.0
 pytest==6.2.2

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -24,9 +24,8 @@ jobs:
     strategy:
       matrix:
         os: [macOS-latest, ubuntu-latest, windows-latest]
-        pyver-env: [ {pyver: '3.7', env: 'test-oldest_env.yaml'},
-                     {pyver: '3.8', env: 'test-compatible_env.yaml'},
-                     {pyver: '3.9', env: 'test_env.yaml'},
+        pyver-env: [ {pyver: '3.8', env: 'test-oldest_env.yaml'},
+                     {pyver: '3.9', env: 'test-compatible_env.yaml'},
                      {pyver: '3.10', env: 'test_env.yaml'},
                      {pyver: '3.11', env: 'test_env.yaml'},
                      {pyver: '3.12', env: 'test_env.yaml'} ]

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,14 @@ The format is based on
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## vX.Y.Z -- YYYY-MM-DD
+
+### Added
+* Support for python 3.12
+
+### Removed
+* Support for python 3.7
+
 ## v2.13.1 -- 2023-09-14
 
 ### Added

--- a/doc/source/reference/credits.rst
+++ b/doc/source/reference/credits.rst
@@ -338,6 +338,7 @@ Tommy Waltmann
 * Fixed segfault in neighborlists owned by compute objects.
 * Added support for ``gsd.hoomd.Frame`` in ``NeighborQuery.from_system`` calls.
 * Added support for building with cython 3.0
+* Added support for python 3.12 and remove support for python 3.7
 
 Maya Martirossyan
 


### PR DESCRIPTION
## Description

This PR removes support for python 3.7 by dropping it from our testing matrix and build wheels operations.

## Motivation and Context

Python 3.7 hit end of life in June: https://devguide.python.org/versions/

## How Has This Been Tested?

If the current tests pass, we are ready to do.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds or improves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation improvement (updates to user guides, docstrings, or developer docs)

## Checklist:
<!-- Put an `x` in all the boxes that apply. If you're unsure about any of
     these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [**CONTRIBUTING**](https://github.com/glotzerlab/freud/blob/master/CONTRIBUTING.md) document.
- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation (if relevant).
- [ ] I have added tests that cover my changes (if relevant).
- [ ] All new and existing tests passed.
- [ ] I have updated the [credits](https://github.com/glotzerlab/freud/blob/master/doc/source/reference/credits.rst).
- [ ] I have updated the [Changelog](https://github.com/glotzerlab/freud/blob/master/ChangeLog.md).