### PR TITLE
Allow non-writeable arrays

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog] and this project adheres to
 
 ### Fixed
 * `PMFTXY.plot` executes without errors.
+* Allow input arguments to be passed read-only NumPy arrays.
 
 ### Added
 * `to_box_params` method for `freud.Box`

--- a/freud/box/export-Box.cc
+++ b/freud/box/export-Box.cc
@@ -38,10 +38,10 @@ void getImages(const std::shared_ptr<Box>& box, const nb_array<float>& vecs, con
     box->getImages(vecs_data, Nvecs, images_data);
 }
 
-void wrap(const std::shared_ptr<Box>& box, const nb_array<float>& vecs, const nb_array<float>& out)
+void wrap(const std::shared_ptr<Box>& box, const nb_array<const float>& vecs, const nb_array<float>& out)
 {
     const unsigned int Nvecs = vecs.shape(0);
-    auto* vecs_data = reinterpret_cast<vec3<float>*>(vecs.data());
+    const auto* vecs_data = reinterpret_cast<const vec3<float>*>(vecs.data());
     auto* out_data = reinterpret_cast<vec3<float>*>(out.data());
     box->wrap(vecs_data, Nvecs, out_data);
 }

--- a/freud/box/export-Box.cc
+++ b/freud/box/export-Box.cc
@@ -14,7 +14,8 @@ namespace nb = nanobind;
 
 namespace freud { namespace box { namespace wrap {
 
-void makeAbsolute(const std::shared_ptr<Box>& box, const nb_array<const float>& vecs, const nb_array<float>& out)
+void makeAbsolute(const std::shared_ptr<Box>& box, const nb_array<const float>& vecs,
+                  const nb_array<float>& out)
 {
     unsigned int const Nvecs = vecs.shape(0);
     const auto* vecs_data = reinterpret_cast<const vec3<float>*>(vecs.data());
@@ -22,7 +23,8 @@ void makeAbsolute(const std::shared_ptr<Box>& box, const nb_array<const float>& 
     box->makeAbsolute(vecs_data, Nvecs, out_data);
 }
 
-void makeFractional(const std::shared_ptr<Box>& box, const nb_array<const float>& vecs, const nb_array<float>& out)
+void makeFractional(const std::shared_ptr<Box>& box, const nb_array<const float>& vecs,
+                    const nb_array<float>& out)
 {
     unsigned int const Nvecs = vecs.shape(0);
     const auto* vecs_data = reinterpret_cast<const vec3<float>*>(vecs.data());
@@ -30,7 +32,8 @@ void makeFractional(const std::shared_ptr<Box>& box, const nb_array<const float>
     box->makeFractional(vecs_data, Nvecs, out_data);
 }
 
-void getImages(const std::shared_ptr<Box>& box, const nb_array<const float>& vecs, const nb_array<int>& images)
+void getImages(const std::shared_ptr<Box>& box, const nb_array<const float>& vecs,
+               const nb_array<int>& images)
 {
     const unsigned int Nvecs = vecs.shape(0);
     const auto* vecs_data = reinterpret_cast<const vec3<float>*>(vecs.data());
@@ -46,8 +49,8 @@ void wrap(const std::shared_ptr<Box>& box, const nb_array<const float>& vecs, co
     box->wrap(vecs_data, Nvecs, out_data);
 }
 
-void unwrap(const std::shared_ptr<Box>& box, const nb_array<const float>& vecs, const nb_array<const int>& images,
-            const nb_array<float>& out)
+void unwrap(const std::shared_ptr<Box>& box, const nb_array<const float>& vecs,
+            const nb_array<const int>& images, const nb_array<float>& out)
 {
     const unsigned int Nvecs = vecs.shape(0);
     const auto* vecs_data = reinterpret_cast<const vec3<float>*>(vecs.data());

--- a/freud/box/export-Box.cc
+++ b/freud/box/export-Box.cc
@@ -14,26 +14,26 @@ namespace nb = nanobind;
 
 namespace freud { namespace box { namespace wrap {
 
-void makeAbsolute(const std::shared_ptr<Box>& box, const nb_array<float>& vecs, const nb_array<float>& out)
+void makeAbsolute(const std::shared_ptr<Box>& box, const nb_array<const float>& vecs, const nb_array<float>& out)
 {
     unsigned int const Nvecs = vecs.shape(0);
-    auto* vecs_data = reinterpret_cast<vec3<float>*>(vecs.data());
+    const auto* vecs_data = reinterpret_cast<const vec3<float>*>(vecs.data());
     auto* out_data = reinterpret_cast<vec3<float>*>(out.data());
     box->makeAbsolute(vecs_data, Nvecs, out_data);
 }
 
-void makeFractional(const std::shared_ptr<Box>& box, const nb_array<float>& vecs, const nb_array<float>& out)
+void makeFractional(const std::shared_ptr<Box>& box, const nb_array<const float>& vecs, const nb_array<float>& out)
 {
     unsigned int const Nvecs = vecs.shape(0);
-    auto* vecs_data = reinterpret_cast<vec3<float>*>(vecs.data());
+    const auto* vecs_data = reinterpret_cast<const vec3<float>*>(vecs.data());
     auto* out_data = reinterpret_cast<vec3<float>*>(out.data());
     box->makeFractional(vecs_data, Nvecs, out_data);
 }
 
-void getImages(const std::shared_ptr<Box>& box, const nb_array<float>& vecs, const nb_array<int>& images)
+void getImages(const std::shared_ptr<Box>& box, const nb_array<const float>& vecs, const nb_array<int>& images)
 {
     const unsigned int Nvecs = vecs.shape(0);
-    auto* vecs_data = reinterpret_cast<vec3<float>*>(vecs.data());
+    const auto* vecs_data = reinterpret_cast<const vec3<float>*>(vecs.data());
     auto* images_data = reinterpret_cast<vec3<int>*>(images.data());
     box->getImages(vecs_data, Nvecs, images_data);
 }
@@ -46,42 +46,42 @@ void wrap(const std::shared_ptr<Box>& box, const nb_array<const float>& vecs, co
     box->wrap(vecs_data, Nvecs, out_data);
 }
 
-void unwrap(const std::shared_ptr<Box>& box, const nb_array<float>& vecs, const nb_array<int>& images,
+void unwrap(const std::shared_ptr<Box>& box, const nb_array<const float>& vecs, const nb_array<const int>& images,
             const nb_array<float>& out)
 {
     const unsigned int Nvecs = vecs.shape(0);
-    auto* vecs_data = reinterpret_cast<vec3<float>*>(vecs.data());
-    auto* images_data = reinterpret_cast<vec3<int>*>(images.data());
+    const auto* vecs_data = reinterpret_cast<const vec3<float>*>(vecs.data());
+    const auto* images_data = reinterpret_cast<const vec3<int>*>(images.data());
     auto* out_data = reinterpret_cast<vec3<float>*>(out.data());
     box->unwrap(vecs_data, images_data, Nvecs, out_data);
 }
 
 std::vector<float> centerOfMass(const std::shared_ptr<Box>& box, const nb_array<float>& vecs,
-                                const nb_array<float, nb::shape<-1>>& masses)
+                                const nb_array<const float, nb::shape<-1>>& masses)
 {
     const unsigned int Nvecs = vecs.shape(0);
     auto* vecs_data = reinterpret_cast<vec3<float>*>(vecs.data());
-    auto* masses_data = reinterpret_cast<float*>(masses.data());
+    const auto* masses_data = reinterpret_cast<const float*>(masses.data());
     auto com = box->centerOfMass(vecs_data, Nvecs, masses_data);
     return {com.x, com.y, com.z};
 }
 
 void center(const std::shared_ptr<Box>& box, const nb_array<float>& vecs,
-            const nb_array<float, nb::ndim<1>>& masses)
+            const nb_array<const float, nb::ndim<1>>& masses)
 {
     const unsigned int Nvecs = vecs.shape(0);
     auto* vecs_data = reinterpret_cast<vec3<float>*>(vecs.data());
-    auto* masses_data = reinterpret_cast<float*>(masses.data());
+    const auto* masses_data = reinterpret_cast<const float*>(masses.data());
     box->center(vecs_data, Nvecs, masses_data);
 }
 
-void computeDistances(const std::shared_ptr<Box>& box, const nb_array<float>& query_points,
-                      const nb_array<float>& points, const nb_array<float, nb::ndim<1>>& distances)
+void computeDistances(const std::shared_ptr<Box>& box, const nb_array<const float>& query_points,
+                      const nb_array<const float>& points, const nb_array<float, nb::ndim<1>>& distances)
 {
     const unsigned int n_query_points = query_points.shape(0);
-    auto* query_points_data = reinterpret_cast<vec3<float>*>(query_points.data());
+    const auto* query_points_data = reinterpret_cast<const vec3<float>*>(query_points.data());
     const unsigned int n_points = points.shape(0);
-    auto* points_data = reinterpret_cast<vec3<float>*>(points.data());
+    const auto* points_data = reinterpret_cast<const vec3<float>*>(points.data());
     auto* distances_data = reinterpret_cast<float*>(distances.data());
     if (n_query_points != n_points)
     {
@@ -90,13 +90,13 @@ void computeDistances(const std::shared_ptr<Box>& box, const nb_array<float>& qu
     box->computeDistances(query_points_data, n_query_points, points_data, distances_data);
 }
 
-void computeAllDistances(const std::shared_ptr<Box>& box, const nb_array<float>& query_points,
-                         const nb_array<float>& points, const nb_array<float, nb::ndim<2>>& distances)
+void computeAllDistances(const std::shared_ptr<Box>& box, const nb_array<const float>& query_points,
+                         const nb_array<const float>& points, const nb_array<float, nb::ndim<2>>& distances)
 {
     const unsigned int n_query_points = query_points.shape(0);
-    auto* query_points_data = reinterpret_cast<vec3<float>*>(query_points.data());
+    const auto* query_points_data = reinterpret_cast<const vec3<float>*>(query_points.data());
     const unsigned int n_points = points.shape(0);
-    auto* points_data = reinterpret_cast<vec3<float>*>(points.data());
+    const auto* points_data = reinterpret_cast<const vec3<float>*>(points.data());
     auto* distances_data = reinterpret_cast<float*>(distances.data());
     box->computeAllDistances(query_points_data, n_query_points, points_data, n_points, distances_data);
 }

--- a/freud/box/export-Box.h
+++ b/freud/box/export-Box.h
@@ -15,16 +15,19 @@ namespace freud { namespace box { namespace wrap {
 template<typename T, typename shape = nanobind::shape<-1, 3>>
 using nb_array = nanobind::ndarray<T, shape, nanobind::device::cpu, nanobind::c_contig>;
 
-void makeAbsolute(const std::shared_ptr<Box>& box, const nb_array<const float>& vecs, const nb_array<float>& out);
+void makeAbsolute(const std::shared_ptr<Box>& box, const nb_array<const float>& vecs,
+                  const nb_array<float>& out);
 
-void makeFractional(const std::shared_ptr<Box>& box, const nb_array<const float>& vecs, const nb_array<float>& out);
+void makeFractional(const std::shared_ptr<Box>& box, const nb_array<const float>& vecs,
+                    const nb_array<float>& out);
 
-void getImages(const std::shared_ptr<Box>& box, const nb_array<const float>& vecs, const nb_array<int>& images);
+void getImages(const std::shared_ptr<Box>& box, const nb_array<const float>& vecs,
+               const nb_array<int>& images);
 
 void wrap(const std::shared_ptr<Box>& box, const nb_array<const float>& vecs, const nb_array<float>& out);
 
-void unwrap(const std::shared_ptr<Box>& box, const nb_array<const float>& vecs, const nb_array<const int>& images,
-            const nb_array<float>& out);
+void unwrap(const std::shared_ptr<Box>& box, const nb_array<const float>& vecs,
+            const nb_array<const int>& images, const nb_array<float>& out);
 
 std::vector<float> centerOfMass(const std::shared_ptr<Box>& box, const nb_array<float>& vecs,
                                 const nb_array<const float, nanobind::shape<-1>>& masses);
@@ -33,10 +36,12 @@ void center(const std::shared_ptr<Box>& box, const nb_array<float>& vecs,
             const nb_array<const float, nanobind::ndim<1>>& masses);
 
 void computeDistances(const std::shared_ptr<Box>& box, const nb_array<const float>& query_points,
-                      const nb_array<const float>& points, const nb_array<float, nanobind::ndim<1>>& distances);
+                      const nb_array<const float>& points,
+                      const nb_array<float, nanobind::ndim<1>>& distances);
 
 void computeAllDistances(const std::shared_ptr<Box>& box, const nb_array<const float>& query_points,
-                         const nb_array<const float>& points, const nb_array<float, nanobind::ndim<2>>& distances);
+                         const nb_array<const float>& points,
+                         const nb_array<float, nanobind::ndim<2>>& distances);
 
 void contains(const std::shared_ptr<Box>& box, const nb_array<float>& points,
               const nb_array<bool, nanobind::ndim<1>>& contains_mask);

--- a/freud/box/export-Box.h
+++ b/freud/box/export-Box.h
@@ -15,28 +15,28 @@ namespace freud { namespace box { namespace wrap {
 template<typename T, typename shape = nanobind::shape<-1, 3>>
 using nb_array = nanobind::ndarray<T, shape, nanobind::device::cpu, nanobind::c_contig>;
 
-void makeAbsolute(const std::shared_ptr<Box>& box, const nb_array<float>& vecs, const nb_array<float>& out);
+void makeAbsolute(const std::shared_ptr<Box>& box, const nb_array<const float>& vecs, const nb_array<float>& out);
 
-void makeFractional(const std::shared_ptr<Box>& box, const nb_array<float>& vecs, const nb_array<float>& out);
+void makeFractional(const std::shared_ptr<Box>& box, const nb_array<const float>& vecs, const nb_array<float>& out);
 
-void getImages(const std::shared_ptr<Box>& box, const nb_array<float>& vecs, const nb_array<int>& images);
+void getImages(const std::shared_ptr<Box>& box, const nb_array<const float>& vecs, const nb_array<int>& images);
 
 void wrap(const std::shared_ptr<Box>& box, const nb_array<const float>& vecs, const nb_array<float>& out);
 
-void unwrap(const std::shared_ptr<Box>& box, const nb_array<float>& vecs, const nb_array<int>& images,
+void unwrap(const std::shared_ptr<Box>& box, const nb_array<const float>& vecs, const nb_array<const int>& images,
             const nb_array<float>& out);
 
 std::vector<float> centerOfMass(const std::shared_ptr<Box>& box, const nb_array<float>& vecs,
-                                const nb_array<float, nanobind::shape<-1>>& masses);
+                                const nb_array<const float, nanobind::shape<-1>>& masses);
 
 void center(const std::shared_ptr<Box>& box, const nb_array<float>& vecs,
-            const nb_array<float, nanobind::ndim<1>>& masses);
+            const nb_array<const float, nanobind::ndim<1>>& masses);
 
-void computeDistances(const std::shared_ptr<Box>& box, const nb_array<float>& query_points,
-                      const nb_array<float>& points, const nb_array<float, nanobind::ndim<1>>& distances);
+void computeDistances(const std::shared_ptr<Box>& box, const nb_array<const float>& query_points,
+                      const nb_array<const float>& points, const nb_array<float, nanobind::ndim<1>>& distances);
 
-void computeAllDistances(const std::shared_ptr<Box>& box, const nb_array<float>& query_points,
-                         const nb_array<float>& points, const nb_array<float, nanobind::ndim<2>>& distances);
+void computeAllDistances(const std::shared_ptr<Box>& box, const nb_array<const float>& query_points,
+                         const nb_array<const float>& points, const nb_array<float, nanobind::ndim<2>>& distances);
 
 void contains(const std::shared_ptr<Box>& box, const nb_array<float>& points,
               const nb_array<bool, nanobind::ndim<1>>& contains_mask);

--- a/freud/box/export-Box.h
+++ b/freud/box/export-Box.h
@@ -21,7 +21,7 @@ void makeFractional(const std::shared_ptr<Box>& box, const nb_array<float>& vecs
 
 void getImages(const std::shared_ptr<Box>& box, const nb_array<float>& vecs, const nb_array<int>& images);
 
-void wrap(const std::shared_ptr<Box>& box, const nb_array<float>& vecs, const nb_array<float>& out);
+void wrap(const std::shared_ptr<Box>& box, const nb_array<const float>& vecs, const nb_array<float>& out);
 
 void unwrap(const std::shared_ptr<Box>& box, const nb_array<float>& vecs, const nb_array<int>& images,
             const nb_array<float>& out);

--- a/freud/density/export-CorrelationFunction.cc
+++ b/freud/density/export-CorrelationFunction.cc
@@ -23,14 +23,14 @@ namespace wrap {
 // Wrapper function for accumulate
 void accumulateCF(const std::shared_ptr<CorrelationFunction>& self,
                   const std::shared_ptr<locality::NeighborQuery>& neighbor_query,
-                  const nb_array<std::complex<double>, nanobind::shape<-1>>& values,
-                  const nb_array<float, nanobind::shape<-1, 3>>& query_points,
-                  const nb_array<std::complex<double>, nanobind::shape<-1>>& query_values,
+                  const nb_array<const std::complex<double>, nanobind::shape<-1>>& values,
+                  const nb_array<const float, nanobind::shape<-1, 3>>& query_points,
+                  const nb_array<const std::complex<double>, nanobind::shape<-1>>& query_values,
                   const std::shared_ptr<locality::NeighborList>& nlist, const locality::QueryArgs& qargs)
 {
-    auto* values_data = reinterpret_cast<std::complex<double>*>(values.data());
-    auto* query_points_data = reinterpret_cast<vec3<float>*>(query_points.data());
-    auto* query_values_data = reinterpret_cast<std::complex<double>*>(query_values.data());
+    const auto* values_data = reinterpret_cast<const std::complex<double>*>(values.data());
+    const auto* query_points_data = reinterpret_cast<const vec3<float>*>(query_points.data());
+    const auto* query_values_data = reinterpret_cast<const std::complex<double>*>(query_values.data());
 
     const unsigned int num_query_points = query_points.shape(0);
 

--- a/freud/density/export-GaussianDensity.cc
+++ b/freud/density/export-GaussianDensity.cc
@@ -30,7 +30,7 @@ nanobind::tuple get_width(const std::shared_ptr<GaussianDensity>& self)
 
 void computeDensity(const std::shared_ptr<GaussianDensity>& self,
                     const std::shared_ptr<locality::NeighborQuery>& nq,
-                    const nb_array<float, nanobind::shape<-1>>& values)
+                    const nb_array<const float, nanobind::shape<-1>>& values)
 {
     const auto* values_data = values.is_valid() ? reinterpret_cast<const float*>(values.data()) : nullptr;
     self->compute(nq.get(), values_data);

--- a/freud/density/export-RDF.cc
+++ b/freud/density/export-RDF.cc
@@ -20,11 +20,11 @@ using nb_array = nanobind::ndarray<T, shape, nanobind::device::cpu, nanobind::c_
 namespace wrap {
 
 void accumulateRDF(const std::shared_ptr<RDF>& self, const std::shared_ptr<locality::NeighborQuery>& nq,
-                   const nb_array<float, nanobind::shape<-1, 3>>& query_points,
+                   const nb_array<const float, nanobind::shape<-1, 3>>& query_points,
                    const std::shared_ptr<locality::NeighborList>& nlist, const locality::QueryArgs& qargs)
 {
     unsigned int const num_query_points = query_points.shape(0);
-    auto* query_points_data = reinterpret_cast<vec3<float>*>(query_points.data());
+    const auto* query_points_data = reinterpret_cast<const vec3<float>*>(query_points.data());
     self->accumulate(nq, query_points_data, num_query_points, nlist, qargs);
 }
 

--- a/freud/diffraction/export-StaticStructureFactor.cc
+++ b/freud/diffraction/export-StaticStructureFactor.cc
@@ -19,9 +19,9 @@ namespace wrap {
 
 void accumulate(const std::shared_ptr<StaticStructureFactor>& self,
                 const std::shared_ptr<locality::NeighborQuery>& neighbor_query,
-                const nb_array<float, nanobind::shape<-1, 3>>& query_points, unsigned int n_total)
+                const nb_array<const float, nanobind::shape<-1, 3>>& query_points, unsigned int n_total)
 {
-    auto* query_points_data = reinterpret_cast<vec3<float>*>(query_points.data());
+    const auto* query_points_data = reinterpret_cast<const vec3<float>*>(query_points.data());
     const unsigned int n_query_points = query_points.shape(0);
     self->accumulate(neighbor_query, query_points_data, n_query_points, n_total);
 };

--- a/freud/environment/BondOrder.cc
+++ b/freud/environment/BondOrder.cc
@@ -100,8 +100,8 @@ std::shared_ptr<const util::ManagedArray<float>> BondOrder::getBondOrder()
 }
 
 void BondOrder::accumulate(const std::shared_ptr<locality::NeighborQuery>& neighbor_query,
-                           quat<float>* orientations, vec3<float>* query_points,
-                           quat<float>* query_orientations, unsigned int n_query_points,
+                           const quat<float>* orientations, const vec3<float>* query_points,
+                           const quat<float>* query_orientations, unsigned int n_query_points,
                            const std::shared_ptr<freud::locality::NeighborList>& nlist,
                            freud::locality::QueryArgs qargs)
 {

--- a/freud/environment/BondOrder.h
+++ b/freud/environment/BondOrder.h
@@ -41,8 +41,9 @@ public:
     ~BondOrder() override = default;
 
     //! Accumulate the bond order
-    void accumulate(const std::shared_ptr<locality::NeighborQuery>& neighbor_query, const quat<float>* orientations,
-                    const vec3<float>* query_points, const quat<float>* query_orientations, unsigned int n_query_points,
+    void accumulate(const std::shared_ptr<locality::NeighborQuery>& neighbor_query,
+                    const quat<float>* orientations, const vec3<float>* query_points,
+                    const quat<float>* query_orientations, unsigned int n_query_points,
                     const std::shared_ptr<freud::locality::NeighborList>& nlist,
                     freud::locality::QueryArgs qargs);
 

--- a/freud/environment/BondOrder.h
+++ b/freud/environment/BondOrder.h
@@ -41,8 +41,8 @@ public:
     ~BondOrder() override = default;
 
     //! Accumulate the bond order
-    void accumulate(const std::shared_ptr<locality::NeighborQuery>& neighbor_query, quat<float>* orientations,
-                    vec3<float>* query_points, quat<float>* query_orientations, unsigned int n_query_points,
+    void accumulate(const std::shared_ptr<locality::NeighborQuery>& neighbor_query, const quat<float>* orientations,
+                    const vec3<float>* query_points, const quat<float>* query_orientations, unsigned int n_query_points,
                     const std::shared_ptr<freud::locality::NeighborList>& nlist,
                     freud::locality::QueryArgs qargs);
 

--- a/freud/environment/export-AngularSeparationGlobal.cc
+++ b/freud/environment/export-AngularSeparationGlobal.cc
@@ -19,16 +19,16 @@ using nb_array = nanobind::ndarray<T, shape, nanobind::device::cpu, nanobind::c_
 
 namespace wrap {
 void compute(const std::shared_ptr<AngularSeparationGlobal>& angular_separation,
-             const nb_array<float, nanobind::shape<-1, 4>>& global_orientations,
-             const nb_array<float, nanobind::shape<-1, 4>>& orientations,
-             const nb_array<float, nanobind::shape<-1, 4>>& equiv_orientations)
+             const nb_array<const float, nanobind::shape<-1, 4>>& global_orientations,
+             const nb_array<const float, nanobind::shape<-1, 4>>& orientations,
+             const nb_array<const float, nanobind::shape<-1, 4>>& equiv_orientations)
 {
     unsigned int const n_global = global_orientations.shape(0);
     unsigned int const n_points = orientations.shape(0);
     unsigned int const n_equiv_orientations = equiv_orientations.shape(0);
-    auto* global_orientations_data = reinterpret_cast<quat<float>*>(global_orientations.data());
-    auto* orientations_data = reinterpret_cast<quat<float>*>(orientations.data());
-    auto* equiv_orientations_data = reinterpret_cast<quat<float>*>(equiv_orientations.data());
+    const auto* global_orientations_data = reinterpret_cast<const quat<float>*>(global_orientations.data());
+    const auto* orientations_data = reinterpret_cast<const quat<float>*>(orientations.data());
+    const auto* equiv_orientations_data = reinterpret_cast<const quat<float>*>(equiv_orientations.data());
     angular_separation->compute(global_orientations_data, n_global, orientations_data, n_points,
                                 equiv_orientations_data, n_equiv_orientations);
 }

--- a/freud/environment/export-BondOrder.cc
+++ b/freud/environment/export-BondOrder.cc
@@ -22,9 +22,9 @@ namespace wrap {
 
 void accumulateBondOrder(const std::shared_ptr<BondOrder>& self,
                          const std::shared_ptr<locality::NeighborQuery>& nq,
-                         const nb_array<float, nb::shape<-1, 4>>& orientations,
-                         const nb_array<float, nb::shape<-1, 3>>& query_points,
-                         const nb_array<float, nb::shape<-1, 4>>& query_orientations,
+                         const nb_array<const float, nb::shape<-1, 4>>& orientations,
+                         const nb_array<const float, nb::shape<-1, 3>>& query_points,
+                         const nb_array<const float, nb::shape<-1, 4>>& query_orientations,
                          const std::shared_ptr<locality::NeighborList>& nlist,
                          const locality::QueryArgs& qargs)
 {
@@ -38,9 +38,9 @@ void accumulateBondOrder(const std::shared_ptr<BondOrder>& self,
     //   auto* query_points_data= reinterpret_cast<vec3<float>*>(query_points.data());
     // }
 
-    auto* orientations_data = reinterpret_cast<quat<float>*>(orientations.data());
-    auto* query_points_data = reinterpret_cast<vec3<float>*>(query_points.data());
-    auto* query_orientations_data = reinterpret_cast<quat<float>*>(query_orientations.data());
+    const auto* orientations_data = reinterpret_cast<const quat<float>*>(orientations.data());
+    const auto* query_points_data = reinterpret_cast<const vec3<float>*>(query_points.data());
+    const auto* query_orientations_data = reinterpret_cast<const quat<float>*>(query_orientations.data());
 
     self->accumulate(nq, orientations_data, query_points_data, query_orientations_data, n_query_points, nlist,
                      qargs);

--- a/freud/environment/export-LocalDescriptors.cc
+++ b/freud/environment/export-LocalDescriptors.cc
@@ -22,13 +22,13 @@ using nb_array = nanobind::ndarray<T, shape, nanobind::device::cpu, nanobind::c_
 namespace wrap {
 void compute(const std::shared_ptr<LocalDescriptors>& local_descriptors,
              const std::shared_ptr<locality::NeighborQuery>& nq,
-             const nb_array<float, nanobind::shape<-1, 3>>& query_points, const unsigned int n_query_points,
-             const nb_array<float, nanobind::shape<-1, 4>>& orientations,
+             const nb_array<const float, nanobind::shape<-1, 3>>& query_points, const unsigned int n_query_points,
+             const nb_array<const float, nanobind::shape<-1, 4>>& orientations,
              const std::shared_ptr<locality::NeighborList>& nlist, const locality::QueryArgs& qargs,
              const unsigned int max_num_neighbors)
 {
-    auto* query_points_data = reinterpret_cast<vec3<float>*>(query_points.data());
-    auto* orientations_data = reinterpret_cast<quat<float>*>(orientations.data());
+    const auto* query_points_data = reinterpret_cast<const vec3<float>*>(query_points.data());
+    const auto* orientations_data = reinterpret_cast<const quat<float>*>(orientations.data());
     local_descriptors->compute(nq, query_points_data, n_query_points, orientations_data, nlist, qargs,
                                max_num_neighbors);
 }

--- a/freud/environment/export-LocalDescriptors.cc
+++ b/freud/environment/export-LocalDescriptors.cc
@@ -22,7 +22,8 @@ using nb_array = nanobind::ndarray<T, shape, nanobind::device::cpu, nanobind::c_
 namespace wrap {
 void compute(const std::shared_ptr<LocalDescriptors>& local_descriptors,
              const std::shared_ptr<locality::NeighborQuery>& nq,
-             const nb_array<const float, nanobind::shape<-1, 3>>& query_points, const unsigned int n_query_points,
+             const nb_array<const float, nanobind::shape<-1, 3>>& query_points,
+             const unsigned int n_query_points,
              const nb_array<const float, nanobind::shape<-1, 4>>& orientations,
              const std::shared_ptr<locality::NeighborList>& nlist, const locality::QueryArgs& qargs,
              const unsigned int max_num_neighbors)

--- a/freud/environment/export-MatchEnv.cc
+++ b/freud/environment/export-MatchEnv.cc
@@ -31,10 +31,10 @@ void compute_env_motif_match(const std::shared_ptr<EnvironmentMotifMatch>& env_m
                              const std::shared_ptr<locality::NeighborQuery>& nq,
                              const std::shared_ptr<locality::NeighborList>& nlist,
                              const locality::QueryArgs& qargs,
-                             const nb_array<float, nanobind::shape<-1, 3>>& motif,
+                             const nb_array<const float, nanobind::shape<-1, 3>>& motif,
                              const unsigned int motif_size, const float threshold, const bool registration)
 {
-    auto* motif_data = reinterpret_cast<vec3<float>*>(motif.data());
+    const auto* motif_data = reinterpret_cast<const vec3<float>*>(motif.data());
     env_motif_match->compute(nq, nlist, qargs, motif_data, motif_size, threshold, registration);
 }
 
@@ -42,20 +42,20 @@ void compute_env_rmsd_min(const std::shared_ptr<EnvironmentRMSDMinimizer>& env_r
                           const std::shared_ptr<locality::NeighborQuery>& nq,
                           const std::shared_ptr<locality::NeighborList>& nlist,
                           const locality::QueryArgs& qargs,
-                          const nb_array<float, nanobind::shape<-1, 3>>& motif, const unsigned int motif_size,
+                          const nb_array<const float, nanobind::shape<-1, 3>>& motif, const unsigned int motif_size,
                           const bool registration)
 {
-    auto* motif_data = reinterpret_cast<vec3<float>*>(motif.data());
+    const auto* motif_data = reinterpret_cast<const vec3<float>*>(motif.data());
     env_rmsd_min->compute(nq, nlist, qargs, motif_data, motif_size, registration);
 }
 
 std::pair<float, std::map<unsigned int, unsigned int>>
-compute_minimize_RMSD(const box::Box& box, const nb_array<float, nanobind::shape<-1, 3>>& refPoints1,
+compute_minimize_RMSD(const box::Box& box, const nb_array<const float, nanobind::shape<-1, 3>>& refPoints1,
                       nb_array<float, nanobind::shape<-1, 3>>& refPoints2, unsigned int numRef,
                       float min_rmsd, bool registration)
 {
     float min_rmsd_modified = min_rmsd;
-    auto* refPoints1_data = reinterpret_cast<vec3<float>*>(refPoints1.data());
+    const auto* refPoints1_data = reinterpret_cast<const vec3<float>*>(refPoints1.data());
     auto* refPoints2_data = reinterpret_cast<vec3<float>*>(refPoints2.data());
     return std::make_pair(
         min_rmsd_modified,
@@ -63,11 +63,11 @@ compute_minimize_RMSD(const box::Box& box, const nb_array<float, nanobind::shape
 }
 
 std::map<unsigned int, unsigned int>
-compute_is_similar(const box::Box& box, const nb_array<float, nanobind::shape<-1, 3>>& refPoints1,
+compute_is_similar(const box::Box& box, const nb_array<const float, nanobind::shape<-1, 3>>& refPoints1,
                    nb_array<float, nanobind::shape<-1, 3>>& refPoints2, unsigned int numRef,
                    float threshold_sq, bool registration)
 {
-    auto* refPoints1_data = reinterpret_cast<vec3<float>*>(refPoints1.data());
+    const auto* refPoints1_data = reinterpret_cast<const vec3<float>*>(refPoints1.data());
     auto* refPoints2_data = reinterpret_cast<vec3<float>*>(refPoints2.data());
     return isSimilar(box, refPoints1_data, refPoints2_data, numRef, threshold_sq, registration);
 }

--- a/freud/environment/export-MatchEnv.cc
+++ b/freud/environment/export-MatchEnv.cc
@@ -42,8 +42,8 @@ void compute_env_rmsd_min(const std::shared_ptr<EnvironmentRMSDMinimizer>& env_r
                           const std::shared_ptr<locality::NeighborQuery>& nq,
                           const std::shared_ptr<locality::NeighborList>& nlist,
                           const locality::QueryArgs& qargs,
-                          const nb_array<const float, nanobind::shape<-1, 3>>& motif, const unsigned int motif_size,
-                          const bool registration)
+                          const nb_array<const float, nanobind::shape<-1, 3>>& motif,
+                          const unsigned int motif_size, const bool registration)
 {
     const auto* motif_data = reinterpret_cast<const vec3<float>*>(motif.data());
     env_rmsd_min->compute(nq, nlist, qargs, motif_data, motif_size, registration);

--- a/freud/locality/export-Filter.cc
+++ b/freud/locality/export-Filter.cc
@@ -25,11 +25,11 @@ using nb_array = nanobind::ndarray<T, shape, nanobind::device::cpu, nanobind::c_
 namespace wrap {
 
 void compute(const std::shared_ptr<Filter>& filter, std::shared_ptr<NeighborQuery> nq,
-             const nb_array<float, nb::shape<-1, 3>>& query_points, std::shared_ptr<NeighborList> nlist,
+             const nb_array<const float, nb::shape<-1, 3>>& query_points, std::shared_ptr<NeighborList> nlist,
              const QueryArgs& qargs)
 {
     const auto num_query_points = query_points.shape(0);
-    const auto* query_points_data = (vec3<float>*) query_points.data();
+    const auto* query_points_data = (const vec3<float>*) query_points.data();
     filter->compute(std::move(nq), query_points_data, num_query_points, std::move(nlist), qargs);
 }
 

--- a/freud/locality/export-NeighborList.cc
+++ b/freud/locality/export-NeighborList.cc
@@ -21,10 +21,11 @@ using nb_array = nanobind::ndarray<T, shape, nanobind::device::cpu, nanobind::c_
 
 namespace wrap {
 
-void ConstructFromArrays(NeighborList* nlist, const nb_array<const unsigned int, nb::ndim<1>>& query_point_indices,
+void ConstructFromArrays(NeighborList* nlist,
+                         const nb_array<const unsigned int, nb::ndim<1>>& query_point_indices,
                          unsigned int num_query_points,
-                         const nb_array<const unsigned int, nb::ndim<1>>& point_indices, unsigned int num_points,
-                         const nb_array<const float, nb::shape<-1, 3>>& vectors,
+                         const nb_array<const unsigned int, nb::ndim<1>>& point_indices,
+                         unsigned int num_points, const nb_array<const float, nb::shape<-1, 3>>& vectors,
                          const nb_array<const float, nb::ndim<1>>& weights)
 {
     const unsigned int num_bonds = query_point_indices.shape(0);
@@ -47,7 +48,8 @@ void ConstructAllPairs(NeighborList* nlist, const nb_array<const float, nb::shap
     new (nlist) NeighborList(points_data, query_points_data, box, exclude_ii, num_points, num_query_points);
 }
 
-unsigned int filter(const std::shared_ptr<NeighborList>& nlist, const nb_array<const bool, nb::ndim<1>>& filter)
+unsigned int filter(const std::shared_ptr<NeighborList>& nlist,
+                    const nb_array<const bool, nb::ndim<1>>& filter)
 {
     const bool* filter_data = (const bool*) filter.data();
     return nlist->filter(filter_data);

--- a/freud/locality/export-NeighborList.cc
+++ b/freud/locality/export-NeighborList.cc
@@ -21,11 +21,11 @@ using nb_array = nanobind::ndarray<T, shape, nanobind::device::cpu, nanobind::c_
 
 namespace wrap {
 
-void ConstructFromArrays(NeighborList* nlist, const nb_array<unsigned int, nb::ndim<1>>& query_point_indices,
+void ConstructFromArrays(NeighborList* nlist, const nb_array<const unsigned int, nb::ndim<1>>& query_point_indices,
                          unsigned int num_query_points,
-                         const nb_array<unsigned int, nb::ndim<1>>& point_indices, unsigned int num_points,
-                         const nb_array<float, nb::shape<-1, 3>>& vectors,
-                         const nb_array<float, nb::ndim<1>>& weights)
+                         const nb_array<const unsigned int, nb::ndim<1>>& point_indices, unsigned int num_points,
+                         const nb_array<const float, nb::shape<-1, 3>>& vectors,
+                         const nb_array<const float, nb::ndim<1>>& weights)
 {
     const unsigned int num_bonds = query_point_indices.shape(0);
     const auto* query_point_indices_data = (const unsigned int*) query_point_indices.data();
@@ -36,8 +36,8 @@ void ConstructFromArrays(NeighborList* nlist, const nb_array<unsigned int, nb::n
                              num_points, vectors_data, weights_data);
 }
 
-void ConstructAllPairs(NeighborList* nlist, const nb_array<float, nb::shape<-1, 3>>& points,
-                       const nb_array<float, nb::shape<-1, 3>>& query_points, const box::Box& box,
+void ConstructAllPairs(NeighborList* nlist, const nb_array<const float, nb::shape<-1, 3>>& points,
+                       const nb_array<const float, nb::shape<-1, 3>>& query_points, const box::Box& box,
                        const bool exclude_ii)
 {
     const unsigned int num_points = points.shape(0);
@@ -47,7 +47,7 @@ void ConstructAllPairs(NeighborList* nlist, const nb_array<float, nb::shape<-1, 
     new (nlist) NeighborList(points_data, query_points_data, box, exclude_ii, num_points, num_query_points);
 }
 
-unsigned int filter(const std::shared_ptr<NeighborList>& nlist, const nb_array<bool, nb::ndim<1>>& filter)
+unsigned int filter(const std::shared_ptr<NeighborList>& nlist, const nb_array<const bool, nb::ndim<1>>& filter)
 {
     const bool* filter_data = (const bool*) filter.data();
     return nlist->filter(filter_data);

--- a/freud/locality/export-NeighborQuery.cc
+++ b/freud/locality/export-NeighborQuery.cc
@@ -31,22 +31,24 @@ std::shared_ptr<NeighborQueryIterator> query(const std::shared_ptr<NeighborQuery
     return nq->query(query_points_data, n_query_points, qargs);
 }
 
-void AABBQueryConstructor(AABBQuery* nq, const box::Box& box, const nb_array<const float, nb::shape<-1, 3>>& points)
+void AABBQueryConstructor(AABBQuery* nq, const box::Box& box,
+                          const nb_array<const float, nb::shape<-1, 3>>& points)
 {
     unsigned int const n_points = points.shape(0);
     const auto* points_data = (const vec3<float>*) points.data();
     new (nq) AABBQuery(box, points_data, n_points);
 }
 
-void LinkCellConstructor(LinkCell* nq, const box::Box& box, const nb_array<const float, nb::shape<-1, 3>>& points,
-                         float cell_width)
+void LinkCellConstructor(LinkCell* nq, const box::Box& box,
+                         const nb_array<const float, nb::shape<-1, 3>>& points, float cell_width)
 {
     unsigned int const n_points = points.shape(0);
     const auto* points_data = (const vec3<float>*) points.data();
     new (nq) LinkCell(box, points_data, n_points, cell_width);
 }
 
-void RawPointsConstructor(RawPoints* nq, const box::Box& box, const nb_array<const float, nb::shape<-1, 3>>& points)
+void RawPointsConstructor(RawPoints* nq, const box::Box& box,
+                          const nb_array<const float, nb::shape<-1, 3>>& points)
 {
     unsigned int const n_points = points.shape(0);
     const auto* points_data = (vec3<float>*) points.data();

--- a/freud/locality/export-NeighborQuery.cc
+++ b/freud/locality/export-NeighborQuery.cc
@@ -27,7 +27,7 @@ std::shared_ptr<NeighborQueryIterator> query(const std::shared_ptr<NeighborQuery
                                              const QueryArgs& qargs)
 {
     unsigned int const n_query_points = query_points.shape(0);
-    const vec3<float>* query_points_data = (const vec3<float>*) query_points.data();
+    const auto* query_points_data = (const vec3<float>*) query_points.data();
     return nq->query(query_points_data, n_query_points, qargs);
 }
 

--- a/freud/locality/export-NeighborQuery.cc
+++ b/freud/locality/export-NeighborQuery.cc
@@ -23,33 +23,33 @@ namespace freud { namespace locality {
 namespace wrap {
 
 std::shared_ptr<NeighborQueryIterator> query(const std::shared_ptr<NeighborQuery>& nq,
-                                             const nb_array<float, nb::shape<-1, 3>>& query_points,
+                                             const nb_array<const float, nb::shape<-1, 3>>& query_points,
                                              const QueryArgs& qargs)
 {
     unsigned int const n_query_points = query_points.shape(0);
-    const vec3<float>* query_points_data = (vec3<float>*) query_points.data();
+    const vec3<float>* query_points_data = (const vec3<float>*) query_points.data();
     return nq->query(query_points_data, n_query_points, qargs);
 }
 
-void AABBQueryConstructor(AABBQuery* nq, const box::Box& box, const nb_array<float, nb::shape<-1, 3>>& points)
+void AABBQueryConstructor(AABBQuery* nq, const box::Box& box, const nb_array<const float, nb::shape<-1, 3>>& points)
 {
     unsigned int const n_points = points.shape(0);
-    auto* points_data = (vec3<float>*) points.data();
+    const auto* points_data = (const vec3<float>*) points.data();
     new (nq) AABBQuery(box, points_data, n_points);
 }
 
-void LinkCellConstructor(LinkCell* nq, const box::Box& box, const nb_array<float, nb::shape<-1, 3>>& points,
+void LinkCellConstructor(LinkCell* nq, const box::Box& box, const nb_array<const float, nb::shape<-1, 3>>& points,
                          float cell_width)
 {
     unsigned int const n_points = points.shape(0);
-    auto* points_data = (vec3<float>*) points.data();
+    const auto* points_data = (const vec3<float>*) points.data();
     new (nq) LinkCell(box, points_data, n_points, cell_width);
 }
 
-void RawPointsConstructor(RawPoints* nq, const box::Box& box, const nb_array<float, nb::shape<-1, 3>>& points)
+void RawPointsConstructor(RawPoints* nq, const box::Box& box, const nb_array<const float, nb::shape<-1, 3>>& points)
 {
     unsigned int const n_points = points.shape(0);
-    auto* points_data = (vec3<float>*) points.data();
+    const auto* points_data = (vec3<float>*) points.data();
     new (nq) RawPoints(box, points_data, n_points);
 }
 

--- a/freud/order/Cubatic.cc
+++ b/freud/order/Cubatic.cc
@@ -161,7 +161,7 @@ Cubatic::Cubatic(float t_initial, float t_final, float scale, unsigned int n_rep
     m_system_vectors[2] = vec3<float>(0, 0, 1);
 }
 
-tensor4 Cubatic::calcCubaticTensor(quat<float>& orientation)
+tensor4 Cubatic::calcCubaticTensor(const quat<float>& orientation)
 {
     tensor4 calculated_tensor = tensor4();
     for (auto& m_system_vector : m_system_vectors)
@@ -214,7 +214,7 @@ util::ManagedArray<tensor4> Cubatic::calculatePerParticleTensor(const quat<float
     return particle_tensor;
 }
 
-tensor4 Cubatic::calculateGlobalTensor(quat<float>* orientations) const
+tensor4 Cubatic::calculateGlobalTensor(const quat<float>* orientations) const
 {
     tensor4 global_tensor = tensor4();
     util::ManagedArray<tensor4> particle_tensor = calculatePerParticleTensor(orientations);
@@ -241,7 +241,7 @@ tensor4 Cubatic::calculateGlobalTensor(quat<float>* orientations) const
     return global_tensor - m_gen_r4_tensor;
 }
 
-void Cubatic::compute(quat<float>* orientations, unsigned int num_orientations)
+void Cubatic::compute(const quat<float>* orientations, unsigned int num_orientations)
 {
     m_n = num_orientations;
     m_particle_order_parameter = std::make_shared<util::ManagedArray<float>>(std::vector<size_t> {m_n});

--- a/freud/order/Cubatic.h
+++ b/freud/order/Cubatic.h
@@ -65,7 +65,7 @@ public:
     void reset();
 
     //! Compute the cubatic order parameter
-    void compute(quat<float>* orientations, unsigned int num_orientations);
+    void compute(const quat<float>* orientations, unsigned int num_orientations);
 
     unsigned int getNumParticles() const
     {
@@ -132,7 +132,7 @@ private:
      *
      *  \return The cubatic tensor M_{\omega}.
      */
-    tensor4 calcCubaticTensor(quat<float>& orientation);
+    tensor4 calcCubaticTensor(const quat<float>& orientation);
 
     //! Calculate the scalar cubatic order parameter.
     /*! Implements eq. 22.
@@ -156,7 +156,7 @@ private:
     //! Calculate the global tensor for the system.
     /*! Implements the third line of eq. 27, the calculation of \bar{M}.
      */
-    tensor4 calculateGlobalTensor(quat<float>* orientations) const;
+    tensor4 calculateGlobalTensor(const quat<float>* orientations) const;
 
     //! Calculate a random quaternion.
     /*! To calculate a random quaternion in a way that obeys the right

--- a/freud/order/Nematic.cc
+++ b/freud/order/Nematic.cc
@@ -43,7 +43,7 @@ vec3<float> Nematic::getNematicDirector() const
     return m_nematic_director;
 }
 
-void Nematic::compute(vec3<float>* orientations, unsigned int n)
+void Nematic::compute(const vec3<float>* orientations, unsigned int n)
 {
     m_n = n;
     m_particle_tensor = std::make_shared<util::ManagedArray<float>>(std::vector<size_t> {m_n, 3, 3});

--- a/freud/order/Nematic.h
+++ b/freud/order/Nematic.h
@@ -34,7 +34,7 @@ public:
     virtual ~Nematic() = default;
 
     //! Compute the nematic order parameter
-    void compute(vec3<float>* orientations, unsigned int n);
+    void compute(const vec3<float>* orientations, unsigned int n);
 
     //! Get the value of the last computed nematic order parameter
     float getNematicOrderParameter() const;

--- a/freud/order/export-Cubatic.cc
+++ b/freud/order/export-Cubatic.cc
@@ -17,10 +17,10 @@ using nb_array = nanobind::ndarray<T, shape, nanobind::device::cpu, nanobind::c_
 namespace wrap {
 
 void computeCubatic(const std::shared_ptr<Cubatic>& self,
-                    const nb_array<float, nanobind::shape<-1, 4>>& orientations)
+                    const nb_array<const float, nanobind::shape<-1, 4>>& orientations)
 {
     unsigned int const num_orientations = orientations.shape(0);
-    auto* orientations_data = reinterpret_cast<quat<float>*>(orientations.data());
+    const auto* orientations_data = reinterpret_cast<const quat<float>*>(orientations.data());
 
     self->compute(orientations_data, num_orientations);
 }

--- a/freud/order/export-Nematic.cc
+++ b/freud/order/export-Nematic.cc
@@ -18,10 +18,10 @@ using nb_array = nanobind::ndarray<T, shape, nanobind::device::cpu, nanobind::c_
 namespace wrap {
 
 void computeNematic(const std::shared_ptr<Nematic>& self,
-                    const nb_array<float, nanobind::shape<-1, 3>>& orientations)
+                    const nb_array<const float, nanobind::shape<-1, 3>>& orientations)
 {
     unsigned int const num_orientations = orientations.shape(0);
-    auto* orientations_data = reinterpret_cast<vec3<float>*>(orientations.data());
+    const auto* orientations_data = reinterpret_cast<const vec3<float>*>(orientations.data());
 
     self->compute(orientations_data, num_orientations);
 }

--- a/freud/order/export-RotationalAutocorrelation.cc
+++ b/freud/order/export-RotationalAutocorrelation.cc
@@ -17,12 +17,12 @@ using nb_array = nanobind::ndarray<T, shape, nanobind::device::cpu, nanobind::c_
 namespace wrap {
 
 void computeRotationalAutocorrelation(const std::shared_ptr<RotationalAutocorrelation>& self,
-                                      const nb_array<float, nanobind::shape<-1, 4>>& ref_orientations,
-                                      const nb_array<float, nanobind::shape<-1, 4>>& orientations)
+                                      const nb_array<const float, nanobind::shape<-1, 4>>& ref_orientations,
+                                      const nb_array<const float, nanobind::shape<-1, 4>>& orientations)
 {
     unsigned int const num_orientations = orientations.shape(0);
-    auto* ref_orientations_data = reinterpret_cast<quat<float>*>(ref_orientations.data());
-    auto* orientations_data = reinterpret_cast<quat<float>*>(orientations.data());
+    const auto* ref_orientations_data = reinterpret_cast<const quat<float>*>(ref_orientations.data());
+    const auto* orientations_data = reinterpret_cast<const quat<float>*>(orientations.data());
 
     self->compute(ref_orientations_data, orientations_data, num_orientations);
 }

--- a/freud/pmft/export-PMFTR12.cc
+++ b/freud/pmft/export-PMFTR12.cc
@@ -22,15 +22,15 @@ using nb_array = nanobind::ndarray<T, shape, nanobind::device::cpu, nanobind::c_
 namespace wrap {
 
 void accumulateR12(const std::shared_ptr<PMFTR12>& self, const std::shared_ptr<locality::NeighborQuery>& nq,
-                   const nb_array<float, nanobind::shape<-1>>& orientations,
-                   const nb_array<float, nanobind::shape<-1, 3>>& query_points,
-                   const nb_array<float, nanobind::shape<-1>>& query_orientations,
+                   const nb_array<const float, nanobind::shape<-1>>& orientations,
+                   const nb_array<const float, nanobind::shape<-1, 3>>& query_points,
+                   const nb_array<const float, nanobind::shape<-1>>& query_orientations,
                    std::shared_ptr<locality::NeighborList> nlist, const locality::QueryArgs& qargs)
 {
     unsigned int const num_query_points = query_points.shape(0);
-    auto* orientations_data = reinterpret_cast<float*>(orientations.data());
-    auto* query_orientations_data = reinterpret_cast<float*>(query_orientations.data());
-    auto* query_points_data = reinterpret_cast<vec3<float>*>(query_points.data());
+    const auto* orientations_data = reinterpret_cast<const float*>(orientations.data());
+    const auto* query_orientations_data = reinterpret_cast<const float*>(query_orientations.data());
+    const auto* query_points_data = reinterpret_cast<const vec3<float>*>(query_points.data());
     self->accumulate(nq, orientations_data, query_points_data, query_orientations_data, num_query_points,
                      std::move(nlist), qargs);
 }

--- a/freud/pmft/export-PMFTXY.cc
+++ b/freud/pmft/export-PMFTXY.cc
@@ -23,13 +23,13 @@ using nb_array = nanobind::ndarray<T, shape, nanobind::device::cpu, nanobind::c_
 namespace wrap {
 
 void accumulateXY(const std::shared_ptr<PMFTXY>& self, const std::shared_ptr<locality::NeighborQuery>& nq,
-                  const nb_array<float, nanobind::shape<-1>>& query_orientations,
-                  const nb_array<float, nanobind::shape<-1, 3>>& query_points,
+                  const nb_array<const float, nanobind::shape<-1>>& query_orientations,
+                  const nb_array<const float, nanobind::shape<-1, 3>>& query_points,
                   std::shared_ptr<locality::NeighborList> nlist, const locality::QueryArgs& qargs)
 {
     unsigned int const num_query_points = query_points.shape(0);
-    auto* query_orientations_data = reinterpret_cast<float*>(query_orientations.data());
-    auto* query_points_data = reinterpret_cast<vec3<float>*>(query_points.data());
+    const auto* query_orientations_data = reinterpret_cast<const float*>(query_orientations.data());
+    const auto* query_points_data = reinterpret_cast<const vec3<float>*>(query_points.data());
     self->accumulate(nq, query_orientations_data, query_points_data, num_query_points, std::move(nlist),
                      qargs);
 }

--- a/freud/pmft/export-PMFTXYT.cc
+++ b/freud/pmft/export-PMFTXYT.cc
@@ -22,15 +22,15 @@ using nb_array = nanobind::ndarray<T, shape, nanobind::device::cpu, nanobind::c_
 namespace wrap {
 
 void accumulateR12(const std::shared_ptr<PMFTXYT>& self, const std::shared_ptr<locality::NeighborQuery>& nq,
-                   const nb_array<float, nanobind::shape<-1>>& orientations,
-                   const nb_array<float, nanobind::shape<-1, 3>>& query_points,
-                   const nb_array<float, nanobind::shape<-1>>& query_orientations,
+                   const nb_array<const float, nanobind::shape<-1>>& orientations,
+                   const nb_array<const float, nanobind::shape<-1, 3>>& query_points,
+                   const nb_array<const float, nanobind::shape<-1>>& query_orientations,
                    std::shared_ptr<locality::NeighborList> nlist, const locality::QueryArgs& qargs)
 {
     unsigned int const num_query_points = query_points.shape(0);
-    auto* orientations_data = reinterpret_cast<float*>(orientations.data());
-    auto* query_orientations_data = reinterpret_cast<float*>(query_orientations.data());
-    auto* query_points_data = reinterpret_cast<vec3<float>*>(query_points.data());
+    const auto* orientations_data = reinterpret_cast<const float*>(orientations.data());
+    const auto* query_orientations_data = reinterpret_cast<const float*>(query_orientations.data());
+    const auto* query_points_data = reinterpret_cast<const vec3<float>*>(query_points.data());
     self->accumulate(nq, orientations_data, query_points_data, query_orientations_data, num_query_points,
                      std::move(nlist), qargs);
 }

--- a/freud/pmft/export-PMFTXYZ.cc
+++ b/freud/pmft/export-PMFTXYZ.cc
@@ -22,15 +22,15 @@ using nb_array = nanobind::ndarray<T, shape, nanobind::device::cpu, nanobind::c_
 namespace wrap {
 
 void accumulateXYZ(const std::shared_ptr<PMFTXYZ>& self, const std::shared_ptr<locality::NeighborQuery>& nq,
-                   const nb_array<float, nanobind::shape<-1, 4>>& query_orientations,
-                   const nb_array<float, nanobind::shape<-1, 3>>& query_points,
-                   const nb_array<float, nanobind::shape<-1, 4>>& equivalent_orientations,
+                   const nb_array<const float, nanobind::shape<-1, 4>>& query_orientations,
+                   const nb_array<const float, nanobind::shape<-1, 3>>& query_points,
+                   const nb_array<const float, nanobind::shape<-1, 4>>& equivalent_orientations,
                    std::shared_ptr<locality::NeighborList> nlist, const locality::QueryArgs& qargs)
 {
     unsigned int const num_query_points = query_points.shape(0);
-    auto* query_orientations_data = reinterpret_cast<quat<float>*>(query_orientations.data());
-    auto* query_points_data = reinterpret_cast<vec3<float>*>(query_points.data());
-    auto* equivalent_orientations_data = reinterpret_cast<quat<float>*>(equivalent_orientations.data());
+    const auto* query_orientations_data = reinterpret_cast<const quat<float>*>(query_orientations.data());
+    const auto* query_points_data = reinterpret_cast<const vec3<float>*>(query_points.data());
+    const auto* equivalent_orientations_data = reinterpret_cast<const quat<float>*>(equivalent_orientations.data());
     unsigned int const num_equivalent_orientations = equivalent_orientations.shape(0);
     self->accumulate(nq, query_orientations_data, query_points_data, num_query_points,
                      equivalent_orientations_data, num_equivalent_orientations, std::move(nlist), qargs);

--- a/freud/pmft/export-PMFTXYZ.cc
+++ b/freud/pmft/export-PMFTXYZ.cc
@@ -30,7 +30,8 @@ void accumulateXYZ(const std::shared_ptr<PMFTXYZ>& self, const std::shared_ptr<l
     unsigned int const num_query_points = query_points.shape(0);
     const auto* query_orientations_data = reinterpret_cast<const quat<float>*>(query_orientations.data());
     const auto* query_points_data = reinterpret_cast<const vec3<float>*>(query_points.data());
-    const auto* equivalent_orientations_data = reinterpret_cast<const quat<float>*>(equivalent_orientations.data());
+    const auto* equivalent_orientations_data
+        = reinterpret_cast<const quat<float>*>(equivalent_orientations.data());
     unsigned int const num_equivalent_orientations = equivalent_orientations.shape(0);
     self->accumulate(nq, query_orientations_data, query_points_data, num_query_points,
                      equivalent_orientations_data, num_equivalent_orientations, std::move(nlist), qargs);


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above. -->

## Description
<!-- Describe your changes in detail. -->
Add const where appropriate to ndarray data types.

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- Replace ??? with the issue number that this pull request resolves, if applicable. -->
This allows users to call freud methods with numpy arrays that have the writeable flag set to false.

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to
     see how your changes affect other areas of the code, etc. -->
Box::wrap is tested offline with unit tests from another tool.

Other methods are not exhaustively tested, but are assumed to work. The C++ compiler validates the const-correctness of the code, and adding `const` only widens the number of types accepted. We cannot be sure we found *all* the places where `const` can be added.

## TODO

- [x] Apply similar changes to all methods in `export-*` files.

## Checklist:
- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/freud/blob/main/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Freud Contributor Agreement**](https://github.com/glotzerlab/freud/blob/main/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/freud/blob/main/doc/source/reference/credits.rst) in the pull request source branch.
- [x] I have updated the [Change log](https://github.com/glotzerlab/freud/blob/main/ChangeLog.md).
