### PR TITLE
Update type hinting in `data/UnitCell`

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog] and this project adheres to
 [Keep a ChangeLog]: https://keepachangelog.com/en/1.0.0/
 [Semantic Versioning]: https://semver.org/spec/v2.0.0.html
 
+## 3.X.X -- XXXX-XX-XX
+
+### Fixed
+* Type hinting in `UnitCell` no longer infers incorrect type.
+
 ## 3.3.1 -- 2025-04-28
 
 ### Fixed

--- a/freud/data.py
+++ b/freud/data.py
@@ -43,10 +43,10 @@ class UnitCell:
 
     def generate_system(
         self,
-        num_replicas: tuple[int, int, int] | int = 1,
-        scale: float = 1.0,
-        sigma_noise: float = 0.0,
-        seed: int | None = None,
+        num_replicas=1,
+        scale=1.0,
+        sigma_noise=0.0,
+        seed=None,
     ):
         """Generate a system from the unit cell.
 

--- a/freud/data.py
+++ b/freud/data.py
@@ -41,7 +41,13 @@ class UnitCell:
         self._box = freud.box.Box.from_box(box)
         self._basis_positions = basis_positions
 
-    def generate_system(self, num_replicas=1, scale=1, sigma_noise=0, seed=None):
+    def generate_system(
+        self,
+        num_replicas: tuple[int, int, int] | int = 1,
+        scale: float = 1.0,
+        sigma_noise: float = 0.0,
+        seed: int | None = None,
+    ):
         """Generate a system from the unit cell.
 
         The box and the positions are expanded by ``scale``, and then Gaussian


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above. -->

## Description

The default value for `sigma_noise` was an integer, even though the docstrings (and internal code) specify a float. This update prevents type annotation systems from raising a warning by setting the defaults to the appropriate type.


## Checklist:
- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/freud/blob/main/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Freud Contributor Agreement**](https://github.com/glotzerlab/freud/blob/main/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/freud/blob/main/doc/source/reference/credits.rst) in the pull request source branch.
- [x] I have updated the [Change log](https://github.com/glotzerlab/freud/blob/main/ChangeLog.md).
