### PR TITLE
Remove garnett support and corresponding documentation

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog] and this project adheres to
 
 * MSD with `mode=="direct"` is now slightly faster (#1414).
 * Nematic order parameter is now ~40x faster. (#1428)
+* Removed garnett from documentation. (#1443)
 
 ## 3.5.0 -- 2025-10-08
 

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -329,7 +329,6 @@ intersphinx_mapping = {
     "matplotlib": ("https://matplotlib.org", None),
     "hoomd": ("https://hoomd-blue.readthedocs.io/en/stable/", None),
     "gsd": ("https://gsd.readthedocs.io/en/stable/", None),
-    "garnett": ("https://garnett.readthedocs.io/en/stable/", None),
     "MDAnalysis": ("https://docs.mdanalysis.org/stable", None),
     "ovito": ("https://www.ovito.org/docs/current/python/", None),
     "pytest": ("https://docs.pytest.org/en/stable", None),

--- a/doc/source/topics/datainputs.rst
+++ b/doc/source/topics/datainputs.rst
@@ -29,7 +29,7 @@ GSD Trajectories
 
 Using the GSD Python API, GSD files can be easily integrated with **freud** as shown in the :ref:`quickstart`.
 This format is natively supported by `HOOMD-blue <https://hoomd-blue.readthedocs.io/>`__.
-Note: the GSD format can also be read by :ref:`MDAnalysis <mdanalysisreaders>` and :ref:`garnett <garnetttrajectories>`.
+Note: the GSD format can also be read by :ref:`MDAnalysis <mdanalysisreaders>`.
 Here, we provide an example that reads data from a GSD file.
 
 .. code-block:: python
@@ -75,23 +75,6 @@ Here, we provide an example of how to construct a system:
 
     for system in zip(np.asarray(traj.unitcell_vectors), traj.xyz):
         rdf.compute(system=system, reset=False)
-
-.. _garnetttrajectories:
-
-garnett Trajectories
---------------------
-
-The `garnett <https://garnett.readthedocs.io/>`__ package can read `several trajectory formats <https://garnett.readthedocs.io/en/stable/readerswriters.html#file-formats>`__ that have historically been supported by the HOOMD-blue simulation engine, as well as other common types such as DCD and CIF.
-The **garnett** package will auto-detect supported file formats by the file extension.
-Here, we provide an example that reads data from a POS file.
-
-.. code-block:: python
-
-    import garnett
-
-    with garnett.read('trajectory.pos') as traj:
-        for frame in traj:
-            rdf.compute(system=frame, reset=False)
 
 OVITO Modifiers
 ---------------

--- a/freud/environment.py
+++ b/freud/environment.py
@@ -310,7 +310,8 @@ class BondOrder(_SpatialHistogram):
             orientations ((:math:`N_{points}`, 4) :class:`numpy.ndarray`):
                 Orientations associated with system points that are used to
                 calculate bonds. Uses identity quaternions if :code:`None`
-                (Default value = :code:`None`).
+                (Default value = :code:`None`). Required if ``mode`` is not
+                "bod".
             query_points ((:math:`N_{query\_points}`, 3) :class:`numpy.ndarray`,
                           optional):
                 Query points used to calculate the correlation function.  Uses
@@ -332,6 +333,11 @@ class BondOrder(_SpatialHistogram):
                 the new computation; if False, will accumulate data (Default
                 value: True).
         """
+        if orientations is None and self._cpp_obj.getMode() != "bod":
+            raise ValueError(
+                "mode must be 'bod' when orientations are not provided."
+            )
+        
         if reset:
             self._reset()
 

--- a/freud/environment.py
+++ b/freud/environment.py
@@ -310,8 +310,7 @@ class BondOrder(_SpatialHistogram):
             orientations ((:math:`N_{points}`, 4) :class:`numpy.ndarray`):
                 Orientations associated with system points that are used to
                 calculate bonds. Uses identity quaternions if :code:`None`
-                (Default value = :code:`None`). Required if ``mode`` is not
-                "bod".
+                (Default value = :code:`None`).
             query_points ((:math:`N_{query\_points}`, 3) :class:`numpy.ndarray`,
                           optional):
                 Query points used to calculate the correlation function.  Uses
@@ -333,11 +332,6 @@ class BondOrder(_SpatialHistogram):
                 the new computation; if False, will accumulate data (Default
                 value: True).
         """
-        if orientations is None and self._cpp_obj.getMode() != "bod":
-            raise ValueError(
-                "mode must be 'bod' when orientations are not provided."
-            )
-        
         if reset:
             self._reset()
 

--- a/freud/locality.py
+++ b/freud/locality.py
@@ -285,7 +285,6 @@ class NeighborQuery:
         * :class:`MDAnalysis.coordinates.timestep.Timestep`
         * :class:`gsd.hoomd.Snapshot`
         * :class:`gsd.hoomd.Frame`
-        * :class:`garnett.trajectory.Frame`
         * :class:`ovito.data.DataCollection`
         * :class:`hoomd.Snapshot`
 
@@ -333,16 +332,6 @@ class NeighborQuery:
             if system.configuration.dimensions == 2:
                 box[[2, 4, 5]] = 0
             system = (box, system.particles.position)
-
-        # garnett compatibility (garnett >=0.5)
-        elif _match_class_path(system, "garnett.trajectory.Frame"):
-            try:
-                # garnett >= 0.7
-                position = system.position
-            except AttributeError:
-                # garnett < 0.7
-                position = system.positions
-            system = (system.box, position)
 
         # OVITO compatibility
         elif _match_class_path(


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above. -->

## Description
Support for garnett frames has been removed from the locality module (the only place where garnett remained), and all mentions of garnett have been removed from the documentation.

## Motivation and Context
Garnett is not actively maintained, and its repository has been archived. This PR resolves #1142 .

## How Has This Been Tested?
There are no tests involving garnett objects, so no changes to testing are needed.

## Checklist:
- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/freud/blob/main/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Freud Contributor Agreement**](https://github.com/glotzerlab/freud/blob/main/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/freud/blob/main/doc/source/reference/credits.rst) in the pull request source branch.
- [x] I have updated the [Change log](https://github.com/glotzerlab/freud/blob/main/ChangeLog.md).
