### PR TITLE
Expose neighbors computed using local density via a neighbor list

### DIFF
--- a/cpp/density/LocalDensity.cc
+++ b/cpp/density/LocalDensity.cc
@@ -2,8 +2,8 @@
 // This file is from the freud project, released under the BSD 3-Clause License.
 
 #include "LocalDensity.h"
-#include "NeighborComputeFunctional.h"
 #include "NeighborBond.h"
+#include "NeighborComputeFunctional.h"
 #include <tbb/enumerable_thread_specific.h>
 #include <vector>
 
@@ -61,9 +61,10 @@ void LocalDensity::compute(const freud::locality::NeighborQuery* neighbor_query,
                     // this is not particularly accurate for a single particle, but works well on average for
                     // lots of them. It smooths out the neighbor count distributions and avoids noisy spikes
                     // that obscure data
-                    weight = float(1.0) + (m_r_max - (nb.getDistance() + m_diameter / float(2.0))) / m_diameter;
+                    weight
+                        = float(1.0) + (m_r_max - (nb.getDistance() + m_diameter / float(2.0))) / m_diameter;
                 }
-                local_bonds.emplace_back(i, nb.getPointIdx(),nb.getDistance(),weight,nb.getVector());
+                local_bonds.emplace_back(i, nb.getPointIdx(), nb.getDistance(), weight, nb.getVector());
                 num_neighbors += weight;
                 m_num_neighbors_array[i] = num_neighbors;
                 if (m_box.is2D())
@@ -78,10 +79,11 @@ void LocalDensity::compute(const freud::locality::NeighborQuery* neighbor_query,
                 }
             }
         });
-        tbb::flattened2d<BondVector> flat_density_bonds = tbb::flatten2d(new_bonds);
-        std::vector<freud::locality::NeighborBond> density_bonds(flat_density_bonds.begin(), flat_density_bonds.end());
+    tbb::flattened2d<BondVector> flat_density_bonds = tbb::flatten2d(new_bonds);
+    std::vector<freud::locality::NeighborBond> density_bonds(flat_density_bonds.begin(),
+                                                             flat_density_bonds.end());
 
-        m_density_nlist = std::make_shared<freud::locality::NeighborList>(density_bonds);
+    m_density_nlist = std::make_shared<freud::locality::NeighborList>(density_bonds);
 }
 
 }; }; // end namespace freud::density

--- a/cpp/density/LocalDensity.h
+++ b/cpp/density/LocalDensity.h
@@ -63,6 +63,15 @@ public:
         return m_num_neighbors_array;
     }
 
+    std::shared_ptr<NeighborList> getDensityNlist() const
+    {
+        return m_density_nlist;
+    }
+
+protected:
+    std::shared_ptr<NeighborList> m_density_nlist;
+
+
 private:
     box::Box m_box;   //!< Simulation box where the particles belong
     float m_r_max;    //!< Maximum neighbor distance
@@ -70,6 +79,7 @@ private:
 
     util::ManagedArray<float> m_density_array;       //!< density array computed
     util::ManagedArray<float> m_num_neighbors_array; //!< number of neighbors array computed
+
 };
 
 }; }; // end namespace freud::density

--- a/cpp/density/LocalDensity.h
+++ b/cpp/density/LocalDensity.h
@@ -71,7 +71,6 @@ public:
 protected:
     std::shared_ptr<freud::locality::NeighborList> m_density_nlist;
 
-
 private:
     box::Box m_box;   //!< Simulation box where the particles belong
     float m_r_max;    //!< Maximum neighbor distance
@@ -79,7 +78,6 @@ private:
 
     util::ManagedArray<float> m_density_array;       //!< density array computed
     util::ManagedArray<float> m_num_neighbors_array; //!< number of neighbors array computed
-
 };
 
 }; }; // end namespace freud::density

--- a/cpp/density/LocalDensity.h
+++ b/cpp/density/LocalDensity.h
@@ -63,13 +63,13 @@ public:
         return m_num_neighbors_array;
     }
 
-    std::shared_ptr<NeighborList> getDensityNlist() const
+    std::shared_ptr<freud::locality::NeighborList> getDensityNlist() const
     {
         return m_density_nlist;
     }
 
 protected:
-    std::shared_ptr<NeighborList> m_density_nlist;
+    std::shared_ptr<freud::locality::NeighborList> m_density_nlist;
 
 
 private:

--- a/freud/_density.pxd
+++ b/freud/_density.pxd
@@ -2,6 +2,7 @@
 # This file is from the freud project, released under the BSD 3-Clause License.
 
 from libcpp.memory cimport shared_ptr
+
 cimport freud._box
 cimport freud._locality
 cimport freud.util

--- a/freud/_density.pxd
+++ b/freud/_density.pxd
@@ -1,10 +1,11 @@
 # Copyright (c) 2010-2024 The Regents of the University of Michigan
 # This file is from the freud project, released under the BSD 3-Clause License.
 
+from libcpp.memory cimport shared_ptr
 cimport freud._box
 cimport freud._locality
 cimport freud.util
-from freud._locality cimport BondHistogramCompute
+from freud._locality cimport BondHistogramCompute, NeighborList
 from freud.util cimport vec3
 
 ctypedef unsigned int uint
@@ -42,6 +43,7 @@ cdef extern from "LocalDensity.h" namespace "freud::density":
             freud._locality.QueryArgs) except +
         const freud.util.ManagedArray[float] &getDensity() const
         const freud.util.ManagedArray[float] &getNumNeighbors() const
+        shared_ptr[NeighborList] getDensityNlist() const
         float getRMax() const
         float getDiameter() const
 

--- a/freud/density.pyx
+++ b/freud/density.pyx
@@ -15,7 +15,7 @@ import freud.locality
 
 from cython.operator cimport dereference
 
-from freud.locality cimport _PairCompute, _SpatialHistogram1D
+from freud.locality cimport _PairCompute, _SpatialHistogram1D, _nlist_from_cnlist
 from freud.util cimport _Compute, vec3
 
 from collections.abc import Sequence
@@ -554,6 +554,14 @@ cdef class LocalDensity(_PairCompute):
         return freud.util.make_managed_numpy_array(
             &self.thisptr.getNumNeighbors(),
             freud.util.arr_type_t.FLOAT)
+        
+    @_Compute._computed_property
+    def densityNlist(self):
+        """:class:`.NeighborList`: The neighbor list used for computing local density
+        with contributions to as weights."""
+        nlist = _nlist_from_cnlist(self.thisptr.getDensityNlist().get())
+        nlist._compute = self
+        return nlist
 
     def __repr__(self):
         return ("freud.density.{cls}(r_max={r_max}, "

--- a/freud/density.pyx
+++ b/freud/density.pyx
@@ -15,7 +15,7 @@ import freud.locality
 
 from cython.operator cimport dereference
 
-from freud.locality cimport _PairCompute, _SpatialHistogram1D, _nlist_from_cnlist
+from freud.locality cimport _nlist_from_cnlist, _PairCompute, _SpatialHistogram1D
 from freud.util cimport _Compute, vec3
 
 from collections.abc import Sequence
@@ -554,7 +554,7 @@ cdef class LocalDensity(_PairCompute):
         return freud.util.make_managed_numpy_array(
             &self.thisptr.getNumNeighbors(),
             freud.util.arr_type_t.FLOAT)
-        
+
     @_Compute._computed_property
     def densityNlist(self):
         """:class:`.NeighborList`: The neighbor list used for computing local density


### PR DESCRIPTION
## Description
This pull request exposes neighbors computed using local density via a neighbor list. The local density computation currently averages the number of neighbors using the approach described in the documentation but does not expose the associated neighbor list. This enhancement computes and exposes the full weighted neighbor list based on the approach described in the local density documentation. The weighted neighbor list applies the same rules used to compute neighbors of particles, considering contributions based on distances as neighbor list weights.

## Motivation and Context
@rayasare requested this be exposed.

## How Has This Been Tested?
Tests and docs are TODO

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds or improves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation improvement (updates to user guides, docstrings, or developer docs)

## Checklist:
<!-- Put an `x` in all the boxes that apply. If you're unsure about any of
     these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/glotzerlab/freud/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] I have updated the documentation (if relevant).
- [ ] I have added tests that cover my changes (if relevant).
- [ ] All new and existing tests passed.
- [ ] I have updated the [credits](https://github.com/glotzerlab/freud/blob/main/doc/source/reference/credits.rst).
- [ ] I have updated the [Changelog](https://github.com/glotzerlab/freud/blob/main/ChangeLog.md).
