### PR TITLE
Return K points from static structure factor

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog] and this project adheres to
 [Keep a ChangeLog]: https://keepachangelog.com/en/1.0.0/
 [Semantic Versioning]: https://semver.org/spec/v2.0.0.html
 
+## 3.5.1 -- (2025-10-22)
+
+### Fixed
+* Access k points from `StaticStructureFactorDirect`.
+
 ## 3.5.0 -- (2025-10-08)
 
 ### Changed

--- a/freud/diffraction.py
+++ b/freud/diffraction.py
@@ -484,7 +484,7 @@ class StaticStructureFactorDirect(_StaticStructureFactor):
         r""":class:`numpy.ndarray`: The :math:`\vec{k}` points used in the
         calculation."""
         k_points = self._cpp_obj.getKPoints()
-        return np.asarray([[k.x, k.y, k.z] for k in k_points])
+        return k_points.toNumpyArray()
 
     def __repr__(self):
         return (

--- a/freud/diffraction/export-StaticStructureFactorDirect.cc
+++ b/freud/diffraction/export-StaticStructureFactorDirect.cc
@@ -14,7 +14,8 @@ void export_StaticStructureFactorDirect(nanobind::module_& m)
 {
     nanobind::class_<StaticStructureFactorDirect, StaticStructureFactor>(m, "StaticStructureFactorDirect")
         .def(nanobind::init<unsigned int, float, float, unsigned int>())
-        .def("getNumSampledKPoints", &StaticStructureFactorDirect::getNumSampledKPoints);
+        .def("getNumSampledKPoints", &StaticStructureFactorDirect::getNumSampledKPoints)
+        .def("getKPoints", &StaticStructureFactorDirect::getKPoints);
 }
 
 } // namespace freud::diffraction::detail

--- a/tests/test_diffraction_static_structure_factor.py
+++ b/tests/test_diffraction_static_structure_factor.py
@@ -421,11 +421,17 @@ class TestStaticStructureFactorDirect(StaticStructureFactorTest):
         """Ensure parameters are initialized properly."""
         super().test_attribute_access(sf_params)
 
+        L = 10
+        N = 100
         _bins, _k_max, _k_min, num_sampled_k_points = sf_params
         sf = self.build_structure_factor_object(*sf_params)
         assert sf.num_sampled_k_points == num_sampled_k_points
         with pytest.raises(AttributeError):
             sf.k_points
+        box, points = freud.data.make_random_system(L, N, seed=1)
+        system = freud.AABBQuery.from_system((box, points))
+        sf.compute(system)
+        assert sf.k_points.shape[1] == 3
 
     @pytest.mark.skipif(
         NumpyVersion(np.__version__) < "1.15.0", reason="Requires numpy>=1.15.0."


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above. -->

## Description
<!-- Describe your changes in detail. -->
Fix bug so that accessing `k_points` of `StaticStructureFactorDirect` no longer raises error.

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- Replace ??? with the issue number that this pull request resolves, if applicable. -->
Resolves: #1372 

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to
     see how your changes affect other areas of the code, etc. -->
Ran standard pytest. Does not affect code.

## Checklist:
- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/freud/blob/main/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Freud Contributor Agreement**](https://github.com/glotzerlab/freud/blob/main/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/freud/blob/main/doc/source/reference/credits.rst) in the pull request source branch.
- [x] I have updated the [Change log](https://github.com/glotzerlab/freud/blob/main/ChangeLog.md).
