### PR TITLE
Convert PMFT to use nanobind

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -65,6 +65,7 @@ jobs:
           pytest tests/test_parallel.py -v
           pytest tests/test_locality_*.py -v
           pytest tests/test_data.py -v
+          pytest tests/test_pmft.py::TestPMFTXY -v
           # pytest tests/ -v
 
   tests_complete:

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -26,11 +26,12 @@ endif()
 include(box/box-files.cmake)
 include(locality/locality-files.cmake)
 include(parallel/parallel-files.cmake)
+include(pmft/pmft-files.cmake)
 include(util/util-files.cmake)
 
 # make libfreud.so
 add_library(libfreud SHARED ${box_sources} ${locality_sources}
-                            ${parallel_sources} ${util-sources})
+                            ${parallel_sources} ${pmft_sources} ${util_sources})
 
 target_link_libraries(libfreud PUBLIC TBB::tbb)
 
@@ -62,6 +63,7 @@ endif()
 add_subdirectory(box)
 add_subdirectory(locality)
 add_subdirectory(parallel)
+add_subdirectory(pmft)
 add_subdirectory(util)
 
 # commented out for now, uncomment them as the conversion to pybind11 progresses

--- a/cpp/locality/BondHistogramCompute.h
+++ b/cpp/locality/BondHistogramCompute.h
@@ -101,9 +101,9 @@ public:
         \param cf An object with operator(NeighborBond) as input.
     */
     template<typename Func>
-    void accumulateGeneral(std::shared_ptr<locality::NeighborQuery> neighbor_query, const vec3<float>* query_points,
-                           unsigned int n_query_points, std::shared_ptr<locality::NeighborList> nlist,
-                           locality::QueryArgs qargs, Func cf)
+    void accumulateGeneral(std::shared_ptr<locality::NeighborQuery> neighbor_query,
+                           const vec3<float>* query_points, unsigned int n_query_points,
+                           std::shared_ptr<locality::NeighborList> nlist, locality::QueryArgs qargs, Func cf)
     {
         m_box = neighbor_query->getBox();
         locality::loopOverNeighbors(neighbor_query, query_points, n_query_points, qargs, nlist, cf);

--- a/cpp/locality/BondHistogramCompute.h
+++ b/cpp/locality/BondHistogramCompute.h
@@ -46,7 +46,7 @@ public:
     }
 
     //! Return thing_to_return after reducing if necessary.
-    template<typename U> U& reduceAndReturn(U& thing_to_return)
+    template<typename U> std::shared_ptr<U> reduceAndReturn(std::shared_ptr<U> thing_to_return)
     {
         if (m_reduce)
         {

--- a/cpp/locality/BondHistogramCompute.h
+++ b/cpp/locality/BondHistogramCompute.h
@@ -101,8 +101,8 @@ public:
         \param cf An object with operator(NeighborBond) as input.
     */
     template<typename Func>
-    void accumulateGeneral(const locality::NeighborQuery* neighbor_query, const vec3<float>* query_points,
-                           unsigned int n_query_points, const locality::NeighborList* nlist,
+    void accumulateGeneral(std::shared_ptr<locality::NeighborQuery> neighbor_query, const vec3<float>* query_points,
+                           unsigned int n_query_points, std::shared_ptr<locality::NeighborList> nlist,
                            locality::QueryArgs qargs, Func cf)
     {
         m_box = neighbor_query->getBox();

--- a/cpp/locality/CMakeLists.txt
+++ b/cpp/locality/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(locality_extension_sources
-    export_BondHistogramCompute.cc export_NeighborQuery.cc export_NeighborList.cc export_Filter.cc
-    export_PeriodicBuffer.cc export_Voronoi.cc)
+    export_BondHistogramCompute.cc export_NeighborQuery.cc
+    export_NeighborList.cc export_Filter.cc export_PeriodicBuffer.cc
+    export_Voronoi.cc)
 
 # create the target and add the needed properties
 nanobind_add_module(_locality ${freud_nanobind_linking} module-locality.cc

--- a/cpp/locality/CMakeLists.txt
+++ b/cpp/locality/CMakeLists.txt
@@ -1,5 +1,5 @@
 set(locality_extension_sources
-    export_NeighborQuery.cc export_NeighborList.cc export_Filter.cc
+    export_BondHistogramCompute.cc export_NeighborQuery.cc export_NeighborList.cc export_Filter.cc
     export_PeriodicBuffer.cc export_Voronoi.cc)
 
 # create the target and add the needed properties

--- a/cpp/locality/NeighborComputeFunctional.h
+++ b/cpp/locality/NeighborComputeFunctional.h
@@ -168,8 +168,8 @@ void loopOverNeighborsIterator(const NeighborQuery* neighbor_query, const vec3<f
  * given qargs. \param cf An object with operator(NeighborBond) as input.
  */
 template<typename ComputePairType>
-void loopOverNeighbors(const NeighborQuery* neighbor_query, const vec3<float>* query_points,
-                       unsigned int n_query_points, QueryArgs qargs, const NeighborList* nlist,
+void loopOverNeighbors(std::shared_ptr<NeighborQuery> neighbor_query, const vec3<float>* query_points,
+                       unsigned int n_query_points, QueryArgs qargs, std::shared_ptr<NeighborList> nlist,
                        const ComputePairType& cf, bool parallel = true)
 {
     // check if nlist exists

--- a/cpp/locality/export_BondHistogramCompute.cc
+++ b/cpp/locality/export_BondHistogramCompute.cc
@@ -1,0 +1,81 @@
+// Copyright (c) 2010-2024 The Regents of the University of Michigan
+// This file is from the freud project, released under the BSD 3-Clause License.
+
+#include "export_BondHistogramCompute.h"
+
+#include <nanobind/nanobind.h>
+#include <nanobind/ndarray.h>
+#include <nanobind/stl/vector.h>
+#include <nanobind/stl/shared_ptr.h>
+
+namespace nb = nanobind;
+
+namespace freud { namespace locality {
+
+namespace wrap {
+
+/**
+ * Here we convert a vector of vectors into a list of lists for returning to python.
+ * */
+template<typename T>
+inline nb::object vectorVectorsToListLists(const std::vector<std::vector<T>>& vectorOfVectors)
+{
+
+    nb::list outer_python_list;
+    for (const auto& vector : vectorOfVectors)
+    {
+        nb::list inner_python_list;
+        for (const auto& element : vector)
+        {
+            inner_python_list.append(element);
+        }
+        outer_python_list.append(inner_python_list);
+    }
+    return outer_python_list;
+}
+
+nb::object getBinCenters(std::shared_ptr<BondHistogramCompute> bondHist)
+{
+    auto bin_centers_cpp = bondHist->getBinCenters();
+    return vectorVectorsToListLists(bin_centers_cpp);
+}
+
+nb::object getBinEdges(std::shared_ptr<BondHistogramCompute> bondHist)
+{
+    auto bin_edges_cpp = bondHist->getBinEdges();
+    return vectorVectorsToListLists(bin_edges_cpp);
+}
+
+nb::object getBounds(std::shared_ptr<BondHistogramCompute> bondHist)
+{
+    auto bounds_cpp = bondHist->getBounds();
+
+    // convert the vector of pairs to a list of tuples
+    nb::list python_list;
+    for (const auto& pair : bounds_cpp)
+    {
+        nb::tuple python_tuple = nb::make_tuple(pair.first, pair.second);
+        python_list.append(python_tuple);
+    }
+    return python_list;
+}
+
+}; // namespace wrap
+
+namespace detail {
+
+void export_BondHistogramCompute(nb::module_& m)
+{
+    nb::class_<BondHistogramCompute>(m, "BondHistogramCompute")
+        .def("getBox", &BondHistogramCompute::getBox)
+        .def("reset", &BondHistogramCompute::reset)
+        .def("getBinCounts", &BondHistogramCompute::getBinCounts)
+        .def("getAxisSizes", &BondHistogramCompute::getAxisSizes)
+        .def("getBinCenters", &wrap::getBinCenters)
+        .def("getBinEdges", &wrap::getBinEdges)
+        .def("getBounds", &wrap::getBounds);
+}
+
+}; // namespace detail
+
+}; }; // namespace freud::locality

--- a/cpp/locality/export_BondHistogramCompute.cc
+++ b/cpp/locality/export_BondHistogramCompute.cc
@@ -5,8 +5,8 @@
 
 #include <nanobind/nanobind.h>
 #include <nanobind/ndarray.h>
-#include <nanobind/stl/vector.h>
 #include <nanobind/stl/shared_ptr.h>
+#include <nanobind/stl/vector.h>
 
 namespace nb = nanobind;
 
@@ -20,7 +20,6 @@ namespace wrap {
 template<typename T>
 inline nb::object vectorVectorsToListLists(const std::vector<std::vector<T>>& vectorOfVectors)
 {
-
     nb::list outer_python_list;
     for (const auto& vector : vectorOfVectors)
     {

--- a/cpp/locality/export_BondHistogramCompute.h
+++ b/cpp/locality/export_BondHistogramCompute.h
@@ -1,0 +1,34 @@
+// Copyright (c) 2010-2024 The Regents of the University of Michigan
+// This file is from the freud project, released under the BSD 3-Clause License.
+
+#ifndef EXPORT_BOND_HISTOGRAM_COMPUTE_H
+#define EXPORT_BOND_HISTOGRAM_COMPUTE_H
+
+#include "BondHistogramCompute.h"
+
+#include <nanobind/nanobind.h>
+#include <nanobind/ndarray.h>
+
+namespace freud { namespace locality {
+
+namespace wrap {
+
+nanobind::object getBinCenters(std::shared_ptr<BondHistogramCompute> bondHist);
+
+nanobind::object getBinEdges(std::shared_ptr<BondHistogramCompute> bondHist);
+
+nanobind::object getBounds(std::shared_ptr<BondHistogramCompute> bondHist);
+
+nanobind::object getAxisSizes(std::shared_ptr<BondHistogramCompute> bondHist);
+
+}; // namespace wrap
+
+namespace detail {
+
+void export_BondHistogramCompute(nanobind::module_& m);
+
+}; // namespace detail
+
+}; }; // namespace freud::locality
+
+#endif

--- a/cpp/locality/module-locality.cc
+++ b/cpp/locality/module-locality.cc
@@ -3,6 +3,7 @@
 
 #include <nanobind/nanobind.h>
 
+#include "export_BondHistogramCompute.h"
 #include "export_Filter.h"
 #include "export_NeighborList.h"
 #include "export_NeighborQuery.h"
@@ -34,4 +35,5 @@ NB_MODULE(_locality, m)
 
     // others
     export_PeriodicBuffer(m);
+    export_BondHistogramCompute(m);
 }

--- a/cpp/pmft/CMakeLists.txt
+++ b/cpp/pmft/CMakeLists.txt
@@ -1,7 +1,7 @@
 set(pmft_extension_sources export_PMFT.h)
 
 nanobind_add_module(_pmft ${freud_nanobind_linking} module-pmft.cc
-  ${pmft_extension_sources})
+                    ${pmft_extension_sources})
 target_link_libraries(_pmft PUBLIC libfreud)
 
 target_set_install_rpath(_pmft)

--- a/cpp/pmft/CMakeLists.txt
+++ b/cpp/pmft/CMakeLists.txt
@@ -1,12 +1,9 @@
-add_library(
-  _pmft OBJECT
-  PMFTR12.h
-  PMFTR12.cc
-  PMFTXY.h
-  PMFTXY.cc
-  PMFTXYT.h
-  PMFTXYT.cc
-  PMFTXYZ.h
-  PMFTXYZ.cc)
+set(pmft_extension_sources export_PMFT.cc)
 
-target_link_libraries(_pmft PUBLIC TBB::tbb)
+nanobind_add_module(_pmft ${freud_nanobind_linking} module-pmft.cc
+  ${pmft_extension_sources})
+target_link_libraries(_pmft PUBLIC libfreud)
+
+target_set_install_rpath(_pmft)
+
+install(TARGETS _pmft DESTINATION freud)

--- a/cpp/pmft/CMakeLists.txt
+++ b/cpp/pmft/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(pmft_extension_sources export_PMFT.cc)
+set(pmft_extension_sources export_PMFT.h)
 
 nanobind_add_module(_pmft ${freud_nanobind_linking} module-pmft.cc
   ${pmft_extension_sources})

--- a/cpp/pmft/PMFT.h
+++ b/cpp/pmft/PMFT.h
@@ -24,8 +24,7 @@ namespace freud { namespace pmft {
  *  subclasses that account for the proper set of dimensions.The required functions are implemented as pure
  *  virtual functions here to enforce this.
  */
-template<size_t Ndim>
-class PMFT : public locality::BondHistogramCompute<Ndim>
+class PMFT : public locality::BondHistogramCompute
 {
 public:
     //! Constructor
@@ -35,7 +34,7 @@ public:
     ~PMFT() override = default;
 
     //! Get a reference to the PCF array
-    std::shared_ptr<util::ManagedArray<float, Ndim>> getPCF()
+    std::shared_ptr<util::ManagedArray<float>> getPCF()
     {
         return reduceAndReturn(m_pcf_array);
     }
@@ -64,8 +63,8 @@ protected:
      */
     template<typename JacobFactor> void reduce(JacobFactor jf)
     {
-        m_pcf_array = std::make_shared<util::ManagedArray<float, Ndim>>(m_histogram.shape());
-        m_histogram = util::Histogram<unsigned int, Ndim>(m_histogram.getAxes());
+        m_pcf_array = std::make_shared<util::ManagedArray<float>>(m_histogram.shape());
+        m_histogram = util::Histogram<unsigned int>(m_histogram.getAxes());
 
         float inv_num_dens = m_box.getVolume() / static_cast<float>(m_n_query_points);
         float norm_factor
@@ -73,11 +72,11 @@ protected:
         float prefactor = inv_num_dens * norm_factor;
 
         m_histogram.reduceOverThreadsPerBin(m_local_histograms, [this, &prefactor, &jf](size_t i) {
-            (*m_pcf_array)[i] = static_cast<float>((*m_histogram)[i]) * prefactor * jf(i);
+            (*m_pcf_array)[i] = static_cast<float>(m_histogram[i]) * prefactor * jf(i);
         });
     }
 
-    std::shared_ptr<util::ManagedArray<float, Ndim>> m_pcf_array; //!< Array of computed pair correlation function.
+    std::shared_ptr<util::ManagedArray<float>> m_pcf_array; //!< Array of computed pair correlation function.
 };
 
 }; }; // end namespace freud::pmft

--- a/cpp/pmft/PMFT.h
+++ b/cpp/pmft/PMFT.h
@@ -63,13 +63,6 @@ protected:
      */
     template<typename JacobFactor> void reduce(JacobFactor jf)
     {
-        // TODO fully consider when we need to re-allocate the array data with PMFT classes
-        // TODO array sizes are static (i.e. set on object construction), but may need
-        // TODO re-allocations based on python object references
-        // TODO tests still pass, so I think there are implicit copies being made right now
-        //m_pcf_array = std::make_shared<util::ManagedArray<float>>(m_histogram.shape());
-        //m_histogram = util::Histogram<unsigned int>(m_histogram.getAxes());
-
         float inv_num_dens = m_box.getVolume() / static_cast<float>(m_n_query_points);
         float norm_factor
             = float(1.0) / (static_cast<float>(m_frame_counter) * static_cast<float>(m_n_points));

--- a/cpp/pmft/PMFT.h
+++ b/cpp/pmft/PMFT.h
@@ -63,8 +63,12 @@ protected:
      */
     template<typename JacobFactor> void reduce(JacobFactor jf)
     {
-        m_pcf_array = std::make_shared<util::ManagedArray<float>>(m_histogram.shape());
-        m_histogram = util::Histogram<unsigned int>(m_histogram.getAxes());
+        // TODO fully consider when we need to re-allocate the array data with PMFT classes
+        // TODO array sizes are static (i.e. set on object construction), but may need
+        // TODO re-allocations based on python object references
+        // TODO tests still pass, so I think there are implicit copies being made right now
+        //m_pcf_array = std::make_shared<util::ManagedArray<float>>(m_histogram.shape());
+        //m_histogram = util::Histogram<unsigned int>(m_histogram.getAxes());
 
         float inv_num_dens = m_box.getVolume() / static_cast<float>(m_n_query_points);
         float norm_factor

--- a/cpp/pmft/PMFTXY.cc
+++ b/cpp/pmft/PMFTXY.cc
@@ -56,9 +56,9 @@ void PMFTXY::reduce()
 }
 
 void PMFTXY::accumulate(std::shared_ptr<locality::NeighborQuery> neighbor_query,
-        const float* query_orientations, const vec3<float>* query_points,
-        unsigned int n_query_points, std::shared_ptr<locality::NeighborList> nlist,
-        const freud::locality::QueryArgs& qargs)
+                        const float* query_orientations, const vec3<float>* query_points,
+                        unsigned int n_query_points, std::shared_ptr<locality::NeighborList> nlist,
+                        const freud::locality::QueryArgs& qargs)
 {
     neighbor_query->getBox().enforce2D();
 

--- a/cpp/pmft/PMFTXY.cc
+++ b/cpp/pmft/PMFTXY.cc
@@ -40,7 +40,7 @@ PMFTXY::PMFTXY(float x_max, float y_max, unsigned int n_x, unsigned int n_y) : P
     m_jacobian = dx * dy;
 
     // Create the PCF array.
-    m_pcf_array.prepare({n_x, n_y});
+    m_pcf_array = std::make_shared<util::ManagedArray<float>>(std::vector<size_t> {n_x, n_y});
 
     // Construct the Histogram object that will be used to keep track of counts of bond distances found.
     const auto axes = util::Axes {std::make_shared<util::RegularAxis>(n_x, -x_max, x_max),
@@ -55,9 +55,10 @@ void PMFTXY::reduce()
     PMFT::reduce([jacobian_factor](size_t i) { return jacobian_factor; }); // NOLINT (misc-unused-parameters)
 }
 
-void PMFTXY::accumulate(const locality::NeighborQuery* neighbor_query, const float* query_orientations,
-                        const vec3<float>* query_points, unsigned int n_query_points,
-                        const locality::NeighborList* nlist, freud::locality::QueryArgs qargs)
+void PMFTXY::accumulate(std::shared_ptr<locality::NeighborQuery> neighbor_query,
+        const float* query_orientations, const vec3<float>* query_points,
+        unsigned int n_query_points, std::shared_ptr<locality::NeighborList> nlist,
+        const freud::locality::QueryArgs& qargs)
 {
     neighbor_query->getBox().enforce2D();
     accumulateGeneral(neighbor_query, query_points, n_query_points, nlist, qargs,

--- a/cpp/pmft/PMFTXY.cc
+++ b/cpp/pmft/PMFTXY.cc
@@ -61,6 +61,12 @@ void PMFTXY::accumulate(std::shared_ptr<locality::NeighborQuery> neighbor_query,
         const freud::locality::QueryArgs& qargs)
 {
     neighbor_query->getBox().enforce2D();
+
+    // reallocate the data arrays so we don't overwrite previous data
+    m_pcf_array = std::make_shared<util::ManagedArray<float>>(m_pcf_array->shape());
+    m_histogram = BondHistogram(m_histogram.getAxes());
+
+    // now accumulate
     accumulateGeneral(neighbor_query, query_points, n_query_points, nlist, qargs,
                       [&](const freud::locality::NeighborBond& neighbor_bond) {
                           const vec3<float>& delta(neighbor_bond.getVector());

--- a/cpp/pmft/PMFTXY.h
+++ b/cpp/pmft/PMFTXY.h
@@ -21,9 +21,10 @@ public:
     /*! Compute the PCF for the passed in set of points. The result will
      *  be added to previous values of the PCF.
      */
-    void accumulate(const locality::NeighborQuery* neighbor_query, const float* query_orientations,
-                    const vec3<float>* query_points, unsigned int n_query_points,
-                    const locality::NeighborList* nlist, freud::locality::QueryArgs qargs);
+    void accumulate(std::shared_ptr<locality::NeighborQuery> neighbor_query,
+                    const float* query_orientations, const vec3<float>* query_points,
+                    unsigned int n_query_points, std::shared_ptr<locality::NeighborList> nlist,
+                    const freud::locality::QueryArgs& qargs);
 
 protected:
     //! \internal

--- a/cpp/pmft/PMFTXY.h
+++ b/cpp/pmft/PMFTXY.h
@@ -21,10 +21,9 @@ public:
     /*! Compute the PCF for the passed in set of points. The result will
      *  be added to previous values of the PCF.
      */
-    void accumulate(std::shared_ptr<locality::NeighborQuery> neighbor_query,
-                    const float* query_orientations, const vec3<float>* query_points,
-                    unsigned int n_query_points, std::shared_ptr<locality::NeighborList> nlist,
-                    const freud::locality::QueryArgs& qargs);
+    void accumulate(std::shared_ptr<locality::NeighborQuery> neighbor_query, const float* query_orientations,
+                    const vec3<float>* query_points, unsigned int n_query_points,
+                    std::shared_ptr<locality::NeighborList> nlist, const freud::locality::QueryArgs& qargs);
 
 protected:
     //! \internal

--- a/cpp/pmft/PMFTXYZ.cc
+++ b/cpp/pmft/PMFTXYZ.cc
@@ -93,10 +93,11 @@ void PMFTXYZ::reset()
     m_num_equiv_orientations = 0xffffffff;
 }
 
-void PMFTXYZ::accumulate(std::shared_ptr<locality::NeighborQuery> neighbor_query, const quat<float>* query_orientations,
-                         const vec3<float>* query_points, unsigned int n_query_points,
-                         const quat<float>* equiv_orientations, unsigned int num_equiv_orientations,
-                         std::shared_ptr<locality::NeighborList> nlist, const freud::locality::QueryArgs& qargs)
+void PMFTXYZ::accumulate(std::shared_ptr<locality::NeighborQuery> neighbor_query,
+                         const quat<float>* query_orientations, const vec3<float>* query_points,
+                         unsigned int n_query_points, const quat<float>* equiv_orientations,
+                         unsigned int num_equiv_orientations, std::shared_ptr<locality::NeighborList> nlist,
+                         const freud::locality::QueryArgs& qargs)
 {
     // Set the number of equivalent orientations the first time we compute
     // (after a reset), then error on subsequent calls if it changes.

--- a/cpp/pmft/export_PMFT.h
+++ b/cpp/pmft/export_PMFT.h
@@ -12,9 +12,9 @@ namespace freud { namespace pmft {
 namespace detail
 {
 
-void export_PMFT(nanobind::module& m, const std::string& name)
+void export_PMFT(nanobind::module_& m)
 {
-    nanobind::class_<PMFT, BondHistogramCompute>(m, name)
+    nanobind::class_<PMFT, locality::BondHistogramCompute>(m, "PMFT")
         .def("getPCF", &PMFT::getPCF);
 }
 

--- a/cpp/pmft/export_PMFT.h
+++ b/cpp/pmft/export_PMFT.h
@@ -2,12 +2,34 @@
 #define EXPORT_PMFT_H
 
 #include <nanobind/nanobind.h>
+#include <nanobind/ndarray.h>
 #include <nanobind/stl/shared_ptr.h>
 
 #include "PMFT.h"
+#include "PMFTXY.h"
 #include "BondHistogramCompute.h"
 
 namespace freud { namespace pmft {
+
+template<typename T, typename shape>
+using nb_array = nanobind::ndarray<T, shape, nanobind::device::cpu, nanobind::c_contig>;
+
+namespace wrap
+{
+
+void accumulateXY(std::shared_ptr<PMFTXY> pmftxy, std::shared_ptr<locality::NeighborQuery> nq,
+        nb_array<float, nanobind::shape<-1>> query_orientations,
+        nb_array<float, nanobind::shape<-1, 3>> query_points,
+        std::shared_ptr<locality::NeighborList> nlist, const locality::QueryArgs& qargs)
+{
+    unsigned int num_query_points = query_points.shape(0);
+    auto* query_orientations_data = reinterpret_cast<float*>(query_orientations.data());
+    auto* query_points_data = reinterpret_cast<vec3<float>*>(query_points.data());
+    pmftxy->accumulate(nq, query_orientations_data, query_points_data, num_query_points,
+            nlist, qargs);
+}
+
+};
 
 namespace detail
 {
@@ -16,6 +38,13 @@ void export_PMFT(nanobind::module_& m)
 {
     nanobind::class_<PMFT, locality::BondHistogramCompute>(m, "PMFT")
         .def("getPCF", &PMFT::getPCF);
+}
+
+void export_PMFTXY(nanobind::module_& m)
+{
+    nanobind::class_<PMFTXY, PMFT>(m, "PMFTXY")
+        .def(nanobind::init<float, float, unsigned int, unsigned int>())
+        .def("accumulate", &wrap::accumulateXY, nanobind::arg("nq"), nanobind::arg("query_orientations"), nanobind::arg("query_points"), nanobind::arg("nlist").none(), nanobind::arg("qargs"));
 }
 
 }  // namespace detail

--- a/cpp/pmft/export_PMFT.h
+++ b/cpp/pmft/export_PMFT.h
@@ -1,0 +1,25 @@
+#ifndef EXPORT_PMFT_H
+#define EXPORT_PMFT_H
+
+#include <nanobind/nanobind.h>
+#include <nanobind/stl/shared_ptr.h>
+
+#include "PMFT.h"
+#include "BondHistogramCompute.h"
+
+namespace freud { namespace pmft {
+
+namespace detail
+{
+
+void export_PMFT(nanobind::module& m, const std::string& name)
+{
+    nanobind::class_<PMFT, BondHistogramCompute>(m, name)
+        .def("getPCF", &PMFT::getPCF);
+}
+
+}  // namespace detail
+
+}; };  // end namespace freud::pmft
+
+#endif

--- a/cpp/pmft/export_PMFT.h
+++ b/cpp/pmft/export_PMFT.h
@@ -1,3 +1,6 @@
+// Copyright (c) 2010-2024 The Regents of the University of Michigan
+// This file is from the freud project, released under the BSD 3-Clause License.
+
 #ifndef EXPORT_PMFT_H
 #define EXPORT_PMFT_H
 
@@ -5,50 +8,47 @@
 #include <nanobind/ndarray.h>
 #include <nanobind/stl/shared_ptr.h>
 
+#include "BondHistogramCompute.h"
 #include "PMFT.h"
 #include "PMFTXY.h"
-#include "BondHistogramCompute.h"
 
 namespace freud { namespace pmft {
 
 template<typename T, typename shape>
 using nb_array = nanobind::ndarray<T, shape, nanobind::device::cpu, nanobind::c_contig>;
 
-namespace wrap
-{
+namespace wrap {
 
 void accumulateXY(std::shared_ptr<PMFTXY> pmftxy, std::shared_ptr<locality::NeighborQuery> nq,
-        nb_array<float, nanobind::shape<-1>> query_orientations,
-        nb_array<float, nanobind::shape<-1, 3>> query_points,
-        std::shared_ptr<locality::NeighborList> nlist, const locality::QueryArgs& qargs)
+                  nb_array<float, nanobind::shape<-1>> query_orientations,
+                  nb_array<float, nanobind::shape<-1, 3>> query_points,
+                  std::shared_ptr<locality::NeighborList> nlist, const locality::QueryArgs& qargs)
 {
     unsigned int num_query_points = query_points.shape(0);
     auto* query_orientations_data = reinterpret_cast<float*>(query_orientations.data());
     auto* query_points_data = reinterpret_cast<vec3<float>*>(query_points.data());
-    pmftxy->accumulate(nq, query_orientations_data, query_points_data, num_query_points,
-            nlist, qargs);
+    pmftxy->accumulate(nq, query_orientations_data, query_points_data, num_query_points, nlist, qargs);
 }
 
-};
+}; // namespace wrap
 
-namespace detail
-{
+namespace detail {
 
 void export_PMFT(nanobind::module_& m)
 {
-    nanobind::class_<PMFT, locality::BondHistogramCompute>(m, "PMFT")
-        .def("getPCF", &PMFT::getPCF);
+    nanobind::class_<PMFT, locality::BondHistogramCompute>(m, "PMFT").def("getPCF", &PMFT::getPCF);
 }
 
 void export_PMFTXY(nanobind::module_& m)
 {
     nanobind::class_<PMFTXY, PMFT>(m, "PMFTXY")
         .def(nanobind::init<float, float, unsigned int, unsigned int>())
-        .def("accumulate", &wrap::accumulateXY, nanobind::arg("nq"), nanobind::arg("query_orientations"), nanobind::arg("query_points"), nanobind::arg("nlist").none(), nanobind::arg("qargs"));
+        .def("accumulate", &wrap::accumulateXY, nanobind::arg("nq"), nanobind::arg("query_orientations"),
+             nanobind::arg("query_points"), nanobind::arg("nlist").none(), nanobind::arg("qargs"));
 }
 
-}  // namespace detail
+} // namespace detail
 
-}; };  // end namespace freud::pmft
+}; }; // end namespace freud::pmft
 
 #endif

--- a/cpp/pmft/module-pmft.cc
+++ b/cpp/pmft/module-pmft.cc
@@ -1,0 +1,14 @@
+#include <nanobind/nanobind.h>
+
+#include "export_PMFT.h"
+
+using namespace freud::pmft::detail
+
+NB_MODULE(_pmft, m)
+{
+    //export_PMFT(m);
+    //export_PMFTR12(m);
+    //export_PMFTXY(m);
+    //export_PMFTXYT(m);
+    //export_PMFTXYZ(m);
+}

--- a/cpp/pmft/module-pmft.cc
+++ b/cpp/pmft/module-pmft.cc
@@ -2,11 +2,11 @@
 
 #include "export_PMFT.h"
 
-using namespace freud::pmft::detail
+using namespace freud::pmft::detail;
 
 NB_MODULE(_pmft, m)
 {
-    //export_PMFT(m);
+    export_PMFT(m);
     //export_PMFTR12(m);
     //export_PMFTXY(m);
     //export_PMFTXYT(m);

--- a/cpp/pmft/module-pmft.cc
+++ b/cpp/pmft/module-pmft.cc
@@ -1,3 +1,6 @@
+// Copyright (c) 2010-2024 The Regents of the University of Michigan
+// This file is from the freud project, released under the BSD 3-Clause License.
+
 #include <nanobind/nanobind.h>
 
 #include "export_PMFT.h"
@@ -8,7 +11,7 @@ NB_MODULE(_pmft, m)
 {
     export_PMFT(m);
     export_PMFTXY(m);
-    //export_PMFTR12(m);
-    //export_PMFTXYT(m);
-    //export_PMFTXYZ(m);
+    // export_PMFTR12(m);
+    // export_PMFTXYT(m);
+    // export_PMFTXYZ(m);
 }

--- a/cpp/pmft/module-pmft.cc
+++ b/cpp/pmft/module-pmft.cc
@@ -7,8 +7,8 @@ using namespace freud::pmft::detail;
 NB_MODULE(_pmft, m)
 {
     export_PMFT(m);
+    export_PMFTXY(m);
     //export_PMFTR12(m);
-    //export_PMFTXY(m);
     //export_PMFTXYT(m);
     //export_PMFTXYZ(m);
 }

--- a/cpp/pmft/pmft-files.cmake
+++ b/cpp/pmft/pmft-files.cmake
@@ -1,12 +1,12 @@
-set(pmft_sources "")
+set(pmft_sources
+    pmft/PMFTXY.cc)
 #pmft/PMFTR12.cc
-#pmft/PMFTXY.cc
 #pmft/PMFTXYT.cc
 #pmft/PMFTXYZ.cc)
 
 set(pmft_headers
-    pmft/PMFT.h)
+    pmft/PMFT.h
+    pmft/PMFTXY.h)
 #pmft/PMFTR12.h
-#pmft/PMFTXY.h
 #pmft/PMFTXYT.h
 #pmft/PMFTXYZ.h)

--- a/cpp/pmft/pmft-files.cmake
+++ b/cpp/pmft/pmft-files.cmake
@@ -1,12 +1,12 @@
-set(pmft_sources
-    pmft/PMFTR12.cc
-    pmft/PMFTXY.cc
-    pmft/PMFTXYT.cc
-    pmft/PMFTXYZ.cc)
+set(pmft_sources "")
+#pmft/PMFTR12.cc
+#pmft/PMFTXY.cc
+#pmft/PMFTXYT.cc
+#pmft/PMFTXYZ.cc)
 
 set(pmft_headers
-    pmft/PMFT.h
-    pmft/PMFTR12.h
-    pmft/PMFTXY.h
-    pmft/PMFTXYT.h
-    pmft/PMFTXYZ.h)
+    pmft/PMFT.h)
+#pmft/PMFTR12.h
+#pmft/PMFTXY.h
+#pmft/PMFTXYT.h
+#pmft/PMFTXYZ.h)

--- a/cpp/pmft/pmft-files.cmake
+++ b/cpp/pmft/pmft-files.cmake
@@ -1,12 +1,5 @@
-set(pmft_sources
-    pmft/PMFTXY.cc)
-#pmft/PMFTR12.cc
-#pmft/PMFTXYT.cc
-#pmft/PMFTXYZ.cc)
+set(pmft_sources pmft/PMFTXY.cc)
+# pmft/PMFTR12.cc pmft/PMFTXYT.cc pmft/PMFTXYZ.cc)
 
-set(pmft_headers
-    pmft/PMFT.h
-    pmft/PMFTXY.h)
-#pmft/PMFTR12.h
-#pmft/PMFTXYT.h
-#pmft/PMFTXYZ.h)
+set(pmft_headers pmft/PMFT.h pmft/PMFTXY.h)
+# pmft/PMFTR12.h pmft/PMFTXYT.h pmft/PMFTXYZ.h)

--- a/cpp/pmft/pmft-files.cmake
+++ b/cpp/pmft/pmft-files.cmake
@@ -1,0 +1,12 @@
+set(pmft_sources
+    pmft/PMFTR12.cc
+    pmft/PMFTXY.cc
+    pmft/PMFTXYT.cc
+    pmft/PMFTXYZ.cc)
+
+set(pmft_headers
+    pmft/PMFT.h
+    pmft/PMFTR12.h
+    pmft/PMFTXY.h
+    pmft/PMFTXYT.h
+    pmft/PMFTXYZ.h)

--- a/cpp/util/Histogram.h
+++ b/cpp/util/Histogram.h
@@ -260,15 +260,15 @@ public:
         }
 
         // Reduce over histograms into the result array.
-        void reduceInto(ManagedArray<T>& result)
+        void reduceInto(std::shared_ptr<ManagedArray<T>> result)
         {
-            result.reset();
-            util::forLoopWrapper(0, result.size(), [&](size_t begin, size_t end) {
+            result->reset();
+            util::forLoopWrapper(0, result->size(), [&](size_t begin, size_t end) {
                 for (size_t i = begin; i < end; ++i)
                 {
                     for (auto hist = m_local_histograms.begin(); hist != m_local_histograms.end(); ++hist)
                     {
-                        result[i] += hist->m_bin_counts[i];
+                        (*result)[i] += (*hist->m_bin_counts)[i];
                     }
                 }
             });

--- a/cpp/util/Histogram.h
+++ b/cpp/util/Histogram.h
@@ -275,7 +275,7 @@ public:
         }
 
     protected:
-        tbb::enumerable_thread_specific<Histogram<T, Ndim>>
+        tbb::enumerable_thread_specific<Histogram<T>>
             m_local_histograms; //!< The thread-local copies of m_histogram.
     };
 
@@ -333,7 +333,7 @@ public:
 
         // First bin the values along each axis.
         std::vector<size_t> ax_bins;
-        for (unsigned int ax_idx = 0; ax_idx < m_axes->size(); ++ax_idx)
+        for (unsigned int ax_idx = 0; ax_idx < m_axes.size(); ++ax_idx)
         {
             size_t bin_i = m_axes[ax_idx]->bin(values[ax_idx]);
             // Immediately return sentinel if any bin is out of bounds.
@@ -400,7 +400,7 @@ public:
     //! Return a vector of tuples (min, max) indicating the bounds of each axis.
     std::vector<std::pair<float, float>> getBounds() const
     {
-        std::vector<std::pair<float, float>, Ndim> bounds(m_axes.size());
+        std::vector<std::pair<float, float>> bounds(m_axes.size());
         for (unsigned int i = 0; i < m_axes.size(); ++i)
         {
             bounds[i] = std::pair<float, float>(m_axes[i]->getMin(), m_axes[i]->getMax());
@@ -409,7 +409,7 @@ public:
     }
 
     //! Return a vector indicating the number of bins in each axis.
-    std::array<size_t, Ndim> getAxisSizes() const
+    std::vector<size_t> getAxisSizes() const
     {
         std::vector<size_t> sizes(m_axes.size());
         for (unsigned int i = 0; i < m_axes.size(); ++i)

--- a/cpp/util/diagonalize.cc
+++ b/cpp/util/diagonalize.cc
@@ -8,7 +8,7 @@ namespace freud { namespace util {
 void diagonalize33SymmetricMatrix(const util::ManagedArray<float>& mat, util::ManagedArray<float>& eigen_vals,
                                   util::ManagedArray<float>& eigen_vecs)
 {
-    const Eigen::Matrix3f m = Eigen::Map<const Eigen::Matrix3f>(mat.get());
+    const Eigen::Matrix3f m = Eigen::Map<const Eigen::Matrix3f>(mat.data());
 
     Eigen::SelfAdjointEigenSolver<Eigen::Matrix3f> es;
     es.compute(m);
@@ -17,7 +17,7 @@ void diagonalize33SymmetricMatrix(const util::ManagedArray<float>& mat, util::Ma
     {
         // numerical issue, return identity matrix
         Eigen::Matrix3f id = Eigen::Matrix3f::Identity();
-        Eigen::Map<Eigen::Matrix3f>(eigen_vecs.get(), 3, 3) = id;
+        Eigen::Map<Eigen::Matrix3f>(eigen_vecs.data(), 3, 3) = id;
         // set eigenvalues to zero so it's easily detectable
         eigen_vals[0] = eigen_vals[1] = eigen_vals[2] = 0.0;
     }
@@ -30,8 +30,8 @@ void diagonalize33SymmetricMatrix(const util::ManagedArray<float>& mat, util::Ma
         // outputmatrix eigen_vecs.
         // See here for information:
         // https://eigen.tuxfamily.org/dox/group__TopicStorageOrders.html
-        Eigen::Map<Eigen::Matrix3f>(eigen_vecs.get(), 3, 3) = es.eigenvectors();
-        Eigen::Map<Eigen::Vector3f>(eigen_vals.get(), 3) = es.eigenvalues();
+        Eigen::Map<Eigen::Matrix3f>(eigen_vecs.data(), 3, 3) = es.eigenvectors();
+        Eigen::Map<Eigen::Vector3f>(eigen_vals.data(), 3) = es.eigenvalues();
     }
 }
 

--- a/freud/CMakeLists.txt
+++ b/freud/CMakeLists.txt
@@ -4,8 +4,9 @@ set(python_files
     errors.py
     locality.py
     parallel.py
+    pmft.py
     plot.py
     util.py)
-# cluster.py density.py diffraction.py environment.py order.py pmft.py)
+# cluster.py density.py diffraction.py environment.py order.py)
 
 install(FILES ${python_files} DESTINATION freud)

--- a/freud/__init__.py
+++ b/freud/__init__.py
@@ -2,8 +2,8 @@
 # This file is from the freud project, released under the BSD 3-Clause License.
 
 
-# cluster,; density,; diffraction,; environment,; interface,; msd,; order,; pmft,
-from . import box, data, locality, parallel
+# cluster,; density,; diffraction,; environment,; interface,; msd,; order,
+from . import box, data, locality, parallel, pmft
 from .box import Box
 
 # from .locality import AABBQuery, LinkCell, NeighborList
@@ -28,7 +28,7 @@ __all__ = [
     # "msd",
     # "order",
     "parallel",
-    # "pmft",
+    "pmft",
     "Box",
     "AABBQuery",
     "LinkCell",

--- a/freud/locality.py
+++ b/freud/locality.py
@@ -998,35 +998,34 @@ class _SpatialHistogram(_PairCompute):
     @_Compute._computed_property
     def bin_counts(self):
         """:class:`numpy.ndarray`: The bin counts in the histogram."""
-        return self._cpp_obj.getBinCounts()
+        return self._cpp_obj.getBinCounts().toNumpyArray()
 
     @property
     def bin_centers(self):
         """:class:`numpy.ndarray`: The centers of each bin in the histogram
         (has the same shape as the histogram itself)."""
-        vec = self._cpp_obj.getBinCenters()
-        return [np.array(b, copy=True) for b in vec]
+        centers = self._cpp_obj.getBinCenters()
+        return [np.array(c) for c in centers]
 
     @property
     def bin_edges(self):
         """:class:`numpy.ndarray`: The edges of each bin in the histogram (is
         one element larger in each dimension than the histogram because each
         bin has a lower and upper bound)."""
-        vec = self._cpp_obj.getBinEdges()
-        return [np.array(b, copy=True) for b in vec]
+        edges = self._cpp_obj.getBinEdges()
+        return [np.array(e) for e in edges]
 
     @property
     def bounds(self):
         """:class:`list` (:class:`tuple`): A list of tuples indicating upper and
         lower bounds of each axis of the histogram."""
-        vec = self._cpp_obj.getBounds()
-        return [tuple(b) for b in vec]
+        return self._cpp_obj.getBounds()  # this returns from cpp with the right type
 
     @property
     def nbins(self):
         """:class:`list`: The number of bins in each dimension of the
         histogram."""
-        return list(self._cpp_obj.getAxisSizes())
+        return self._cpp_obj.getAxisSizes()
 
     def _reset(self):
         # Resets the values of RDF in memory.
@@ -1046,19 +1045,19 @@ class _SpatialHistogram1D(_SpatialHistogram):
     def bin_centers(self):
         """:math:`(N_{bins}, )` :class:`numpy.ndarray`: The centers of each bin
         in the histogram."""
-        return np.array(self._cpp_obj.getBinCenters(), copy=True)
+        return np.array(self._cpp_obj.getBinCenters()[0])
 
     @property
     def bin_edges(self):
         """:math:`(N_{bins}+1, )` :class:`numpy.ndarray`: The edges of each bin
         in the histogram. It is one element larger because each bin has a lower
         and an upper bound."""
-        return np.array(self._cpp_obj.getBinEdges(), copy=True)
+        return np.array(self._cpp_obj.getBinEdges()[0])
 
     @property
     def bounds(self):
         """tuple: A tuple indicating upper and lower bounds of the histogram."""
-        return self._cpp_obj.getBounds()
+        return self._cpp_obj.getBounds()[0]
 
     @property
     def nbins(self):

--- a/freud/pmft.py
+++ b/freud/pmft.py
@@ -1,0 +1,528 @@
+# Copyright (c) 2010-2024 The Regents of the University of Michigan
+# This file is from the freud project, released under the BSD 3-Clause License.
+
+r"""
+The :class:`freud.pmft` module allows for the calculation of the Potential of
+Mean Force and Torque (PMFT) :cite:`vanAnders:2014aa,van_Anders_2013` in a
+number of different coordinate systems. The shape of the arrays computed by
+this module depend on the coordinate system used, with space discretized into a
+set of bins created by the PMFT object's constructor. Each query point's
+neighboring points are assigned to bins, determined by the relative positions
+and/or orientations of the particles. Next, the pair correlation function
+(PCF) is computed by normalizing the binned histogram, by dividing out the
+number of accumulated frames, bin sizes (the Jacobian), and query point
+number density. The PMFT is then defined as the negative logarithm of the PCF.
+For further descriptions of the numerical methods used to compute the PMFT,
+refer to the supplementary information of :cite:`vanAnders:2014aa`.
+
+.. note::
+    The coordinate system in which the calculation is performed is not the same
+    as the coordinate system in which particle positions and orientations
+    should be supplied. Only certain coordinate systems are available for
+    certain particle positions and orientations:
+
+    * 2D particle coordinates (position: [:math:`x`, :math:`y`, :math:`0`],
+      orientation: :math:`\theta`):
+
+        * :math:`r`, :math:`\theta_1`, :math:`\theta_2`.
+        * :math:`x`, :math:`y`.
+        * :math:`x`, :math:`y`, :math:`\theta`.
+
+    * 3D particle coordinates:
+
+        * :math:`x`, :math:`y`, :math:`z`.
+
+.. note::
+    For any bins where the histogram is zero (i.e. no observations were made
+    with that relative position/orientation of particles), the PMFT will return
+    :code:`nan`.
+"""
+
+from freud.locality import _SpatialHistogram
+from freud.util import _Compute, quat, vec3
+
+import numpy as np
+import rowan
+
+import freud.locality
+
+import numpy as np
+
+import freud._pmft
+
+
+def _quat_to_z_angle(orientations, num_points):
+    """If orientations are quaternions, convert them to angles.
+
+    For consistency with the boxes and points in freud, we require that
+    the orientations represent rotations about the z-axis. If last
+    dimension is of length 4, it's a quaternion, unless we have exactly
+    4 points, in which case it could be 4 angles. In that case, we also
+    have to check that orientations are of shape (4, 4)
+    """
+    # Either we have a 1D array of length 4 (and we don't have exactly 4
+    # points), or we have a 2D array with the second dimension having length 4.
+    is_quat = (
+        (len(orientations.shape) == 1 and orientations.shape[0] == 4 and
+            num_points != 4) or
+        (len(orientations.shape) == 2 and orientations.shape[1] == 4)
+    )
+
+    if is_quat:
+        axes, orientations = rowan.to_axis_angle(orientations)
+        if not (np.allclose(orientations, 0) or np.allclose(axes, [0, 0, 1])):
+            raise ValueError("Orientations provided as quaternions "
+                             "must represent rotations about the z-axis.")
+    return orientations
+
+
+def _gen_angle_array(orientations, shape):
+    """Generates properly shaped, freud-compliant arrays of angles.
+
+    This computation is specific to 2D calculations that require angles as
+    orientations. It performs the conversion of quaternion inputs if needed and
+    ensures that singleton arrays are treated correctly."""
+
+    return freud.util._convert_array(np.atleast_1d(_quat_to_z_angle(
+        np.asarray(orientations).squeeze(), shape[0])), shape=shape)
+
+
+class _PMFT(_SpatialHistogram):
+    r"""Compute the PMFT :cite:`vanAnders:2014aa,van_Anders_2013` for a
+    given set of points.
+
+    This class provides an abstract interface for computing the PMFT.
+    It must be specialized for a specific coordinate system; although in
+    principle the PMFT is coordinate independent, the binning process must be
+    performed in a particular coordinate system.
+    """
+
+    def __init__(self):
+        # abstract class
+        pass
+
+    @_Compute._computed_property
+    def pmft(self):
+        """:class:`np.ndarray`: The discrete potential of mean force and
+        torque."""
+        with np.errstate(divide='ignore'):
+            result = -np.log(np.copy(self._pcf))
+        return result
+
+    @_Compute._computed_property
+    def _pcf(self):
+        """:class:`np.ndarray`: The discrete pair correlation function."""
+        return self._cpp_obj.getPCF().toNumpyArray()
+
+
+class PMFTR12(_PMFT):
+    r"""Computes the PMFT :cite:`vanAnders:2014aa,van_Anders_2013` in a 2D
+    system described by :math:`r`, :math:`\theta_1`, :math:`\theta_2`.
+
+    .. note::
+        **2D:** :class:`freud.pmft.PMFTR12` is only defined for 2D systems.
+        The points must be passed in as :code:`[x, y, 0]`.
+
+    Args:
+        r_max (float):
+            Maximum distance at which to compute the PMFT.
+        bins (unsigned int or sequence of length 3):
+            If an unsigned int, the number of bins in :math:`r`,
+            :math:`\theta_1`, and :math:`\theta_2`. If a sequence of three
+            integers, interpreted as :code:`(num_bins_r, num_bins_t1,
+            num_bins_t2)`.
+    """  # noqa: E501
+
+    def __init__(self, r_max, bins):
+        try:
+            n_r, n_t1, n_t2 = bins
+        except TypeError:
+            n_r = n_t1 = n_t2 = bins
+        self._cpp_obj = freud._pmft.PMFTR12(r_max, n_r, n_t1, n_t2)
+        self.r_max = r_max
+
+    def compute(self, system, orientations, query_points=None,
+                query_orientations=None, neighbors=None, reset=True):
+        r"""Calculates the PMFT.
+
+        Args:
+            system:
+                Any object that is a valid argument to
+                :class:`freud.locality.NeighborQuery.from_system`.
+            orientations ((:math:`N_{points}`, 4) or (:math:`N_{points}`,) :class:`numpy.ndarray`):
+                Orientations associated with system points that are used to
+                calculate bonds. If the array is one-dimensional, the values
+                are treated as angles in radians corresponding to
+                **counterclockwise** rotations about the z axis.
+            query_points ((:math:`N_{query\_points}`, 3) :class:`numpy.ndarray`, optional):
+                Query points used to calculate the PMFT. Uses the system's
+                points if :code:`None` (Default value = :code:`None`).
+            query_orientations ((:math:`N_{query\_points}`, 4) :class:`numpy.ndarray`, optional):
+                Query orientations associated with query points that are used
+                to calculate bonds. If the array is one-dimensional, the values
+                are treated as angles in radians corresponding to
+                **counterclockwise** rotations about the z axis. Uses
+                :code:`orientations` if :code:`None`.  (Default value =
+                :code:`None`).
+            neighbors (:class:`freud.locality.NeighborList` or dict, optional):
+                Either a :class:`NeighborList <freud.locality.NeighborList>` of
+                neighbor pairs to use in the calculation, or a dictionary of
+                `query arguments
+                <https://freud.readthedocs.io/en/stable/topics/querying.html>`_
+                (Default value: None).
+            reset (bool):
+                Whether to erase the previously computed values before adding
+                the new computation; if False, will accumulate data (Default
+                value: True).
+        """  # noqa: E501
+        if reset:
+            self._reset()
+
+        nq, nlist, qargs, query_points, num_query_points = \
+            self._preprocess_arguments(
+                system, query_points, neighbors)
+
+        orientations = _gen_angle_array(
+            orientations, shape=(nq.points.shape[0], ))
+        if query_orientations is None:
+            query_orientations = orientations
+        else:
+            query_orientations = _gen_angle_array(
+                query_orientations, shape=(query_points.shape[0], ))
+
+        self._cpp_obj.accumulate(nq._cpp_obj, orientations, query_points,
+                                 query_orientations, nlist._cpp_obj, qargs._cpp_obj)
+        return self
+
+    def __repr__(self):
+        bounds = self.bounds
+        return ("freud.pmft.{cls}(r_max={r_max}, bins=({bins}))").format(
+            cls=type(self).__name__,
+            r_max=self.r_max,
+            bins=', '.join([str(b) for b in self.nbins]))
+
+
+class PMFTXYT(_PMFT):
+    r"""Computes the PMFT :cite:`vanAnders:2014aa,van_Anders_2013` for
+    systems described by coordinates :math:`x`, :math:`y`, :math:`\theta`.
+
+    .. note::
+        **2D:** :class:`freud.pmft.PMFTXYT` is only defined for 2D systems.
+        The points must be passed in as :code:`[x, y, 0]`.
+
+    Args:
+        x_max (float):
+            Maximum :math:`x` distance at which to compute the PMFT.
+        y_max (float):
+            Maximum :math:`y` distance at which to compute the PMFT.
+        bins (unsigned int or sequence of length 3):
+            If an unsigned int, the number of bins in :math:`x`, :math:`y`, and
+            :math:`t`. If a sequence of three integers, interpreted as
+            :code:`(num_bins_x, num_bins_y, num_bins_t)`.
+    """  # noqa: E501
+
+    def __init__(self, x_max, y_max, bins):
+        try:
+            n_x, n_y, n_t = bins
+        except TypeError:
+            n_x = n_y = n_t = bins
+
+        self._cpp_obj = freud._pmft.PMFTXYT(x_max, y_max, n_x, n_y, n_t)
+        self.r_max = np.sqrt(x_max**2 + y_max**2)
+
+    def compute(self, system, orientations, query_points=None,
+                query_orientations=None, neighbors=None, reset=True):
+        r"""Calculates the PMFT.
+
+        Args:
+            system:
+                Any object that is a valid argument to
+                :class:`freud.locality.NeighborQuery.from_system`.
+            orientations ((:math:`N_{points}`, 4) or (:math:`N_{points}`,) :class:`numpy.ndarray`):
+                Orientations associated with system points that are used to
+                calculate bonds. If the array is one-dimensional, the values
+                are treated as angles in radians corresponding to
+                **counterclockwise** rotations about the z axis.
+            query_points ((:math:`N_{query\_points}`, 3) :class:`numpy.ndarray`, optional):
+                Query points used to calculate the PMFT. Uses the system's
+                points if :code:`None` (Default value = :code:`None`).
+            query_orientations ((:math:`N_{query\_points}`, 4) :class:`numpy.ndarray`, optional):
+                Query orientations associated with query points that are used
+                to calculate bonds. If the array is one-dimensional, the values
+                are treated as angles in radians corresponding to
+                **counterclockwise** rotations about the z axis. Uses
+                :code:`orientations` if :code:`None`.  (Default value =
+                :code:`None`).
+            neighbors (:class:`freud.locality.NeighborList` or dict, optional):
+                Either a :class:`NeighborList <freud.locality.NeighborList>` of
+                neighbor pairs to use in the calculation, or a dictionary of
+                `query arguments
+                <https://freud.readthedocs.io/en/stable/topics/querying.html>`_
+                (Default value: None).
+            reset (bool):
+                Whether to erase the previously computed values before adding
+                the new computation; if False, will accumulate data (Default
+                value: True).
+        """  # noqa: E501
+        if reset:
+            self._reset()
+
+        nq, nlist, qargs, query_points, num_query_points = \
+            self._preprocess_arguments(
+                system, query_points, neighbors)
+
+        orientations = _gen_angle_array(
+            orientations, shape=(nq.points.shape[0], ))
+        if query_orientations is None:
+            query_orientations = orientations
+        else:
+            query_orientations = _gen_angle_array(
+                query_orientations, shape=(l_query_points.shape[0], ))
+
+        self._cpp_obj.accumulate(nq._cpp_obj, orientations, query_points,
+                                 query_orientations, nlist._cpp_obj, qargs._cpp_obj)
+        return self
+
+    def __repr__(self):
+        bounds = self.bounds
+        return ("freud.pmft.{cls}(x_max={x_max}, y_max={y_max}, "
+                "bins=({bins}))").format(cls=type(self).__name__,
+                                         x_max=bounds[0][1],
+                                         y_max=bounds[1][1],
+                                         bins=', '.join(
+                                             [str(b) for b in self.nbins]))
+
+
+class PMFTXY(_PMFT):
+    r"""Computes the PMFT :cite:`vanAnders:2014aa,van_Anders_2013` in
+    coordinates :math:`x`, :math:`y`.
+
+    There are 3 degrees of translational and rotational freedom in 2
+    dimensions, so this class implicitly integrates over the rotational degree
+    of freedom of the second particle.
+
+    .. note::
+        **2D:** :class:`freud.pmft.PMFTXY` is only defined for 2D systems.
+        The points must be passed in as :code:`[x, y, 0]`.
+
+    Args:
+        x_max (float):
+            Maximum :math:`x` distance at which to compute the PMFT.
+        y_max (float):
+            Maximum :math:`y` distance at which to compute the PMFT.
+        bins (unsigned int or sequence of length 2):
+            If an unsigned int, the number of bins in :math:`x` and :math:`y`.
+            If a sequence of two integers, interpreted as
+            :code:`(num_bins_x, num_bins_y)`.
+    """  # noqa: E501
+
+    def __init__(self, x_max, y_max, bins):
+        try:
+            n_x, n_y = bins
+        except TypeError:
+            n_x = n_y = bins
+
+        self._cpp_obj = freud._pmft.PMFTXY(x_max, y_max, n_x, n_y)
+        self.r_max = np.sqrt(x_max**2 + y_max**2)
+
+    def compute(self, system, query_orientations, query_points=None,
+                neighbors=None, reset=True):
+        r"""Calculates the PMFT.
+
+        .. note::
+            The orientations of the system points are irrelevant for this
+            calculation because that dimension is integrated out. The provided
+            ``query_orientations`` are therefore always associated with
+            ``query_points`` (which are equal to the system points if no
+            ``query_points`` are explicitly provided).
+
+        Args:
+            system:
+                Any object that is a valid argument to
+                :class:`freud.locality.NeighborQuery.from_system`.
+            query_orientations ((:math:`N_{query\_points}`, 4) or (:math:`N_{query\_points}`,) :class:`numpy.ndarray`):
+                Query orientations associated with query points that are used
+                to calculate bonds. If the array is one-dimensional, the values
+                are treated as angles in radians corresponding to
+                **counterclockwise** rotations about the z axis.
+            query_points ((:math:`N_{query\_points}`, 3) :class:`numpy.ndarray`, optional):
+                Query points used to calculate the PMFT. Uses the system's
+                points if :code:`None` (Default value = :code:`None`).
+            neighbors (:class:`freud.locality.NeighborList` or dict, optional):
+                Either a :class:`NeighborList <freud.locality.NeighborList>` of
+                neighbor pairs to use in the calculation, or a dictionary of
+                `query arguments
+                <https://freud.readthedocs.io/en/stable/topics/querying.html>`_
+                (Default value: None).
+            reset (bool):
+                Whether to erase the previously computed values before adding
+                the new computation; if False, will accumulate data (Default
+                value: True).
+        """  # noqa: E501
+        if reset:
+            self._reset()
+
+        nq, nlist, qargs, query_points, num_query_points = \
+            self._preprocess_arguments(
+                system, query_points, neighbors)
+
+        query_orientations = _gen_angle_array(
+            query_orientations, shape=(num_query_points, ))
+
+        self._cpp_obj.accumulate(nq._cpp_obj, query_orientations, query_points,
+                                 nlist._cpp_obj, qargs._cpp_obj)
+        return self
+
+    @_Compute._computed_property
+    def bin_counts(self):
+        """:class:`numpy.ndarray`: The bin counts in the histogram."""
+        # Currently the parent function returns a 3D array that must be
+        # squeezed due to the internal choices in the histogramming; this will
+        # be fixed in future changes.
+        return np.squeeze(super(PMFTXY, self).bin_counts)
+
+    def __repr__(self):
+        bounds = self.bounds
+        return ("freud.pmft.{cls}(x_max={x_max}, y_max={y_max}, "
+                "bins=({bins}))").format(cls=type(self).__name__,
+                                         x_max=bounds[0][1],
+                                         y_max=bounds[1][1],
+                                         bins=', '.join(
+                                             [str(b) for b in self.nbins]))
+
+    def _repr_png_(self):
+        try:
+            import freud.plot
+            return freud.plot._ax_to_bytes(self.plot())
+        except (AttributeError, ImportError):
+            return None
+
+    def plot(self, ax=None):
+        """Plot PMFTXY.
+
+        Args:
+            ax (:class:`matplotlib.axes.Axes`, optional): Axis to plot on. If
+                :code:`None`, make a new figure and axis.
+                (Default value = :code:`None`)
+
+        Returns:
+            (:class:`matplotlib.axes.Axes`): Axis with the plot.
+        """
+        import freud.plot
+        return freud.plot.pmft_plot(self, ax)
+
+
+class PMFTXYZ(_PMFT):
+    r"""Computes the PMFT :cite:`vanAnders:2014aa,van_Anders_2013` in
+    coordinates :math:`x`, :math:`y`, :math:`z`.
+
+    There are 6 degrees of translational and rotational freedom in 3
+    dimensions, so this class is implicitly integrates out the orientational
+    degrees of freedom in the system associated with the points. All
+    calculations are done in the reference from of the query points.
+
+    Args:
+        x_max (float):
+            Maximum :math:`x` distance at which to compute the PMFT.
+        y_max (float):
+            Maximum :math:`y` distance at which to compute the PMFT.
+        z_max (float):
+            Maximum :math:`z` distance at which to compute the PMFT.
+        bins (unsigned int or sequence of length 3):
+            If an unsigned int, the number of bins in :math:`x`, :math:`y`, and
+            :math:`z`. If a sequence of three integers, interpreted as
+            :code:`(num_bins_x, num_bins_y, num_bins_z)`.
+        shiftvec (list):
+            Vector pointing from ``[0, 0, 0]`` to the center of the PMFT.
+    """  # noqa: E501
+
+    def __init__(self, x_max, y_max, z_max, bins,
+                  shiftvec=[0, 0, 0]):
+        try:
+            n_x, n_y, n_z = bins
+        except TypeError:
+            n_x = n_y = n_z = bins
+
+        self._cpp_obj = freud._pmft.PMFTXYZ(
+                x_max, y_max, z_max, n_x, n_y, n_z, shiftvec)
+        self.shiftvec = np.array(shiftvec, dtype=np.float32)
+        self.r_max = np.sqrt(x_max**2 + y_max**2 + z_max**2)
+
+    def compute(self, system, query_orientations, query_points=None,
+                equiv_orientations=None, neighbors=None, reset=True):
+        r"""Calculates the PMFT.
+
+        .. note::
+            The orientations of the system points are irrelevant for this
+            calculation because that dimension is integrated out. The provided
+            ``query_orientations`` are therefore always associated with
+            ``query_points`` (which are equal to the system points if no
+            ``query_points`` are explicitly provided.
+
+        Args:
+            system:
+                Any object that is a valid argument to
+                :class:`freud.locality.NeighborQuery.from_system`.
+            query_orientations ((:math:`N_{points}`, 4) :class:`numpy.ndarray`):
+                Query orientations associated with query points that are used
+                to calculate bonds.
+            query_points ((:math:`N_{query\_points}`, 3) :class:`numpy.ndarray`, optional):
+                Query points used to calculate the PMFT. Uses the system's
+                points if :code:`None` (Default value = :code:`None`).
+            equiv_orientations ((:math:`N_{faces}`, 4) :class:`numpy.ndarray`, optional):
+                Orientations to be treated as equivalent to account for
+                symmetry of the points. For instance, if the
+                :code:`query_points` are rectangular prisms with the long axis
+                corresponding to the x-axis, then a point at :math:`(1, 0, 0)`
+                and a point at :math:`(-1, 0, 0)` are symmetrically equivalent
+                and can be counted towards both the positive and negative bins.
+                If not supplied by user or :code:`None`, a unit quaternion will
+                be used (Default value = :code:`None`).
+            neighbors (:class:`freud.locality.NeighborList` or dict, optional):
+                Either a :class:`NeighborList <freud.locality.NeighborList>` of
+                neighbor pairs to use in the calculation, or a dictionary of
+                `query arguments
+                <https://freud.readthedocs.io/en/stable/topics/querying.html>`_
+                (Default value: None).
+            reset (bool):
+                Whether to erase the previously computed values before adding
+                the new computation; if False, will accumulate data (Default
+                value: True).
+        """  # noqa: E501
+        if reset:
+            self._reset()
+
+        nq, nlist, qargs, query_points, num_query_points = \
+            self._preprocess_arguments(
+                system, query_points, neighbors)
+        query_points = query_points - self.shiftvec.reshape(1, 3)
+
+        query_orientations = freud.util._convert_array(
+            np.atleast_1d(query_orientations), shape=(num_query_points, 4))
+
+        if equiv_orientations is None:
+            equiv_orientations = np.array([[1, 0, 0, 0]], dtype=np.float32)
+        else:
+            equiv_orientations = freud.util._convert_array(
+                equiv_orientations, shape=(None, 4))
+
+        self.pmftxyzptr.accumulate(
+            nq._cpp_obj,
+            query_orientations,
+            query_points,
+            equiv_orientations,
+            nlist._cpp_obj,
+            qargs._cpp_obj)
+        return self
+
+    def __repr__(self):
+        bounds = self.bounds
+        return ("freud.pmft.{cls}(x_max={x_max}, y_max={y_max}, "
+                "z_max={z_max}, bins=({bins}), "
+                "shiftvec={shiftvec})").format(
+                    cls=type(self).__name__,
+                    x_max=bounds[0][1],
+                    y_max=bounds[1][1],
+                    z_max=bounds[2][1],
+                    bins=', '.join([str(b) for b in self.nbins]),
+                    shiftvec=self.shiftvec.tolist())


### PR DESCRIPTION
## Description

This PR converts the PMFT module to use nanobind.

## Motivation and Context

This PR is part of a series of PRs which removes the cython from freud.

## How Has This Been Tested?

If existing tests pass, this PR should be good to go.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds or improves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation improvement (updates to user guides, docstrings, or developer docs)

## Checklist:
<!-- Put an `x` in all the boxes that apply. If you're unsure about any of
     these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [**CONTRIBUTING**](https://github.com/glotzerlab/freud/blob/main/CONTRIBUTING.md) document.
- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation (if relevant).
- [ ] I have added tests that cover my changes (if relevant).
- [ ] All new and existing tests passed.
- [ ] I have updated the [credits](https://github.com/glotzerlab/freud/blob/main/doc/source/reference/credits.rst).
- [ ] I have updated the [Changelog](https://github.com/glotzerlab/freud/blob/main/ChangeLog.md).
