### PR TITLE
Fix TBB Pinning

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -76,7 +76,7 @@ jobs:
         with:
           submodules: "recursive"
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v5.0.0
         name: Install Python
         with:
           python-version: '3.9'

--- a/.github/workflows/env-files/test-oldest_env.yaml
+++ b/.github/workflows/env-files/test-oldest_env.yaml
@@ -3,8 +3,8 @@ channels:
   - conda-forge
 
 dependencies:
-  - tbb=2019.7
-  - tbb-devel=2019.7
+  - tbb=2020.2
+  - tbb-devel=2020.2
   - ninja
   - pip
   - pip:

--- a/.github/workflows/oldest-test-reqs.txt
+++ b/.github/workflows/oldest-test-reqs.txt
@@ -1,5 +1,5 @@
 ase==3.16.0
-cmake==3.18.2
+cmake==3.20.2
 cython==3.0.2
 dynasor==1.1b0; platform_system != "Windows"
 gsd==2.4.2

--- a/.github/workflows/oldest-test-reqs.txt
+++ b/.github/workflows/oldest-test-reqs.txt
@@ -3,8 +3,8 @@ cmake==3.20.2
 cython==3.0.2
 dynasor==1.1b0; platform_system != "Windows"
 gsd==2.5.0
-matplotlib==3.2.0
-numpy==1.18.0
+matplotlib==3.5.0
+numpy==1.21.0
 pillow==7.0.0
 pytest==6.2.2
 rowan==1.2.1

--- a/.github/workflows/oldest-test-reqs.txt
+++ b/.github/workflows/oldest-test-reqs.txt
@@ -2,7 +2,7 @@ ase==3.16.0
 cmake==3.20.2
 cython==3.0.2
 dynasor==1.1b0; platform_system != "Windows"
-gsd==2.4.2
+gsd==2.5.0
 matplotlib==3.2.0
 numpy==1.18.0
 pillow==7.0.0

--- a/.github/workflows/oldest-test-reqs.txt
+++ b/.github/workflows/oldest-test-reqs.txt
@@ -5,9 +5,9 @@ dynasor==1.1b0; platform_system != "Windows"
 gsd==2.5.0
 matplotlib==3.5.0
 numpy==1.21.0
-pillow==7.0.0
+pillow==8.3.0
 pytest==6.2.2
 rowan==1.2.1
 scikit-build==0.13.1
-scipy==1.4.0
+scipy==1.8.0
 sympy==1.0

--- a/.github/workflows/oldest-test-reqs.txt
+++ b/.github/workflows/oldest-test-reqs.txt
@@ -1,5 +1,5 @@
 ase==3.16.0
-cmake==3.14.3
+cmake==3.16.3
 cython==3.0.2
 dynasor==1.1b0; platform_system != "Windows"
 gsd==2.4.2

--- a/.github/workflows/oldest-test-reqs.txt
+++ b/.github/workflows/oldest-test-reqs.txt
@@ -1,5 +1,5 @@
 ase==3.16.0
-cmake==3.16.3
+cmake==3.18.2
 cython==3.0.2
 dynasor==1.1b0; platform_system != "Windows"
 gsd==2.4.2

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -54,7 +54,7 @@ jobs:
           submodules: true
 
       - name: Create Python Environment
-        uses: conda-incubator/setup-miniconda@v3
+        uses: conda-incubator/setup-miniconda@v3.0.2
         with:
           python-version: ${{ matrix.python }}
           environment-file: .github/workflows/env-files/${{ matrix.env }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools", "wheel", "oldest-supported-numpy", "cython>=3.0.2", "scikit-build>=0.17.3", "cmake"]
+requires = ["setuptools", "wheel", "numpy>=1.21.0", "cython>=3.0.2", "scikit-build>=0.17.3", "cmake"]
 
 [tool.black]
 target-version = ['py36']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools", "wheel", "numpy>=1.21.0", "cython>=3.0.2", "scikit-build>=0.17.3", "cmake"]
+requires = ["setuptools", "wheel", "oldest-supported-numpy", "cython>=3.0.2", "scikit-build>=0.17.3", "cmake"]
 
 [tool.black]
 target-version = ['py36']


### PR DESCRIPTION
## Description

This PR pins TBB in our oldest builds to the oldest version with an arm64 binary. It also more completely specifies the version of the github action we use to setup miniconda and the python environment.

## Motivation and Context

A new release of setup-miniconda broke our test-oldest CI workflow because it installed an arm64 miniforge instead of an x86_64 one. 

## How Has This Been Tested?

If CI passes, we are good to go.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds or improves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation improvement (updates to user guides, docstrings, or developer docs)

## Checklist:
<!-- Put an `x` in all the boxes that apply. If you're unsure about any of
     these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [**CONTRIBUTING**](https://github.com/glotzerlab/freud/blob/master/CONTRIBUTING.md) document.
- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation (if relevant).
- [ ] I have added tests that cover my changes (if relevant).
- [ ] All new and existing tests passed.
- [ ] I have updated the [credits](https://github.com/glotzerlab/freud/blob/master/doc/source/reference/credits.rst).
- [ ] I have updated the [Changelog](https://github.com/glotzerlab/freud/blob/master/ChangeLog.md).
