### PR TITLE
cite Brandon's thesis

### DIFF
--- a/doc/source/reference/credits.rst
+++ b/doc/source/reference/credits.rst
@@ -45,6 +45,7 @@ The following people contributed to the development of freud:
 * Mayank Agrawal, University of Michigan
 * Melody Zhang, University of Michigan
 * Michael Stryk, University of Michigan
+* Michelle Thran, University of Michigan
 * Mike Henry, Boise State
 * Paul Dodd, University of Michigan
 * Pavel Buslaev

--- a/doc/source/reference/freud.bib
+++ b/doc/source/reference/freud.bib
@@ -56,6 +56,17 @@
   bdsk-url-1    = {https://doi.org/10.1103/PhysRevB.28.784}
 }
 
+@article{Butler:2024,
+  author        = {Brandon Butler},
+  date-added    = {2026-07-01 11:56:57 -0400},
+  date-modified = {2026-07-01 11:56:57 -0400},
+  doi           = {10.7302/23058},
+  title         = {On the Development of Tools for the Study of Colloidal Self-Assembly},
+  year          = {2024},
+  type          = {Doctoral Dissertation},
+  school        = {University of Michigan},
+}
+
 @article{Lechner_2008,
   author        = {Lechner, Wolfgang and Dellago, Christoph},
   date-added    = {2019-10-02 23:56:45 -0400},

--- a/doc/source/reference/freud.bib
+++ b/doc/source/reference/freud.bib
@@ -56,15 +56,15 @@
   bdsk-url-1    = {https://doi.org/10.1103/PhysRevB.28.784}
 }
 
-@article{Butler:2024,
+@phdthesis{Butler:2024,
   author        = {Brandon Butler},
   date-added    = {2026-07-01 11:56:57 -0400},
   date-modified = {2026-07-01 11:56:57 -0400},
-  doi           = {10.7302/23058},
   title         = {On the Development of Tools for the Study of Colloidal Self-Assembly},
   year          = {2024},
   type          = {Doctoral Dissertation},
   school        = {University of Michigan},
+  bdsk-url-1    = {https://dx.doi.org/10.7302/23058}
 }
 
 @article{Lechner_2008,

--- a/freud/order.py
+++ b/freud/order.py
@@ -889,7 +889,7 @@ class ContinuousCoordination(_PairCompute):
     r"""Computes the continuous local coordination number.
 
     The :class:`ContinuousCoordination` class implements extensions of the Voronoi
-    discrete coordination number to the real numbers. The formulas for the
+    discrete coordination number to the real numbers :cite:`Butler:2024`. The formulas for the
     various implementations are:
 
     Power:

--- a/freud/order.py
+++ b/freud/order.py
@@ -889,8 +889,8 @@ class ContinuousCoordination(_PairCompute):
     r"""Computes the continuous local coordination number.
 
     The :class:`ContinuousCoordination` class implements extensions of the Voronoi
-    discrete coordination number to the real numbers :cite:`Butler:2024`. The formulas for the
-    various implementations are:
+    discrete coordination number to the real numbers :cite:`Butler:2024`. The formulas
+    for the various implementations are:
 
     Power:
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above. -->

## Description
This PR cites Brandon Butler's thesis in `ContinuousCoordination`. 

## Motivation and Context
The current documentation for `ContinuousCoordination` documents the functions, but does not provide any context or details on when each variant should be used. Citing Brandon's thesis provides such a resource for interested readers. 
Resolves: #1226 

## How Has This Been Tested?
The docs have been built locally and I have confirmed that the citation is accessible to users.

## Checklist:
- [ ] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/freud/blob/main/CONTRIBUTING.md).
- [ ] I agree with the terms of the [**Freud Contributor Agreement**](https://github.com/glotzerlab/freud/blob/main/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/freud/blob/main/doc/source/reference/credits.rst) in the pull request source branch.
- [ ] I have updated the [Change log](https://github.com/glotzerlab/freud/blob/main/ChangeLog.md).
