### PR TITLE
Add `to_box_params` method for exporting boxes to GSD

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog] and this project adheres to
 [Keep a ChangeLog]: https://keepachangelog.com/en/1.0.0/
 [Semantic Versioning]: https://semver.org/spec/v2.0.0.html
 
+## 3.X.X -- XXXX-XX-XX
+
+### Added
+* `to_box_params` method for `freud.Box`
+
 ## 3.2.0 -- 2025-02-10
 
 ### Added

--- a/freud/box.py
+++ b/freud/box.py
@@ -648,7 +648,7 @@ class Box:
 
             >>> box = freud.box.Box.cube(L=10)
             >>> box.to_array()
-            array([10., 10., 10., 0., 0., 0.])
+            (10.0, 10.0, 10.0, 0.0, 0.0, 0.0)
 
         Returns:
             tuple:

--- a/freud/box.py
+++ b/freud/box.py
@@ -639,15 +639,15 @@ class Box:
             ]
         )
 
-    def to_array(self):
-        r"""Returns the box lengths and tilt factors as a flat (6,) array.
+    def to_box_params(self):
+        r"""Returns the box lengths and tilt factors as a flat (6,) tuple.
 
         The output from this method can be saved as a `GSD box <https://gsd.readthedocs.io/en/stable/schema-hoomd.html#chunk-configuration-box>`_.
 
         Example::
 
             >>> box = freud.box.Box.cube(L=10)
-            >>> box.to_array()
+            >>> box.to_box_params()
             (10.0, 10.0, 10.0, 0.0, 0.0, 0.0)
 
         Returns:

--- a/freud/box.py
+++ b/freud/box.py
@@ -639,6 +639,24 @@ class Box:
             ]
         )
 
+    def to_array(self):
+        r"""Returns the box lengths and tilt factors as a flat (6,) array.
+
+        The output from this method can be saved as a `GSD box <https://gsd.readthedocs.io/en/stable/schema-hoomd.html#chunk-configuration-box>`_.
+
+        Example::
+
+            >>> box = freud.box.Box.cube(L=10)
+            >>> box.to_array()
+            array([10., 10., 10., 0., 0., 0.])
+
+        Returns:
+            tuple:
+                The box extents along each axis and tilt factors
+                :math:`(L_x, L_y, L_z, xy, xz, yz)`.
+        """
+        return (self.Lx, self.Ly, self.Lz, self.xy, self.xz, self.yz)
+
     def to_box_lengths_and_angles(self):
         r"""Return the box lengths and angles.
 

--- a/tests/test_box_box.py
+++ b/tests/test_box_box.py
@@ -450,12 +450,15 @@ class TestBox:
         for k, v in box_dict.items():
             npt.assert_allclose(v, box2[k])
 
-    def test_to_array(self):
+    def test_to_box_params(self):
         box = freud.box.Box(2, 2, 2, 1, 0.5, 0.1)
-        npt.assert_equal(box.to_array(), [*box.to_dict().values()][:6])
+        npt.assert_equal(box.to_box_params(), [*box.to_dict().values()][:6])
+        npt.assert_equal(
+            box.to_box_params(), [box.Lx, box.Ly, box.Lz, box.xy, box.xz, box.yz]
+        )
 
         box2 = freud.box.Box.cube(0.001)
-        npt.assert_allclose(box2.to_array(), [0.001, 0.001, 0.001, 0, 0, 0])
+        npt.assert_allclose(box2.to_box_params(), [0.001, 0.001, 0.001, 0, 0, 0])
 
     def test_from_box(self):
         """Test various methods of initializing a box"""

--- a/tests/test_box_box.py
+++ b/tests/test_box_box.py
@@ -450,6 +450,13 @@ class TestBox:
         for k, v in box_dict.items():
             npt.assert_allclose(v, box2[k])
 
+    def test_to_array(self):
+        box = freud.box.Box(2, 2, 2, 1, 0.5, 0.1)
+        npt.assert_equal(box.to_array(), [*box.to_dict().values()][:6])
+
+        box2 = freud.box.Box.cube(0.001)
+        npt.assert_allclose(box2.to_array(), [0.001, 0.001, 0.001, 0, 0, 0])
+
     def test_from_box(self):
         """Test various methods of initializing a box"""
         box = freud.box.Box(2, 2, 2, 1, 0.5, 0.1)


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above. -->

## Description

Freud boxes are typically initialized from `Lx, Ly, Lz, xy, xz, yz` data, but there is no neat way to recover that data from the input. This method (which ~could~ should? be renamed for clarity) provides that functionality.

## Motivation and Context

Initializing GSD boxes can now be achieved in one function call:
```diff
frame = gsd.hoomd.Frame()
- frame.configuration.box = [freud_box.Lx, freud_box.Ly, ..., freud_box.yz]
+ frame.configuration.box = freud_box.to_box_params()
```


## How Has This Been Tested?
New tests have been added

## Checklist:
- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/freud/blob/main/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Freud Contributor Agreement**](https://github.com/glotzerlab/freud/blob/main/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/freud/blob/main/doc/source/reference/credits.rst) in the pull request source branch.
- [x] I have updated the [Change log](https://github.com/glotzerlab/freud/blob/main/ChangeLog.md).
