### PR TITLE
Different SLDs for Diffraction Pattern

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog] and this project adheres to
 [Keep a ChangeLog]: https://keepachangelog.com/en/1.0.0/
 [Semantic Versioning]: https://semver.org/spec/v2.0.0.html
 
+## 3.3.2 -- tbd.
+### Added
+* SLD for computation of the Diffraction Pattern.
+
+
 ## 3.3.1 -- 2025-04-28
 
 ### Fixed

--- a/doc/source/reference/credits.rst
+++ b/doc/source/reference/credits.rst
@@ -25,6 +25,7 @@ The following people contributed to the development of freud:
 * Emily Siew, University of Michigan
 * Eric Harper, University of Michigan
 * Erin Teich, University of Michigan
+* Fabian Prandl, University of Tübingen
 * Gabby Jones, University of Michigan
 * Greg van Anders, University of Michigan
 * James Antonaglia, University of Michigan

--- a/freud/diffraction.py
+++ b/freud/diffraction.py
@@ -13,6 +13,7 @@ finalized in a future release.
 """
 
 import logging
+from importlib.util import find_spec
 
 import numpy as np
 import rowan
@@ -22,6 +23,15 @@ import freud._diffraction
 import freud.locality
 import freud.util
 from freud.util import _Compute
+
+_HAS_MPL = find_spec("matplotlib") is not None
+if _HAS_MPL:
+    import matplotlib.cm
+    import matplotlib.colors
+
+    import freud.plot
+else:
+    msg_mpl = "Plotting requires matplotlib."
 
 logger = logging.getLogger(__name__)
 
@@ -55,8 +65,6 @@ class _StaticStructureFactor(_Compute):
 
     def _repr_png_(self):
         try:
-            import freud.plot
-
             return freud.plot._ax_to_bytes(self.plot())
         except (AttributeError, ImportError):
             return None
@@ -260,8 +268,8 @@ class StaticStructureFactorDebye(_StaticStructureFactor):
         Returns:
             (:class:`matplotlib.axes.Axes`): Axis with the plot.
         """
-        import freud.plot
-
+        if not _HAS_MPL:
+            raise ImportError(msg_mpl)
         return freud.plot.line_plot(
             self.k_values[self.k_values > self.min_valid_k],
             self.S_k[self.k_values > self.min_valid_k],
@@ -500,8 +508,8 @@ class StaticStructureFactorDirect(_StaticStructureFactor):
         Returns:
             (:class:`matplotlib.axes.Axes`): Axis with the plot.
         """
-        import freud.plot
-
+        if not _HAS_MPL:
+            raise ImportError(msg_mpl)
         return freud.plot.line_plot(
             self.bin_centers[self.bin_centers > self.min_valid_k],
             self.S_k[self.bin_centers > self.min_valid_k],
@@ -692,11 +700,12 @@ class DiffractionPattern(_Compute):
                 Width of Gaussian convolved with points, in system length units
                 (Default value = 1).
             weights ((:math:`N`,) :class:`numpy.ndarray`, optional):
-                SLD weights for each point in the system. If provided, the
-                diffraction pattern will be normalized such that the sum of the
-                weights is equal to the number of points in the system, resulting in
-                :math:`S(0) = N`. If not provided, all points are assumed to
-                have a weight of 1. (Default value = :code:`None`).
+                Scattering length density (SLD) weights for each point in the system.
+                If provided, the diffraction pattern will be normalized such
+                that the sum of the weights is equal to the number of points in
+                the system, resulting in :math:`S(0) = N`. If not provided,
+                all points are assumed to have a weight of 1.
+                (Default value = :code:`None`).
             reset (bool, optional):
                 Whether to erase the previously computed values before adding
                 the new computations; if False, will accumulate data (Default
@@ -849,15 +858,12 @@ class DiffractionPattern(_Compute):
             ((output_size, output_size, 4) :class:`numpy.ndarray`):
                 RGBA array of pixels.
         """
-        import matplotlib.cm
-        import matplotlib.colors
-
+        if not _HAS_MPL:
+            raise ImportError(msg_mpl)
         if vmin is None:
             vmin = 4e-6 * self.N_points
-
         if vmax is None:
             vmax = 0.7 * self.N_points
-
         norm = matplotlib.colors.LogNorm(vmin=vmin, vmax=vmax)
         cmap = matplotlib.colormaps[cmap]
         image = cmap(norm(np.clip(self.diffraction, vmin, vmax)))
@@ -882,22 +888,18 @@ class DiffractionPattern(_Compute):
         Returns:
             (:class:`matplotlib.axes.Axes`): Axis with the plot.
         """
+        if not _HAS_MPL:
+            raise ImportError(msg_mpl)
         if vmin is None:
             vmin = 4e-6 * self.N_points
-
         if vmax is None:
             vmax = 0.7 * self.N_points
-
-        import freud.plot
-
         return freud.plot.diffraction_plot(
             self.diffraction, self.k_values, self.N_points, ax, cmap, vmin, vmax
         )
 
     def _repr_png_(self):
         try:
-            import freud.plot
-
             return freud.plot._ax_to_bytes(self.plot())
         except (AttributeError, ImportError):
             return None

--- a/tests/test_diffraction_diffraction_pattern.py
+++ b/tests/test_diffraction_diffraction_pattern.py
@@ -245,14 +245,13 @@ class TestDiffractionPattern:
         weights = np.random.uniform(0, 10, N)
         dp = freud.diffraction.DiffractionPattern(grid_size=256)
         weighted_diffraction = dp.compute((box, positions), weights=weights, reset=True)
-        
+
         assert np.allclose(weighted_diffraction.diffraction[128, 128], len(positions))
 
         dp = freud.diffraction.DiffractionPattern(grid_size=256)
 
         unweighted_diffraction = dp.compute((box, positions), reset=True)
-        
-        assert (unweighted_diffraction.diffraction != weighted_diffraction.diffraction).any()
-        
-        
-        
+
+        assert (
+            unweighted_diffraction.diffraction != weighted_diffraction.diffraction
+        ).any()

--- a/tests/test_diffraction_diffraction_pattern.py
+++ b/tests/test_diffraction_diffraction_pattern.py
@@ -237,3 +237,22 @@ class TestDiffractionPattern:
         dp = freud.diffraction.DiffractionPattern()
         with pytest.raises(ValueError):
             dp.compute((box, points))
+
+    def test_weighted_diffraction(self):
+        box = freud.box.Box(Lx=10, Ly=10, Lz=10)
+        N = 40
+        positions = np.random.uniform(-5, 5, (N, 3))
+        weights = np.random.uniform(0, 10, N)
+        dp = freud.diffraction.DiffractionPattern(grid_size=256)
+        weighted_diffraction = dp.compute((box, positions), weights=weights, reset=True)
+        
+        assert np.allclose(weighted_diffraction.diffraction[128, 128], len(positions))
+
+        dp = freud.diffraction.DiffractionPattern(grid_size=256)
+
+        unweighted_diffraction = dp.compute((box, positions), reset=True)
+        
+        assert (unweighted_diffraction.diffraction != weighted_diffraction.diffraction).any()
+        
+        
+        


### PR DESCRIPTION
I provided a little modification to the `DiffractionPattern` class, to account for differently strong scattering mixtures. 

## Description
I added weights to the computation of the histogram, to account for the different SLDs. I normalized the weights in a way, that $S(q=0) = N$ still holds.

## Motivation and Context
For mixed systems, it is possible, that different parts of the mixture have very different SLDs, resulting in a higher contribution of one part of the mixture to the signal. To have a scattering image, that is close to an experimental one, it is imperative to account for different SLDs. 

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
I added new tests, to ensure, that the changes do not change existing behavior, i.e. $S(q = 0) = N$, otherwise it does not affect the code downstream. 

## Checklist:
- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/freud/blob/main/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Freud Contributor Agreement**](https://github.com/glotzerlab/freud/blob/main/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/freud/blob/main/doc/source/reference/credits.rst) in the pull request source branch.
- [x] I have updated the [Change log](https://github.com/glotzerlab/freud/blob/main/ChangeLog.md).
