### PR TITLE
Fix `terminate_after_blocked` default in `FilterRAD`

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -10,6 +10,9 @@ and this project adheres to
 * New continuous coordination number compute `freud.order.ContinuousCoordination`.
 * New methods for conversion of box lengths and angles to/from `freud.box.Box`.
 
+### Fixed
+* Default value for `terminate_after_blocked` in `FilterRAD`.
+
 ### Removed
 * `freud.order.Translational`.
 

--- a/freud/locality.pyx
+++ b/freud/locality.pyx
@@ -1522,7 +1522,7 @@ cdef class FilterRAD(Filter):
     def __cinit__(
         self,
         cbool allow_incomplete_shell=False,
-        cbool terminate_after_blocked=True
+        cbool terminate_after_blocked=False
     ):
         self._filterptr = self._thisptr = new freud._locality.FilterRAD(
             allow_incomplete_shell,


### PR DESCRIPTION
## Description

This PR fixes the default value for `FilterRAD`'s `terminate_after_blocked` argument so it defaults to RAD-open rather than RAD-closed.

## Motivation and Context

The value in the docs was right, but the value in the source code was wrong.

Resolves: #1247 

## How Has This Been Tested?

Existing tests should be appropriate to verify nothing is broken.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds or improves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation improvement (updates to user guides, docstrings, or developer docs)

## Checklist:
<!-- Put an `x` in all the boxes that apply. If you're unsure about any of
     these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [**CONTRIBUTING**](https://github.com/glotzerlab/freud/blob/main/CONTRIBUTING.md) document.
- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation (if relevant).
- [ ] I have added tests that cover my changes (if relevant).
- [ ] All new and existing tests passed.
- [ ] I have updated the [credits](https://github.com/glotzerlab/freud/blob/main/doc/source/reference/credits.rst).
- [ ] I have updated the [Changelog](https://github.com/glotzerlab/freud/blob/main/ChangeLog.md).
