### PR TITLE
Remove unnecessary allocations in Nematic OP

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog] and this project adheres to
 ### Changed
 
 * MSD with `mode=="direct"` is now slightly faster (#1414).
+* Nematic order parameter is now ~40x faster. (#1428)
 
 ## 3.5.0 -- 2025-10-08
 

--- a/freud/order/Nematic.cc
+++ b/freud/order/Nematic.cc
@@ -1,6 +1,7 @@
 // Copyright (c) 2010-2026 The Regents of the University of Michigan
 // This file is from the freud project, released under the BSD 3-Clause License.
 
+#include <array>
 #include <cmath>
 #include <cstddef>
 #include <memory>
@@ -59,7 +60,7 @@ void Nematic::compute(const vec3<float>* orientations, unsigned int n)
             auto u_i = orientations[i];
             u_i = u_i / std::sqrt(dot(u_i, u_i));
 
-            float Q_ab[9];
+            std::array<float, 9> Q_ab;
 
             Q_ab[0] = (1.5F * u_i.x * u_i.x) - 0.5F;
             Q_ab[1] = 1.5F * u_i.x * u_i.y;

--- a/freud/order/Nematic.cc
+++ b/freud/order/Nematic.cc
@@ -50,33 +50,33 @@ void Nematic::compute(const vec3<float>* orientations, unsigned int n)
     m_nematic_tensor_local->reset();
 
     // calculate per-particle tensor
+    float* const pt_base = m_particle_tensor->data();
     util::forLoopWrapper(0, n, [&](size_t begin, size_t end) {
+        float* nt = m_nematic_tensor_local->local().data();
         for (size_t i = begin; i < end; ++i)
         {
             // get the orientation of the particle and normalize it
             auto u_i = orientations[i];
             u_i = u_i / std::sqrt(dot(u_i, u_i));
 
-            util::ManagedArray<float> Q_ab({3, 3});
+            float Q_ab[9];
 
-            Q_ab(0, 0) = 1.5F * u_i.x * u_i.x - 0.5F;
-            Q_ab(0, 1) = 1.5F * u_i.x * u_i.y;
-            Q_ab(0, 2) = 1.5F * u_i.x * u_i.z;
-            Q_ab(1, 0) = 1.5F * u_i.y * u_i.x;
-            Q_ab(1, 1) = 1.5F * u_i.y * u_i.y - 0.5F;
-            Q_ab(1, 2) = 1.5F * u_i.y * u_i.z;
-            Q_ab(2, 0) = 1.5F * u_i.z * u_i.x;
-            Q_ab(2, 1) = 1.5F * u_i.z * u_i.y;
-            Q_ab(2, 2) = 1.5F * u_i.z * u_i.z - 0.5F;
+            Q_ab[0] = (1.5F * u_i.x * u_i.x) - 0.5F;
+            Q_ab[1] = 1.5F * u_i.x * u_i.y;
+            Q_ab[2] = 1.5F * u_i.x * u_i.z;
+            Q_ab[3] = 1.5F * u_i.y * u_i.x;
+            Q_ab[4] = (1.5F * u_i.y * u_i.y) - 0.5F;
+            Q_ab[5] = 1.5F * u_i.y * u_i.z;
+            Q_ab[6] = 1.5F * u_i.z * u_i.x;
+            Q_ab[7] = 1.5F * u_i.z * u_i.y;
+            Q_ab[8] = (1.5F * u_i.z * u_i.z) - 0.5F;
 
             // Set the values. The nematic tensor is reduced later.
-            for (unsigned int j = 0; j < 3; j++)
+            float* pt = pt_base + (i * 9);
+            for (int j = 0; j < 9; j++)
             {
-                for (unsigned int k = 0; k < 3; k++)
-                {
-                    (*m_particle_tensor)(i, j, k) += Q_ab(j, k);
-                    m_nematic_tensor_local->local()(j, k) += Q_ab(j, k);
-                }
+                pt[j] = Q_ab[j];
+                nt[j] += Q_ab[j];
             }
         }
     });
@@ -86,9 +86,11 @@ void Nematic::compute(const vec3<float>* orientations, unsigned int n)
     m_nematic_tensor_local->reduceInto(*m_nematic_tensor);
 
     // Normalize by the number of particles
-    for (unsigned int i = 0; i < m_nematic_tensor->size(); ++i)
+    const float inv_n = 1.0F / static_cast<float>(m_n);
+    float* nt_data = m_nematic_tensor->data();
+    for (unsigned int i = 0; i < 9; ++i)
     {
-        (*m_nematic_tensor)[i] /= static_cast<float>(m_n);
+        nt_data[i] *= inv_n;
     }
 
     // the order parameter is the eigenvector belonging to the largest eigenvalue


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above. -->

## Description

The nematic OP used Managedarray{3, 3} which is a vector backed data structure. This resulted in an unnecessary allocation in the innermost loop. Worse yet, the fancy multi-index of managed arrays allocates an extra vector for every call to `operator()`, so each particle was performing a huge number of unnecessary allocations. This PR swaps to using a basic `float[9]` as the intermediate buffer, which is then distributed to the particle and global tensors as needed.

A future PR revising the ManagedArray indexing is probably in order too -- see #1429. This PR is a separate change though, as nematic is so fast that the single managed array allocation quarters the performance.

## Motivation and Context

Benchmarks run on battery power on an M1 Pro MacBook.

```
BEFORE:
  scenario                            median     per 1k         min         max     order
  --------------------------------------------------------------------------------------
  uniform random                  med  43.230 ms  ( 432.30 us/k)  min  41.262  max  52.311  OP=0.002568
  perturbed theta=5 deg           med  40.345 ms  ( 403.45 us/k)  min  39.501  max  46.995  OP=0.988540
  perturbed theta=15 deg          med  40.231 ms  ( 402.31 us/k)  min  39.558  max  49.638  OP=0.899437
  perturbed theta=30 deg          med  40.669 ms  ( 406.69 us/k)  min  39.564  max  76.491  OP=0.625012
  50/50 mixed (theta=5)           med  43.379 ms  ( 433.79 us/k)  min  39.575  max 121.277  OP=0.494433
  50/50 mixed (theta=30)          med  40.859 ms  ( 408.59 us/k)  min  39.738  max 107.235  OP=0.313669
  10/90 mixed (theta=5)           med  40.122 ms  ( 401.22 us/k)  min  39.511  max  48.554  OP=0.098905


AFTER:

  scenario                            median     per 1k         min         max     order
  --------------------------------------------------------------------------------------
  uniform random                  med   1.177 ms  (  11.77 us/k)  min   1.074  max   1.726  OP=0.002568
  perturbed theta=5 deg           med   1.170 ms  (  11.70 us/k)  min   1.090  max   1.406  OP=0.988483
  perturbed theta=15 deg          med   1.168 ms  (  11.68 us/k)  min   1.092  max   1.400  OP=0.899524
  perturbed theta=30 deg          med   1.166 ms  (  11.66 us/k)  min   1.062  max   1.386  OP=0.625011
  50/50 mixed (theta=5)           med   1.169 ms  (  11.69 us/k)  min   1.095  max   1.408  OP=0.494429
  50/50 mixed (theta=30)          med   1.167 ms  (  11.67 us/k)  min   1.094  max   1.428  OP=0.313670
  10/90 mixed (theta=5)           med   1.168 ms  (  11.68 us/k)  min   1.098  max   1.424  OP=0.098907
```

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to
     see how your changes affect other areas of the code, etc. -->

## Checklist:
- [ ] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/freud/blob/main/CONTRIBUTING.md).
- [ ] I agree with the terms of the [**Freud Contributor Agreement**](https://github.com/glotzerlab/freud/blob/main/ContributorAgreement.md).
- [ ] My name is on the [list of contributors](https://github.com/glotzerlab/freud/blob/main/doc/source/reference/credits.rst) in the pull request source branch.
- [ ] I have updated the [Change log](https://github.com/glotzerlab/freud/blob/main/ChangeLog.md).
