### PR TITLE
swap to macos-15-intel

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -48,8 +48,8 @@ jobs:
           version: 15
           arch: 'arm64'
         - base: macos
-          version: 13
-          arch: 'x86_64'
+          version: 15
+          arch: 'intel'
 
         python:
         # Pinned versions installed in CIBW_TEST_REQIURES are kept. Those defined installed in

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -89,7 +89,7 @@ jobs:
 
       - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
-          name: dist-${{ matrix.os.base }}-${{ matrix.os.version }}-${{ matrix.python.version }}
+          name: dist-${{ matrix.os.base }}-${{ matrix.os.version }}-${{ matrix.os.arch }}-${{ matrix.python.version }}
           path: ./wheelhouse/*.whl
 
   build_sdist:


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above. -->

## Description

https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- Replace ??? with the issue number that this pull request resolves, if applicable. -->
Resolves #1390 

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to
     see how your changes affect other areas of the code, etc. -->

## Checklist:
- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/freud/blob/main/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Freud Contributor Agreement**](https://github.com/glotzerlab/freud/blob/main/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/freud/blob/main/doc/source/reference/credits.rst) in the pull request source branch.
- [x] I have updated the [Change log](https://github.com/glotzerlab/freud/blob/main/ChangeLog.md).
