### PR TITLE
Minor performance boost for `msd`

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -15,6 +15,10 @@ The format is based on [Keep a Changelog] and this project adheres to
 * Access k points from `StaticStructureFactorDirect`.
 * Unit tests pass with scipy 1.17 installed (#1413).
 
+### Changed
+
+* MSD with `mode=="direct"` is now slightly faster (#1414).
+
 ## 3.5.0 -- 2025-10-08
 
 ### Changed

--- a/freud/msd.py
+++ b/freud/msd.py
@@ -230,8 +230,9 @@ class MSD(_Compute):
 
             self._particle_msd.append(S1 - 2 * S2)
         elif self.mode == "direct":
+            diff = positions - positions[[0], :, :]
             self._particle_msd.append(
-                np.linalg.norm(positions - positions[[0], :, :], axis=-1) ** 2
+                np.einsum("ijk, ijk -> ij", diff, diff)  # Dot product along last axis
             )
 
         return self


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above. -->

## Description

Current MSD code with mode=="direct" computes a euclidean norm and then squares it. This is now ~2x faster by using an einsum.

## Motivation and Context
```diff
        elif self.mode == "direct":
+           diff = positions - positions[[0], :, :]
            self._particle_msd.append(
-                np.linalg.norm(positions - positions[[0], :, :], axis=-1) ** 2
+                np.einsum("ijk, ijk -> ij", diff, diff)  # Dot product along last axis
            )
```

```

<> : %timeit -r 10 -n 10 np.einsum("ijk, ijk->ij", diff, diff)
5.8 ms ± 910 μs per loop (mean ± std. dev. of 10 runs, 10 loops each)

<> : %timeit -r 10 -n 10 np.linalg.norm(diff, axis=-1)**2
12.1 ms ± 1.13 ms per loop (mean ± std. dev. of 10 runs, 10 loops each)

```

## How Has This Been Tested?

The two expressions are equivalent. 

## Checklist:
- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/freud/blob/main/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Freud Contributor Agreement**](https://github.com/glotzerlab/freud/blob/main/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/freud/blob/main/doc/source/reference/credits.rst) in the pull request source branch.
- [x] I have updated the [Change log](https://github.com/glotzerlab/freud/blob/main/ChangeLog.md).
