### PR TITLE
Add validation for orientations when calculating bond order diagrams

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog] and this project adheres to
 ### Fixed
 * Access k points from `StaticStructureFactorDirect`.
 * Unit tests pass with scipy 1.17 installed (#1413).
+* Input validation for orientations in `BondOrder.compute()` (#1444).
 
 ### Changed
 

--- a/doc/source/reference/credits.rst
+++ b/doc/source/reference/credits.rst
@@ -38,6 +38,7 @@ The following people contributed to the development of freud:
 * Kate Jensen, University of Michigan
 * Kelly Wang, University of Michigan
 * Kody Takada, University of Michigan
+* Kristi Pepa, University of Michigan
 * M. Eric Irrgang, University of Michigan
 * Matthew Palathingal, University of Michigan
 * Matthew Spellings, University of Michigan
@@ -53,6 +54,7 @@ The following people contributed to the development of freud:
 * Rose Cersonsky, University of Michigan
 * Rubén Chaves
 * Ryan Marson, University of Michigan
+* Sumitava Kundu, University of Michigan
 * Suraj Kannur, University of Michigan
 * Tim Moore, University of Michigan
 * Tommy Waltmann, University of Michigan

--- a/freud/environment.py
+++ b/freud/environment.py
@@ -310,7 +310,8 @@ class BondOrder(_SpatialHistogram):
             orientations ((:math:`N_{points}`, 4) :class:`numpy.ndarray`):
                 Orientations associated with system points that are used to
                 calculate bonds. Uses identity quaternions if :code:`None`
-                (Default value = :code:`None`).
+                (Default value = :code:`None`). Required if ``mode`` is not
+                "bod".
             query_points ((:math:`N_{query\_points}`, 3) :class:`numpy.ndarray`,
                           optional):
                 Query points used to calculate the correlation function.  Uses
@@ -332,6 +333,11 @@ class BondOrder(_SpatialHistogram):
                 the new computation; if False, will accumulate data (Default
                 value: True).
         """
+        if orientations is None and self._cpp_obj.getMode() != "bod":
+            raise ValueError(
+                "mode must be 'bod' when orientations are not provided."
+            )
+        
         if reset:
             self._reset()
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above. -->

## Description
The non-default modes for bond order diagram calculation are no longer supported when the user does not explicitly provide particle orientations.

## Motivation and Context
Previously, the lack of validation on provided orientations produced unexpected behavior when `mode` was not "bod", which led to confusion among users even though the documentation implies that orientations should be given for other modes. This PR resolves #1201 .

## How Has This Been Tested?
All of the existing tests provide orientations, so this change should not affect test behvaior.

## Checklist:
- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/freud/blob/main/CONTRIBUTING.md).
- [x] I agree with the terms of the [**Freud Contributor Agreement**](https://github.com/glotzerlab/freud/blob/main/ContributorAgreement.md).
- [x] My name is on the [list of contributors](https://github.com/glotzerlab/freud/blob/main/doc/source/reference/credits.rst) in the pull request source branch.
- [x] I have updated the [Change log](https://github.com/glotzerlab/freud/blob/main/ChangeLog.md).
