### PR TITLE
Use std::array to reduce allocations in ManagedArray::operator()

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog] and this project adheres to
 
 * MSD with `mode=="direct"` is now slightly faster (#1414).
 * Nematic order parameter is now ~40x faster. (#1428)
+* C++ code using the `MangedArray` multi-index no longer requires memory allocation (#1429).
 
 ## 3.5.0 -- 2025-10-08
 

--- a/freud/order/Steinhardt.cc
+++ b/freud/order/Steinhardt.cc
@@ -345,7 +345,7 @@ void Steinhardt::aggregatewl(
                 const auto wigner3j_values = getWigner3j(l);
 
                 (*target)[target_particle_index + l_index]
-                    = reduceWigner3j(&(*source_l)({i, 0}), l, wigner3j_values);
+                    = reduceWigner3j(&(*source_l)(i, 0), l, wigner3j_values);
                 if (m_wl_normalize)
                 {
                     const float normalization = std::sqrt(normalizationfactor)

--- a/freud/util/ManagedArray.h
+++ b/freud/util/ManagedArray.h
@@ -202,32 +202,6 @@ public:
         return (*this)[idx];
     }
 
-    //! Core function for multidimensional indexing (vector overload, kept for compatibility).
-    T& operator()(const std::vector<size_t>& indices)
-    {
-        size_t cur_prod = 1;
-        size_t idx = 0;
-        for (unsigned int i = indices.size() - 1; i != static_cast<unsigned int>(-1); --i)
-        {
-            idx += indices[i] * cur_prod;
-            cur_prod *= m_shape[i];
-        }
-        return (*this)[idx];
-    }
-
-    //! Const version of core function for multidimensional indexing (vector overload).
-    const T& operator()(const std::vector<size_t>& indices) const
-    {
-        size_t cur_prod = 1;
-        size_t idx = 0;
-        for (unsigned int i = indices.size() - 1; i != static_cast<unsigned int>(-1); --i)
-        {
-            idx += indices[i] * cur_prod;
-            cur_prod *= m_shape[i];
-        }
-        return (*this)[idx];
-    }
-
     //! Get the multi-index corresponding to a single regular index.
     /*! This function is provided as an external utility in the event that
      * index generation is necessary without an actual array.

--- a/freud/util/ManagedArray.h
+++ b/freud/util/ManagedArray.h
@@ -4,6 +4,7 @@
 #ifndef MANAGED_ARRAY_H
 #define MANAGED_ARRAY_H
 
+#include <array>
 #include <cstring>
 #include <functional>
 #include <numeric>
@@ -164,32 +165,48 @@ public:
     //! Implementation of variadic indexing function.
     template<typename... Ints> T& operator()(Ints... indices)
     {
-        return (*this)(buildIndex(indices...));
+        static_assert(sizeof...(Ints) > 0, "operator() requires at least one index");
+        return (*this)(buildIndexArray(indices...));
     }
 
     //! Constant implementation of variadic indexing function.
     template<typename... Ints> const T& operator()(Ints... indices) const
     {
-        return (*this)(buildIndex(indices...));
+        static_assert(sizeof...(Ints) > 0, "operator() requires at least one index");
+        return (*this)(buildIndexArray(indices...));
     }
 
     //! Core function for multidimensional indexing.
-    /*! All the other convenience functions for indexing ultimately call this
-     * function (or the const version below), which operates on a vector of
-     * indexes.
-     *
-     * Note that the logic in getIndex is intentionally inlined here for
-     * performance reasons. Although unimportant in most cases, operator() can
-     * become a performance bottleneck when used in highly performance critical
-     * code paths.
-     */
+    template<size_t N> T& operator()(const std::array<size_t, N>& indices)
+    {
+        size_t cur_prod = 1;
+        size_t idx = 0;
+        for (size_t i = N; i > 0; --i)
+        {
+            idx += indices[i - 1] * cur_prod;
+            cur_prod *= m_shape[i - 1];
+        }
+        return (*this)[idx];
+    }
+
+    //! Const version of core function for multidimensional indexing.
+    template<size_t N> const T& operator()(const std::array<size_t, N>& indices) const
+    {
+        size_t cur_prod = 1;
+        size_t idx = 0;
+        for (size_t i = N; i > 0; --i)
+        {
+            idx += indices[i - 1] * cur_prod;
+            cur_prod *= m_shape[i - 1];
+        }
+        return (*this)[idx];
+    }
+
+    //! Core function for multidimensional indexing (vector overload, kept for compatibility).
     T& operator()(const std::vector<size_t>& indices)
     {
         size_t cur_prod = 1;
         size_t idx = 0;
-        // In getting the linear bin, we must iterate over bins in reverse
-        // order to build up the value of cur_prod because each subsequent axis
-        // contributes less according to row-major ordering.
         for (unsigned int i = indices.size() - 1; i != static_cast<unsigned int>(-1); --i)
         {
             idx += indices[i] * cur_prod;
@@ -198,14 +215,11 @@ public:
         return (*this)[idx];
     }
 
-    //! Const version of core function for multidimensional indexing.
+    //! Const version of core function for multidimensional indexing (vector overload).
     const T& operator()(const std::vector<size_t>& indices) const
     {
         size_t cur_prod = 1;
         size_t idx = 0;
-        // In getting the linear bin, we must iterate over bins in reverse
-        // order to build up the value of cur_prod because each subsequent axis
-        // contributes less according to row-major ordering.
         for (unsigned int i = indices.size() - 1; i != static_cast<unsigned int>(-1); --i)
         {
             idx += indices[i] * cur_prod;
@@ -304,27 +318,11 @@ public:
     }
 
 private:
-    //! The base case for building up the index.
-    /*! These argument building functions are templated on two types, one that
-    std::vector<size_t> m_shape; //!< Shape of array.
-     *  encapsulates the current object being operated on and the other being
-    size_t m_size;               //!< number of array elements.
-     *  the list of remaining arguments. Since users may provide both signed and
-     *  unsigned ints to the function, we perform the appropriate check on each
-     *  Int object. The second function is used for template recursion in
-     *  unwrapping the list of arguments.
-     */
-    template<typename Int> static std::vector<size_t> buildIndex(Int index)
+    //! Build an index array from variadic arguments using pack expansion.
+    template<typename... Ints>
+    static auto buildIndexArray(Ints... indices) -> std::array<size_t, sizeof...(Ints)>
     {
-        return {static_cast<size_t>(index)};
-    }
-
-    //! The recursive case for building up the index (see above).
-    template<typename Int, typename... Ints> static std::vector<size_t> buildIndex(Int index, Ints... indices)
-    {
-        std::vector<size_t> tmp = buildIndex(indices...);
-        tmp.insert(tmp.begin(), static_cast<size_t>(index));
-        return tmp;
+        return {{static_cast<size_t>(indices)...}};
     }
 
     std::vector<T> m_data;       //!< array data.


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above. -->

## Description
As noted in a now-removed comment, the use of std::vector in operator() for managed arrays could be a performance bottleneck. This was particularly obvious in order/Nematic, but is also true of SolidLiquid and probably other OPs. This fix retains the original vector indexing where needed, but defaults to std::array for allocation-free indexing.

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- Replace ??? with the issue number that this pull request resolves, if applicable. -->
Resolves: #???

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to
     see how your changes affect other areas of the code, etc. -->

## Checklist:
- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/freud/blob/main/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Freud Contributor Agreement**](https://github.com/glotzerlab/freud/blob/main/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/freud/blob/main/doc/source/reference/credits.rst) in the pull request source branch.
- [ ] I have updated the [Change log](https://github.com/glotzerlab/freud/blob/main/ChangeLog.md).
