### PR TITLE
Enable cmake color output for clang/ninja

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,6 +63,17 @@ if(WIN32)
   add_compile_options(/DNOMINMAX)
 endif()
 
+# Enable diagnostic colors for ninja
+if(CMAKE_COMPILER_IS_GNUCXX AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 5.0)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fdiagnostics-color=always")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fdiagnostics-color=always")
+endif()
+
+if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fcolor-diagnostics")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fcolor-diagnostics")
+endif()
+
 include_directories(
   ${PROJECT_SOURCE_DIR}/cpp/util ${PROJECT_SOURCE_DIR}/cpp/locality
   ${PROJECT_SOURCE_DIR}/cpp/box)

--- a/doc/source/reference/credits.rst
+++ b/doc/source/reference/credits.rst
@@ -403,6 +403,12 @@ Philipp Schönhöfer
 
 * Contributed code, design, documentation, and testing for ``freud.locality.FilterRAD`` class.
 
+
+Jen Bradley
+
+* Updated CMake to color error messages for build systems that buffer output.
+
+
 Source code
 -----------
 


### PR DESCRIPTION
As in ninja-build/Ninja's [FAQ](https://github.com/ninja-build/ninja/wiki/FAQ#why-does-my-program-with-colored-output-not-have-color-under-ninja), cmake does not color output for build systems that buffer output. The code added in this PR fixes this

## How Has This Been Tested?

CMake colors output with the changes made, and does not without.

Before:
<img width="363" alt="image" src="https://github.com/user-attachments/assets/4ef68a1c-0daa-48fa-a21b-9ff84f4528e2">

After:
<img width="363" alt="image" src="https://github.com/user-attachments/assets/ca868142-110d-4646-b2ff-78c8b79a9255">


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds or improves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation improvement (updates to user guides, docstrings, or developer docs)

## Checklist:
<!-- Put an `x` in all the boxes that apply. If you're unsure about any of
     these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/glotzerlab/freud/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] I have updated the documentation (if relevant).
- [x] I have added tests that cover my changes (if relevant).
- [x] All new and existing tests passed.
- [x] I have updated the [credits](https://github.com/glotzerlab/freud/blob/main/doc/source/reference/credits.rst).
- [x] I have updated the [Changelog](https://github.com/glotzerlab/freud/blob/main/ChangeLog.md).
