### PR TITLE
Fix PMFT plot and add cmap option

### DIFF
--- a/freud/plot.py
+++ b/freud/plot.py
@@ -317,7 +317,7 @@ def histogram_plot(
     return ax
 
 
-def pmft_plot(pmft, ax=None):
+def pmft_plot(pmft, ax=None, cmap="viridis"):
     """Helper function to draw 2D PMFT diagram.
 
     Args:
@@ -326,6 +326,8 @@ def pmft_plot(pmft, ax=None):
         ax (:class:`matplotlib.axes.Axes`): Axes object to plot.
             If :code:`None`, make a new axes and figure object.
             (Default value = :code:`None`).
+        cmap (str): String name of Matplotlib colormap.
+            (Default value = :code:`"viridis"`).
 
     Returns:
         :class:`matplotlib.axes.Axes`: Axes object with the diagram.
@@ -338,11 +340,10 @@ def pmft_plot(pmft, ax=None):
         fig = plt.figure()
         ax = fig.subplots()
 
-    pmft_arr = np.copy(pmft.PMFT)
+    pmft_arr = np.copy(pmft.pmft)
     pmft_arr[np.isinf(pmft_arr)] = np.nan
 
-    xlims = (pmft.X[0], pmft.X[-1])
-    ylims = (pmft.Y[0], pmft.Y[-1])
+    xlims, ylims = pmft.bounds
     ax.set_xlim(xlims)
     ax.set_ylim(ylims)
     ax.xaxis.set_ticks([i for i in range(int(xlims[0]), int(xlims[1] + 1))])
@@ -358,7 +359,7 @@ def pmft_plot(pmft, ax=None):
         np.flipud(pmft_arr),
         extent=[xlims[0], xlims[1], ylims[0], ylims[1]],
         interpolation="nearest",
-        cmap="viridis",
+        cmap=cmap,
         vmin=-2.5,
         vmax=3.0,
     )

--- a/freud/pmft.py
+++ b/freud/pmft.py
@@ -436,8 +436,8 @@ class PMFTXY(_PMFT):
             ax (:class:`matplotlib.axes.Axes`, optional): Axis to plot on. If
                 :code:`None`, make a new figure and axis.
                 (Default value = :code:`None`)
-        cmap (str): String name of Matplotlib colormap.
-            (Default value = :code:`"viridis"`).
+        cmap (str):
+            String name of a Matplotlib colormap. (Default value = :code:`"viridis"`).
 
         Returns:
             (:class:`matplotlib.axes.Axes`): Axis with the plot.

--- a/freud/pmft.py
+++ b/freud/pmft.py
@@ -429,20 +429,22 @@ class PMFTXY(_PMFT):
         except (AttributeError, ImportError):
             return None
 
-    def plot(self, ax=None):
+    def plot(self, ax=None, cmap="viridis"):
         """Plot PMFTXY.
 
         Args:
             ax (:class:`matplotlib.axes.Axes`, optional): Axis to plot on. If
                 :code:`None`, make a new figure and axis.
                 (Default value = :code:`None`)
+        cmap (str): String name of Matplotlib colormap.
+            (Default value = :code:`"viridis"`).
 
         Returns:
             (:class:`matplotlib.axes.Axes`): Axis with the plot.
         """
         import freud.plot
 
-        return freud.plot.pmft_plot(self, ax)
+        return freud.plot.pmft_plot(self, ax, cmap=cmap)
 
 
 class PMFTXYZ(_PMFT):


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above. -->

## Description, Motivation, and Context

PMFTXY.plot() called for the `self.PMFT`, `self.X`, and `self.Y` properties which were renamed to `self.pmft` and `self.bounds` in a recent PR. This changes fixes these calls, and adds an optional "cmap" parameter that passes through into the internal call to `matplotlib.imshow`.

## How Has This Been Tested?

Used with cmap="afmhot".

<img width="624" alt="image" src="https://github.com/user-attachments/assets/f801762f-1506-4228-b5a7-a49413162b81" />


## Checklist:
- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/freud/blob/main/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Freud Contributor Agreement**](https://github.com/glotzerlab/freud/blob/main/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/freud/blob/main/doc/source/reference/credits.rst) in the pull request source branch.
- [ ] I have updated the [Change log](https://github.com/glotzerlab/freud/blob/main/ChangeLog.md).
